### PR TITLE
fix: import jsonResult from core instead of removed browser-support subpath

### DIFF
--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -26,7 +26,7 @@ export {
   setAccountEnabledInConfigSection,
 } from "openclaw/plugin-sdk/core";
 
-export { jsonResult } from "openclaw/plugin-sdk/browser-support";
+export { jsonResult } from "openclaw/plugin-sdk/core";
 export { readNumberParam, readStringParam } from "openclaw/plugin-sdk/param-readers";
 export { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 export { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";


### PR DESCRIPTION
## Summary

- `openclaw/plugin-sdk/browser-support` was removed from openclaw's exports map in the current release (the subpath no longer exists and the file is absent from `dist/plugin-sdk/`)
- `jsonResult` is exported from `openclaw/plugin-sdk/core` and has been all along — this is a one-line redirect
- Without this fix the plugin fails to load entirely with `Error: Cannot find module '.../root-alias.cjs/browser-support'`

## How to reproduce

Install `openclaw-channel-zulip@2026.4.29` against `openclaw@2026.4.29` and run `openclaw status --deep` — the plugin load error appears immediately.

## Test plan

- [ ] Run `openclaw status` after applying the fix and confirm no `zulip failed to load` error
- [ ] Verify `jsonResult` is still re-exported correctly by the plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)