### PR TITLE
fix(zulip): surface uploads as local media

### DIFF
--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -73,7 +73,9 @@ const state = vi.hoisted(() => {
   return {
     abortController: undefined as AbortController | undefined,
     pollResponses: [] as Array<Record<string, unknown>>,
-    client: { authHeader: "Basic fake" },
+    downloadedUploads: [] as Array<{ buffer: Buffer; contentType: string; filename: string }>,
+    extractedUploadUrls: [] as string[],
+    client: { authHeader: "fake-auth" },
     botUser: {
       id: 999,
       email: "debbie-bot@zlp.pubnerd.app",
@@ -133,11 +135,18 @@ vi.mock("./send.js", () => ({
   sendMessageZulip: vi.fn(async () => {}),
 }));
 
-vi.mock("./uploads.js", () => ({
-  downloadZulipUpload: vi.fn(async () => {
+const downloadZulipUploadMock = vi.fn(async () => {
+  const next = state.downloadedUploads.shift();
+  if (!next) {
     throw new Error("unexpected upload download in test");
-  }),
-  extractZulipUploadUrls: vi.fn(() => []),
+  }
+  return next;
+});
+const extractZulipUploadUrlsMock = vi.fn(() => state.extractedUploadUrls);
+
+vi.mock("./uploads.js", () => ({
+  downloadZulipUpload: downloadZulipUploadMock,
+  extractZulipUploadUrls: extractZulipUploadUrlsMock,
   normalizeZulipEmojiName: vi.fn((name: string) => name),
 }));
 
@@ -224,7 +233,11 @@ describe("monitorZulipProvider", () => {
       reactions: { enabled: false },
     };
     state.pollResponses = [];
+    state.downloadedUploads = [];
+    state.extractedUploadUrls = [];
     state.abortController = undefined;
+    downloadZulipUploadMock.mockClear();
+    extractZulipUploadUrlsMock.mockClear();
     registerZulipQueueMock.mockClear();
     getZulipEventsWithRetryMock.mockClear();
     deleteZulipQueueMock.mockClear();
@@ -259,6 +272,51 @@ describe("monitorZulipProvider", () => {
     expect(state.core.channel.reply.finalizeInboundContext).toHaveBeenCalledTimes(1);
     expect(state.core.channel.reply.dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
     expect(state.core.system.enqueueSystemEvent).not.toHaveBeenCalled();
+  });
+
+  it("downloads Zulip uploads and surfaces saved local media paths to the agent", async () => {
+    state.extractedUploadUrls = [
+      "https://zlp.pubnerd.app/user_uploads/2/aa/song.mp3",
+      "https://zlp.pubnerd.app/user_uploads/2/bb/image.png",
+      "https://zlp.pubnerd.app/user_uploads/2/cc/report.pdf",
+    ];
+    state.downloadedUploads = [
+      { buffer: Buffer.from("synthetic mp3"), contentType: "audio/mpeg", filename: "song.mp3" },
+      { buffer: Buffer.from("synthetic png"), contentType: "image/png", filename: "image.png" },
+      { buffer: Buffer.from("synthetic pdf"), contentType: "application/pdf", filename: "report.pdf" },
+    ];
+    state.core.channel.media.saveMediaBuffer.mockImplementation(
+      async (_buffer: Buffer, contentType: string, _direction: string, _maxBytes: number, filename: string) => ({
+        path: `/managed/${filename}`,
+        contentType,
+      }),
+    );
+    state.pollResponses = [
+      {
+        result: "success",
+        events: [{ id: 1, type: "message", message: makeChannelMessage(1004) }],
+      },
+    ];
+
+    await runMonitorOnce();
+
+    expect(downloadZulipUploadMock).toHaveBeenCalledWith(
+      "https://zlp.pubnerd.app/user_uploads/2/aa/song.mp3",
+      "https://zlp.pubnerd.app",
+      "fake-auth",
+      5 * 1024 * 1024,
+    );
+    expect(state.core.channel.media.saveMediaBuffer).toHaveBeenCalledTimes(3);
+    expect(state.core.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        MediaPath: "/managed/song.mp3",
+        MediaPaths: ["/managed/song.mp3", "/managed/image.png", "/managed/report.pdf"],
+        MediaUrl: "/managed/song.mp3",
+        MediaUrls: ["/managed/song.mp3", "/managed/image.png", "/managed/report.pdf"],
+        MediaType: "audio/mpeg",
+        MediaTypes: ["audio/mpeg", "image/png", "application/pdf"],
+      }),
+    );
   });
 
   it("stores last-route delivery context for stream-topic messages", async () => {

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -274,6 +274,29 @@ describe("monitorZulipProvider", () => {
     expect(state.core.system.enqueueSystemEvent).not.toHaveBeenCalled();
   });
 
+  it("falls back to temp-file media storage when runtime saveMediaBuffer is unavailable", async () => {
+    state.extractedUploadUrls = ["https://zlp.pubnerd.app/user_uploads/2/aa/report.pdf"];
+    state.downloadedUploads = [
+      { buffer: Buffer.from("synthetic pdf"), contentType: "application/pdf", filename: "report.pdf" },
+    ];
+    state.core.channel.media = {};
+    state.pollResponses = [
+      {
+        result: "success",
+        events: [{ id: 1, type: "message", message: makeChannelMessage(1005) }],
+      },
+    ];
+
+    await runMonitorOnce();
+
+    expect(state.core.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        MediaPath: expect.stringMatching(/^\/tmp\/zulip-upload-[^/]+\/report\.pdf$/),
+        MediaType: "application/pdf",
+      }),
+    );
+  });
+
   it("downloads Zulip uploads and surfaces saved local media paths to the agent", async () => {
     state.extractedUploadUrls = [
       "https://zlp.pubnerd.app/user_uploads/2/aa/song.mp3",

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -390,13 +390,20 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     const mediaTypes: string[] = [];
     const mediaUrls: string[] = [];
     if (uploadUrls.length > 0) {
+      logVerboseMessage(
+        `zulip: discovered ${uploadUrls.length} upload${uploadUrls.length === 1 ? "" : "s"} for message ${messageId} maxBytes=${mediaMaxBytes}`,
+      );
       for (const uploadUrl of uploadUrls) {
         try {
+          logVerboseMessage(`zulip: downloading upload ${uploadUrl}`);
           const downloaded = await downloadZulipUpload(
             uploadUrl,
             baseUrl,
             client.authHeader,
             mediaMaxBytes,
+          );
+          logVerboseMessage(
+            `zulip: downloaded upload filename=${downloaded.filename} type=${downloaded.contentType} bytes=${downloaded.buffer.length}`,
           );
           const saved = await saveZulipMediaBuffer({
             core,
@@ -408,7 +415,10 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
           if (saved) {
             mediaPaths.push(saved.path);
             mediaTypes.push(saved.contentType);
-            mediaUrls.push(uploadUrl);
+            mediaUrls.push(saved.path);
+            logVerboseMessage(
+              `zulip: saved upload filename=${downloaded.filename} path=${saved.path} type=${saved.contentType}`,
+            );
           }
         } catch (err) {
           logVerboseMessage(`zulip: failed to download/save upload ${uploadUrl}: ${String(err)}`);

--- a/src/zulip/uploads.test.ts
+++ b/src/zulip/uploads.test.ts
@@ -36,6 +36,19 @@ describe("extractZulipUploadUrls", () => {
 });
 
 describe("downloadZulipUpload", () => {
+  it("rejects cross-origin uploads before fetch/auth", async () => {
+    await expect(
+      downloadZulipUpload(
+        "https://evil.test/user_uploads/2/ab/secret.mp3",
+        "https://zlp.pubnerd.app",
+        "encoded-auth",
+        1024,
+      ),
+    ).rejects.toThrow("Refusing to download Zulip upload from non-Zulip origin");
+
+    expect(sdkState.fetchWithSsrFGuard).not.toHaveBeenCalled();
+  });
+
   it("uses Zulip basic auth, keeps PDF-ish metadata, and decodes filenames", async () => {
     const release = vi.fn(async () => {});
     sdkState.fetchWithSsrFGuard.mockResolvedValueOnce({
@@ -64,6 +77,29 @@ describe("downloadZulipUpload", () => {
     expect(result.filename).toBe("Quarterly Report.pdf");
     expect(result.contentType).toBe("application/pdf");
     expect(result.buffer.toString()).toBe("%PDF-1.7");
+    expect(release).toHaveBeenCalled();
+  });
+
+  it("rejects chunked uploads above the configured max size after buffering", async () => {
+    const release = vi.fn(async () => {});
+    sdkState.fetchWithSsrFGuard.mockResolvedValueOnce({
+      release,
+      response: new Response(Buffer.from("too big"), {
+        status: 200,
+        headers: {
+          "content-type": "audio/mpeg",
+        },
+      }),
+    });
+
+    await expect(
+      downloadZulipUpload(
+        "https://zlp.pubnerd.app/user_uploads/2/ab/song.mp3",
+        "https://zlp.pubnerd.app",
+        "encoded-auth",
+        3,
+      ),
+    ).rejects.toThrow("Zulip upload exceeds max size (7 > 3)");
     expect(release).toHaveBeenCalled();
   });
 

--- a/src/zulip/uploads.test.ts
+++ b/src/zulip/uploads.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import { downloadZulipUpload, extractZulipUploadUrls } from "./uploads.js";
+
+const sdkState = vi.hoisted(() => ({
+  fetchWithSsrFGuard: vi.fn(),
+}));
+
+vi.mock("../sdk.js", () => ({
+  fetchWithSsrFGuard: sdkState.fetchWithSsrFGuard,
+}));
+
+describe("extractZulipUploadUrls", () => {
+  it("extracts Zulip upload links from common image, audio, and document HTML", () => {
+    const html = [
+      '<p><a href="/user_uploads/2/f4/image.png">image.png</a></p>',
+      '<p><a href="https://zlp.pubnerd.app/user_uploads/2/ab/song.mp3">song.mp3</a></p>',
+      '<p><a href="/user_uploads/2/cd/report.pdf?download=1&amp;foo=bar">report.pdf</a></p>',
+    ].join("\n");
+
+    expect(extractZulipUploadUrls(html, "https://zlp.pubnerd.app")).toEqual([
+      "https://zlp.pubnerd.app/user_uploads/2/f4/image.png",
+      "https://zlp.pubnerd.app/user_uploads/2/ab/song.mp3",
+      "https://zlp.pubnerd.app/user_uploads/2/cd/report.pdf?download=1&foo=bar",
+    ]);
+  });
+
+  it("ignores non-Zulip origins and trims markdown punctuation", () => {
+    const html =
+      "see https://zlp.pubnerd.app/user_uploads/2/ab/song.mp3), " +
+      "and https://evil.test/user_uploads/2/ab/secret.mp3";
+
+    expect(extractZulipUploadUrls(html, "https://zlp.pubnerd.app")).toEqual([
+      "https://zlp.pubnerd.app/user_uploads/2/ab/song.mp3",
+    ]);
+  });
+});
+
+describe("downloadZulipUpload", () => {
+  it("uses Zulip basic auth, keeps PDF-ish metadata, and decodes filenames", async () => {
+    const release = vi.fn(async () => {});
+    sdkState.fetchWithSsrFGuard.mockResolvedValueOnce({
+      release,
+      response: new Response(Buffer.from("%PDF-1.7"), {
+        status: 200,
+        headers: {
+          "content-type": "application/pdf",
+          "content-length": "8",
+          "content-disposition": "attachment; filename*=UTF-8''Quarterly%20Report.pdf",
+        },
+      }),
+    });
+
+    const result = await downloadZulipUpload(
+      "https://zlp.pubnerd.app/user_uploads/2/ab/Quarterly%20Report.pdf",
+      "https://zlp.pubnerd.app",
+      "encoded-auth",
+      1024,
+    );
+
+    expect(sdkState.fetchWithSsrFGuard).toHaveBeenCalledWith({
+      url: "https://zlp.pubnerd.app/user_uploads/2/ab/Quarterly%20Report.pdf",
+      init: { headers: { Authorization: "Basic encoded-auth" } },
+    });
+    expect(result.filename).toBe("Quarterly Report.pdf");
+    expect(result.contentType).toBe("application/pdf");
+    expect(result.buffer.toString()).toBe("%PDF-1.7");
+    expect(release).toHaveBeenCalled();
+  });
+
+  it("rejects uploads above the configured max size before buffering", async () => {
+    const release = vi.fn(async () => {});
+    sdkState.fetchWithSsrFGuard.mockResolvedValueOnce({
+      release,
+      response: new Response("too big", {
+        status: 200,
+        headers: {
+          "content-type": "audio/mpeg",
+          "content-length": "10485761",
+        },
+      }),
+    });
+
+    await expect(
+      downloadZulipUpload(
+        "https://zlp.pubnerd.app/user_uploads/2/ab/song.mp3",
+        "https://zlp.pubnerd.app",
+        "encoded-auth",
+        10 * 1024 * 1024,
+      ),
+    ).rejects.toThrow("Zulip upload exceeds max size");
+    expect(release).toHaveBeenCalled();
+  });
+});

--- a/src/zulip/uploads.ts
+++ b/src/zulip/uploads.ts
@@ -9,6 +9,23 @@ export function normalizeZulipEmojiName(raw?: string | null): string {
   return trimmed.replace(/^:+|:+$/g, "");
 }
 
+function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}
+
+function trimUploadUrlCandidate(raw: string): string {
+  let candidate = decodeHtmlEntities(raw).trim();
+  while (/[),.;!?]$/.test(candidate)) {
+    candidate = candidate.slice(0, -1);
+  }
+  return candidate;
+}
+
 export function extractZulipUploadUrls(html: string, baseUrl: string): string[] {
   if (!html) {
     return [];
@@ -22,7 +39,7 @@ export function extractZulipUploadUrls(html: string, baseUrl: string): string[] 
   const matches = html.matchAll(/(?:https?:\/\/[^\s"'<>)]+)?\/user_uploads\/[^\s"'<>)]+/g);
   const urls = new Set<string>();
   for (const match of matches) {
-    const raw = match[0];
+    const raw = trimUploadUrlCandidate(match[0]);
     try {
       const absolute = new URL(raw, baseUrl);
       if (baseOrigin && absolute.origin !== baseOrigin) continue;
@@ -50,7 +67,7 @@ function resolveFilename(url: string, contentDisposition?: string | null): strin
     const parsed = new URL(url);
     const base = path.basename(parsed.pathname);
     if (base) {
-      return base;
+      return decodeURIComponent(base);
     }
   } catch {
     // ignore


### PR DESCRIPTION
## Summary
- download discovered Zulip `/user_uploads/` links with bot basic auth, save them through OpenClaw media storage, and pass the saved local paths as inbound MediaUrl(s)/MediaPath(s)
- harden upload URL extraction for HTML-escaped query strings, markdown punctuation, decoded filenames, and same-origin filtering
- add fixture/unit coverage for inbound MP3/image/PDF-style attachments and upload downloader metadata/size handling
- add verbose attachment discovery/download/save/failure logging without logging file contents

## Verification
- npm test
- npm run build

Fixes #14
