### PR TITLE
feat: add Zulip topic monitor filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026.4.29
+
+### Features
+- **Inbound topic filters**: Add `topics` and `streamTopics` config for filtering monitored Zulip stream messages by topic. Topic matching trims whitespace and is case-insensitive; omitted, empty, or `"*"` filters allow all topics. Per-stream filters can be keyed by stream name or stream id and further restrict the global topic allowlist.
+
+### Compatibility
+- **OpenClaw 2026.4.26 compatibility carry-forward**: Includes the 2026.4.26 runtime alignment, SecretRef API key support, and stream target parsing fixes from the prior compatibility PR.
+
 ## 2026.4.26
 
 ### Compatibility

--- a/README.md
+++ b/README.md
@@ -94,6 +94,19 @@ Add the plugin id to `plugins.allow` in `~/.openclaw/openclaw.json`:
       // Which streams to monitor ("*" = all)
       "streams": ["general", "bot-testing"],
 
+      // Optional inbound topic filters for monitored streams.
+      // Topic matching trims whitespace and is case-insensitive.
+      // Omit, use [], or include "*" to allow all topics.
+      "topics": ["support", "bot help"],
+
+      // Optional per-stream topic filters. Keys may be stream names or ids.
+      // A matching stream-specific filter further restricts the global topics list;
+      // streams with no entry use only the global topics filter.
+      "streamTopics": {
+        "general": ["support"],
+        "42": ["bot help"]
+      },
+
       // Default topic for outbound messages with no explicit topic
       "defaultTopic": "bot replies",
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Add the plugin id to `plugins.allow` in `~/.openclaw/openclaw.json`:
       "url": "https://your-org.zulipchat.com",
       "email": "yourbot@your-org.zulipchat.com",
       "apiKey": "your-zulip-api-key",
+      // Or store the API key in an OpenClaw SecretRef:
+      // "apiKey": { "source": "env", "provider": "zulip", "id": "ZULIP_API_KEY" },
 
       // Which streams to monitor ("*" = all)
       "streams": ["general", "bot-testing"],

--- a/docs/OPENCLAW_2026_4_26_AUDIT_PLAN.md
+++ b/docs/OPENCLAW_2026_4_26_AUDIT_PLAN.md
@@ -104,8 +104,8 @@ Release notes deprecate direct plugin config load/write helpers in favor of pass
 
 Current real reads:
 
-- `src/zulip/send.ts` calls `core.config.loadConfig()`.
-- `src/zulip/monitor.ts` uses `opts.config ?? core.config.loadConfig()`.
+- ✅ `src/zulip/send.ts` now requires resolved runtime config via `ZulipSendOpts.cfg` instead of calling `core.config.loadConfig()`.
+- ✅ `src/zulip/monitor.ts` now requires `opts.config` and fails fast if a monitor starts without resolved runtime config.
 
 Plan:
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -50,6 +50,11 @@
               "email": { "type": "string" },
               "apiKey": { "$ref": "#/$defs/secretInput" },
               "streams": { "type": "array", "items": { "type": "string" } },
+              "topics": { "type": "array", "items": { "type": "string" } },
+              "streamTopics": {
+                "type": "object",
+                "additionalProperties": { "type": "array", "items": { "type": "string" } }
+              },
               "defaultTopic": { "type": "string" },
               "chatmode": { "type": "string", "enum": ["oncall", "onmessage", "onchar"] },
               "oncharPrefixes": { "type": "array", "items": { "type": "string" } },
@@ -107,6 +112,11 @@
           "email": { "type": "string" },
           "apiKey": { "$ref": "#/$defs/secretInput" },
           "streams": { "type": "array", "items": { "type": "string" } },
+          "topics": { "type": "array", "items": { "type": "string" } },
+          "streamTopics": {
+            "type": "object",
+            "additionalProperties": { "type": "array", "items": { "type": "string" } }
+          },
           "defaultTopic": { "type": "string" },
           "chatmode": { "type": "string", "enum": ["oncall", "onmessage", "onchar"] },
           "oncharPrefixes": { "type": "array", "items": { "type": "string" } },
@@ -164,6 +174,14 @@
           "label": "Streams to Monitor",
           "placeholder": "[\"general\", \"random\"]"
         },
+        "topics": {
+          "label": "Topics to Monitor",
+          "placeholder": "[\"support\", \"bot help\"]"
+        },
+        "streamTopics": {
+          "label": "Per-Stream Topic Filters",
+          "placeholder": "{\"general\":[\"support\"]}"
+        },
         "defaultTopic": {
           "label": "Default Topic",
           "placeholder": "general chat"
@@ -199,6 +217,14 @@
     "streams": {
       "label": "Streams to Monitor",
       "placeholder": "[\"general\", \"random\"]"
+    },
+    "topics": {
+      "label": "Topics to Monitor",
+      "placeholder": "[\"support\", \"bot help\"]"
+    },
+    "streamTopics": {
+      "label": "Per-Stream Topic Filters",
+      "placeholder": "{\"general\":[\"support\"]}"
     },
     "defaultTopic": {
       "label": "Default Topic",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-channel-zulip",
-  "version": "2026.4.26",
+  "version": "2026.4.29",
   "description": "Zulip channel plugin for OpenClaw — concurrent message processing, file uploads, approval hooks, and full actions API",
   "type": "module",
   "author": "FtlC-ian",

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -216,14 +216,16 @@ export const zulipPlugin = {
         }
         return { ok: true, to: trimmed };
       },
-      sendText: async ({ to, text, accountId }) => {
+      sendText: async ({ cfg, to, text, accountId }) => {
         const result = await sendMessageZulip(to, text, {
+          cfg,
           accountId: accountId ?? undefined,
         });
         return { channel: "zulip", ...result };
       },
-      sendMedia: async ({ to, text, mediaUrl, accountId }) => {
+      sendMedia: async ({ cfg, to, text, mediaUrl, accountId }) => {
         const result = await sendMessageZulip(to, text, {
+          cfg,
           accountId: accountId ?? undefined,
           mediaUrl,
         });
@@ -240,6 +242,7 @@ export const zulipPlugin = {
           let lastResult;
           for (let i = 0; i < mediaUrls.length; i++) {
             lastResult = await sendMessageZulip(ctx.to, i === 0 ? text : "", {
+              cfg: ctx.cfg,
               accountId: ctx.accountId ?? undefined,
               mediaUrl: mediaUrls[i],
               interactive: i === 0 ? ctx.payload.interactive : undefined,
@@ -249,6 +252,7 @@ export const zulipPlugin = {
           return { channel: "zulip", ...lastResult! };
         }
         const result = await sendMessageZulip(ctx.to, text, {
+          cfg: ctx.cfg,
           accountId: ctx.accountId ?? undefined,
           interactive: ctx.payload.interactive,
           channelData: ctx.payload.channelData as ReplyPayload["channelData"] | undefined,

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -67,6 +67,8 @@ const ZulipAccountSchemaBase = z
     email: z.string().optional(),
     apiKey: OptionalSecretInputSchema,
     streams: z.array(z.string()).optional(),
+    topics: z.array(z.string()).optional(),
+    streamTopics: z.record(z.string(), z.array(z.string())).optional(),
     defaultTopic: z.string().optional(),
     chatmode: z.enum(["oncall", "onmessage", "onchar"]).optional(),
     oncharPrefixes: z.array(z.string()).optional(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,10 @@ export type ZulipAccountConfig = {
   defaultTopic?: string;
   /** Restrict monitored streams ("*" = all streams). */
   streams?: string[];
+  /** Restrict monitored stream topics globally ("*" or empty = all topics). Case-insensitive after trimming. */
+  topics?: string[];
+  /** Restrict monitored topics per stream name or stream id. Case-insensitive after trimming. */
+  streamTopics?: Record<string, string[]>;
   /**
    * Controls when channel messages trigger replies.
    * - "oncall": only respond when mentioned

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -218,6 +218,11 @@ async function runMonitorOnce() {
 describe("monitorZulipProvider", () => {
   beforeEach(() => {
     state.core = state.createCore();
+    state.account.config = {
+      dmPolicy: "open",
+      groupPolicy: "open",
+      reactions: { enabled: false },
+    };
     state.pollResponses = [];
     state.abortController = undefined;
     registerZulipQueueMock.mockClear();
@@ -338,6 +343,83 @@ describe("monitorZulipProvider", () => {
         accountId: "default",
       },
     });
+  });
+
+  it("drops stream messages outside the configured global topic filter", async () => {
+    state.account.config = {
+      ...state.account.config,
+      topics: ["allowed-topic"],
+    };
+    state.pollResponses = [
+      {
+        result: "success",
+        events: [{ id: 1, type: "message", message: makeChannelMessage(1200) }],
+      },
+    ];
+
+    await runMonitorOnce();
+
+    expect(state.core.channel.reply.finalizeInboundContext).not.toHaveBeenCalled();
+    expect(state.core.channel.reply.dispatchReplyFromConfig).not.toHaveBeenCalled();
+  });
+
+  it("processes stream messages inside configured topic filters with case and whitespace normalization", async () => {
+    state.account.config = {
+      ...state.account.config,
+      topics: ["  ZULIP-PLUGIN-PR  "],
+      streamTopics: { "  DEBBIE  ": ["  Zulip-Plugin-PR  "] },
+    };
+    state.pollResponses = [
+      {
+        result: "success",
+        events: [{ id: 1, type: "message", message: makeChannelMessage(1201) }],
+      },
+    ];
+
+    await runMonitorOnce();
+
+    expect(state.core.channel.reply.finalizeInboundContext).toHaveBeenCalledTimes(1);
+    expect(state.core.channel.reply.dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops stream messages outside a configured stream-scoped topic filter", async () => {
+    state.account.config = {
+      ...state.account.config,
+      topics: ["*"],
+      streamTopics: { "4": ["another-topic"] },
+    };
+    state.pollResponses = [
+      {
+        result: "success",
+        events: [{ id: 1, type: "message", message: makeChannelMessage(1202) }],
+      },
+    ];
+
+    await runMonitorOnce();
+
+    expect(state.core.channel.reply.finalizeInboundContext).not.toHaveBeenCalled();
+    expect(state.core.channel.reply.dispatchReplyFromConfig).not.toHaveBeenCalled();
+  });
+
+  it("treats empty and wildcard stream-scoped topic filters as unrestricted", async () => {
+    state.account.config = {
+      ...state.account.config,
+      streamTopics: {
+        debbie: [],
+        "4": ["*"],
+      },
+    };
+    state.pollResponses = [
+      {
+        result: "success",
+        events: [{ id: 1, type: "message", message: makeChannelMessage(1203) }],
+      },
+    ];
+
+    await runMonitorOnce();
+
+    expect(state.core.channel.reply.finalizeInboundContext).toHaveBeenCalledTimes(1);
+    expect(state.core.channel.reply.dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
   });
 
   it("ignores duplicate inbound message ids on repeat processing", async () => {

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -106,6 +106,48 @@ function resolveOncharPrefixes(prefixes: string[] | undefined): string[] {
   return cleaned.length > 0 ? cleaned : DEFAULT_ONCHAR_PREFIXES;
 }
 
+function normalizeTopicFilterValue(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function normalizeTopicFilterList(values?: string[]): Set<string> | undefined {
+  const normalized = (values ?? [])
+    .map(normalizeTopicFilterValue)
+    .filter(Boolean);
+  if (normalized.length === 0 || normalized.includes("*")) {
+    return undefined;
+  }
+  return new Set(normalized);
+}
+
+function shouldMonitorTopic(params: {
+  topic: string;
+  streamName?: string;
+  streamId?: string;
+  topics?: string[];
+  streamTopics?: Record<string, string[]>;
+}): boolean {
+  const topic = normalizeTopicFilterValue(params.topic);
+  const globalTopics = normalizeTopicFilterList(params.topics);
+  if (globalTopics && !globalTopics.has(topic)) {
+    return false;
+  }
+
+  const streamTopics = params.streamTopics ?? {};
+  const candidateKeys = [params.streamName, params.streamId]
+    .map((value) => value?.trim())
+    .filter((value): value is string => Boolean(value));
+  const matchingStreamFilter = Object.entries(streamTopics).find(([key]) =>
+    candidateKeys.some((candidate) => normalizeTopicFilterValue(candidate) === normalizeTopicFilterValue(key)),
+  );
+  if (!matchingStreamFilter) {
+    return true;
+  }
+
+  const allowedTopics = normalizeTopicFilterList(matchingStreamFilter[1]);
+  return !allowedTopics || allowedTopics.has(topic);
+}
+
 function stripOncharPrefix(
   text: string,
   prefixes: string[],
@@ -212,7 +254,10 @@ function delay(ms: number): Promise<void> {
 
 export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise<void> {
   const core = getZulipRuntime();
-  const cfg = opts.config ?? core.config.loadConfig();
+  if (!opts.config) {
+    throw new Error("monitorZulipProvider requires resolved runtime config");
+  }
+  const cfg = opts.config;
   const runtime = resolveRuntime(opts);
   const account = await resolveZulipRuntimeAccount({
     cfg,
@@ -318,6 +363,23 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         streamName = message.display_recipient;
       }
       topic = message.subject?.trim() || defaultTopic;
+      if (
+        !shouldMonitorTopic({
+          topic,
+          streamName,
+          streamId,
+          topics: account.config.topics,
+          streamTopics: account.config.streamTopics,
+        })
+      ) {
+        logInboundDrop({
+          log: logVerboseMessage,
+          channel: "zulip",
+          reason: `topic filter (${streamName || streamId}:${topic})`,
+          target: senderIdentity,
+        });
+        return;
+      }
     }
 
     const rawText = stripHtmlToText(message.content ?? "");
@@ -446,7 +508,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
                   idLine: `Your Zulip email: ${senderIdentity}`,
                   code,
                 }),
-                { accountId: account.accountId },
+                { cfg, accountId: account.accountId },
               );
               opts.statusSink?.({ lastOutboundAt: Date.now() });
             } catch (err) {
@@ -734,6 +796,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
                 continue;
               }
               await sendMessageZulip(to, chunk, {
+                cfg,
                 accountId: account.accountId,
                 topic: resolvedTopic,
               });
@@ -744,6 +807,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
               const caption = first ? text : "";
               first = false;
               await sendMessageZulip(to, caption, {
+                cfg,
                 accountId: account.accountId,
                 mediaUrl,
                 topic: resolvedTopic,

--- a/src/zulip/send.test.ts
+++ b/src/zulip/send.test.ts
@@ -109,7 +109,7 @@ const sendState = vi.hoisted(() => {
   const sendZulipStreamMessage = vi.fn(async () => ({ id: 9002 }));
   return {
     runtime: {
-      config: { loadConfig: vi.fn(() => ({ channels: { zulip: {} } })) },
+      config: {},
       logging: {
         getChildLogger: () => ({ debug: vi.fn(), warn: vi.fn() }),
       },
@@ -158,7 +158,10 @@ vi.mock("./client.js", () => ({
 describe("sendMessageZulip target parsing hardening", () => {
   it("rejects malformed dm-like targets instead of silently auto-correcting", async () => {
     await expect(
-      sendMessageZulip("user:user:user8@zlp.pubnerd.app", "hello", { accountId: "default" }),
+      sendMessageZulip("user:user:user8@zlp.pubnerd.app", "hello", {
+        cfg: { channels: { zulip: {} } },
+        accountId: "default",
+      }),
     ).rejects.toThrow("Invalid Zulip direct-message target; expected an email address");
   });
 });

--- a/src/zulip/send.ts
+++ b/src/zulip/send.ts
@@ -3,7 +3,7 @@ import fsPromises from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolvePreferredOpenClawTmpDir } from "../sdk.js";
-import type { InteractiveReply } from "../sdk.js";
+import type { InteractiveReply, OpenClawConfig } from "../sdk.js";
 import { getZulipRuntime } from "../runtime.js";
 import { resolveZulipRuntimeAccount } from "./accounts.js";
 import {
@@ -44,6 +44,7 @@ type ZulipWidgetContent = {
 };
 
 export type ZulipSendOpts = {
+  cfg: OpenClawConfig;
   apiKey?: string;
   email?: string;
   baseUrl?: string;
@@ -249,13 +250,12 @@ function parseZulipTarget(raw: string): ZulipTarget {
 export async function sendMessageZulip(
   to: string,
   text: string,
-  opts: ZulipSendOpts = {},
+  opts: ZulipSendOpts,
 ): Promise<ZulipSendResult> {
   const core = getCore();
   const logger = core.logging.getChildLogger({ module: "zulip" });
-  const cfg = core.config.loadConfig();
   const account = await resolveZulipRuntimeAccount({
-    cfg,
+    cfg: opts.cfg,
     accountId: opts.accountId,
   });
   const apiKey = opts.apiKey?.trim() || account.apiKey?.trim();
@@ -295,7 +295,7 @@ export async function sendMessageZulip(
       const upload = await uploadZulipFile(client, localPath);
       mediaUrl = upload.url;
     } else if (isHttpUrl(mediaUrl) && !isZulipHosted) {
-      const maxBytes = (cfg.agents?.defaults?.mediaMaxMb ?? 5) * 1024 * 1024;
+      const maxBytes = (opts.cfg.agents?.defaults?.mediaMaxMb ?? 5) * 1024 * 1024;
       const fetched = await core.channel.media.fetchRemoteMedia({
         url: mediaUrl,
         maxBytes,
@@ -336,7 +336,7 @@ export async function sendMessageZulip(
 
   if (message) {
     const tableMode = core.channel.text.resolveMarkdownTableMode({
-      cfg,
+      cfg: opts.cfg,
       channel: "zulip",
       accountId: account.accountId,
     });


### PR DESCRIPTION
## Summary
- Add `topics` and `streamTopics` config for filtering monitored Zulip stream messages by topic
- Document topic filtering in README and expose the fields in `openclaw.plugin.json` schema/UI hints
- Prepare npm release version `2026.4.29` and changelog entry

## Testing
- npm test
- npm run build
- git diff --check
- Live smoke: restricted `debbie` stream to `Zulip Plugin PR`, confirmed allowed topic processed and another topic was filtered; restored normal config afterward

Closes #11