### PR TITLE
feat: auto-convert HEIC/HEIF inbound media to JPEG

### DIFF
--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -1,5 +1,7 @@
+import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { promisify } from "node:util";
 import type {
   ChannelAccountSnapshot,
   OpenClawConfig,
@@ -187,6 +189,9 @@ async function saveZulipMediaBuffer(params: {
   maxBytes: number;
 }): Promise<{ path: string; contentType: string } | null> {
   const { core, buffer, contentType, filename, maxBytes } = params;
+  let savedPath: string;
+  let savedContentType: string;
+
   if (core.channel.media?.saveMediaBuffer) {
     const saved = await core.channel.media.saveMediaBuffer(
       buffer,
@@ -195,15 +200,39 @@ async function saveZulipMediaBuffer(params: {
       maxBytes,
       filename,
     );
-    return {
-      path: saved.path,
-      contentType: saved.contentType ?? contentType,
-    };
+    savedPath = saved.path;
+    savedContentType = saved.contentType ?? contentType;
+  } else {
+    const dir = await fs.mkdtemp(path.join(resolvePreferredOpenClawTmpDir(), "zulip-upload-"));
+    const filePath = path.join(dir, filename);
+    await fs.writeFile(filePath, buffer);
+    savedPath = filePath;
+    savedContentType = contentType;
   }
-  const dir = await fs.mkdtemp(path.join(resolvePreferredOpenClawTmpDir(), "zulip-upload-"));
-  const filePath = path.join(dir, filename);
-  await fs.writeFile(filePath, buffer);
-  return { path: filePath, contentType };
+
+  // Auto-convert HEIC/HEIF to JPEG for vision pipeline compatibility
+  const ext = path.extname(savedPath).toLowerCase();
+  if (ext === ".heic" || ext === ".heif") {
+    const jpgPath = savedPath.replace(/\.heic$/i, ".jpg").replace(/\.heif$/i, ".jpg");
+    try {
+      const execFileAsync = promisify(execFile);
+      await execFileAsync("heif-convert", ["-q", "90", savedPath, jpgPath], { timeout: 30000 });
+      // Remove original HEIC file
+      try {
+        await fs.unlink(savedPath);
+      } catch {
+        /* ignore cleanup failure */
+      }
+      return { path: jpgPath, contentType: "image/jpeg" };
+    } catch {
+      // heif-convert not available or conversion failed — use original file
+      params.core.logging.getChildLogger({ module: "zulip" }).warn?.(
+        `HEIC conversion failed for ${path.basename(savedPath)} — using original`,
+      );
+    }
+  }
+
+  return { path: savedPath, contentType: savedContentType };
 }
 
 function delay(ms: number): Promise<void> {


### PR DESCRIPTION
## Summary

- Auto-converts `.heic` / `.heif` inbound media to JPEG in `saveZulipMediaBuffer` before passing to the vision pipeline
- Uses `heif-convert -q 90` (from `libheif-examples`) with a 30s timeout
- Graceful fallback: if `heif-convert` is not installed, logs a warning and passes the original file through unchanged

## Why

Apple devices (iPhones, iPads) capture photos in HEIC/HEIF format by default. Most LLM vision endpoints — GPT-4V, Claude, Gemini — don't accept HEIC, causing silent failures or errors when users send photos from iOS devices via Zulip.

## How

In `src/zulip/monitor.ts`, the `saveZulipMediaBuffer` function now checks the saved file's extension after writing to disk. If `.heic` or `.heif`:

1. Runs `heif-convert -q 90 <source> <dest.jpg>` via `child_process.execFile` (promisified)
2. On success: removes the original HEIC file, returns the JPEG path with `image/jpeg` content type
3. On failure: logs a warning via the plugin's logger and returns the original file unchanged

### Prerequisite

The host running the Zulip plugin needs `heif-convert` installed:

```bash
# Ubuntu/Debian
sudo apt install libheif-examples

# macOS
brew install libheif
```

## Test plan

- [ ] Send a `.heic` photo via Zulip DM — verify it arrives as JPEG in the vision pipeline
- [ ] Send a `.heif` photo via Zulip channel — verify same conversion
- [ ] Test without `heif-convert` installed — verify warning logged, original file passed through
- [ ] Send a regular `.jpg` or `.png` — verify no conversion attempted (no regression)
- [ ] Verify TypeScript compiles cleanly with `npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)