### PR TITLE
Harden Zulip upload filenames

### DIFF
--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -148,6 +148,16 @@ vi.mock("./uploads.js", () => ({
   downloadZulipUpload: downloadZulipUploadMock,
   extractZulipUploadUrls: extractZulipUploadUrlsMock,
   normalizeZulipEmojiName: vi.fn((name: string) => name),
+  sanitizeUploadFilename: vi.fn((name: string) =>
+    name
+      .replace(/[\u0000-\u001f\u007f]/g, " ")
+      .replace(/[\\/]+/g, "_")
+      .split(/_+/g)
+      .filter((part) => part && part !== "." && part !== "..")
+      .join("_")
+      .replace(/\s+/g, " ")
+      .trim() || "upload.bin",
+  ),
 }));
 
 const typingCallbacksMock = vi.fn(() => ({
@@ -274,10 +284,10 @@ describe("monitorZulipProvider", () => {
     expect(state.core.system.enqueueSystemEvent).not.toHaveBeenCalled();
   });
 
-  it("falls back to temp-file media storage when runtime saveMediaBuffer is unavailable", async () => {
+  it("falls back to temp-file media storage with a sanitized filename when runtime saveMediaBuffer is unavailable", async () => {
     state.extractedUploadUrls = ["https://zlp.pubnerd.app/user_uploads/2/aa/report.pdf"];
     state.downloadedUploads = [
-      { buffer: Buffer.from("synthetic pdf"), contentType: "application/pdf", filename: "report.pdf" },
+      { buffer: Buffer.from("synthetic pdf"), contentType: "application/pdf", filename: "../evil/name.pdf" },
     ];
     state.core.channel.media = {};
     state.pollResponses = [
@@ -291,7 +301,7 @@ describe("monitorZulipProvider", () => {
 
     expect(state.core.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
       expect.objectContaining({
-        MediaPath: expect.stringMatching(/^\/tmp\/zulip-upload-[^/]+\/report\.pdf$/),
+        MediaPath: expect.stringMatching(/^\/tmp\/zulip-upload-[^/]+\/evil_name\.pdf$/),
         MediaType: "application/pdf",
       }),
     );

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -45,7 +45,7 @@ import {
 } from "./monitor-helpers.js";
 import { buildZulipStreamConversation } from "../session-conversation.js";
 import { sendMessageZulip } from "./send.js";
-import { downloadZulipUpload, extractZulipUploadUrls, normalizeZulipEmojiName } from "./uploads.js";
+import { downloadZulipUpload, extractZulipUploadUrls, normalizeZulipEmojiName, sanitizeUploadFilename } from "./uploads.js";
 
 export type MonitorZulipOpts = {
   apiKey?: string;
@@ -228,7 +228,8 @@ async function saveZulipMediaBuffer(params: {
   filename: string;
   maxBytes: number;
 }): Promise<{ path: string; contentType: string } | null> {
-  const { core, buffer, contentType, filename, maxBytes } = params;
+  const { core, buffer, contentType, maxBytes } = params;
+  const filename = sanitizeUploadFilename(params.filename);
   if (core.channel.media?.saveMediaBuffer) {
     const saved = await core.channel.media.saveMediaBuffer(
       buffer,

--- a/src/zulip/uploads.test.ts
+++ b/src/zulip/uploads.test.ts
@@ -80,6 +80,32 @@ describe("downloadZulipUpload", () => {
     expect(release).toHaveBeenCalled();
   });
 
+  it.each([
+    ["attachment; filename*=UTF-8''evil%2Fname.mp3", "https://zlp.pubnerd.app/user_uploads/2/ab/safe.mp3", "evil_name.mp3"],
+    ["attachment; filename*=UTF-8''evil%5Cname.pdf", "https://zlp.pubnerd.app/user_uploads/2/ab/safe.pdf", "evil_name.pdf"],
+    ["attachment; filename=\"..%2F..%2Fsecret.txt\"", "https://zlp.pubnerd.app/user_uploads/2/ab/safe.txt", "secret.txt"],
+    ["attachment; filename=\"../../secret.txt\"", "https://zlp.pubnerd.app/user_uploads/2/ab/safe.txt", "secret.txt"],
+    [undefined, "https://zlp.pubnerd.app/user_uploads/2/ab/evil%2Fname.mp3", "evil_name.mp3"],
+    [undefined, "https://zlp.pubnerd.app/user_uploads/2/ab/evil%5Cname.pdf", "evil_name.pdf"],
+    ["attachment; filename=\"../..\"", "https://zlp.pubnerd.app/user_uploads/2/ab/safe.bin", "upload.bin"],
+  ])("sanitizes decoded upload filenames from content-disposition and URL fallbacks", async (contentDisposition, url, expected) => {
+    const release = vi.fn(async () => {});
+    sdkState.fetchWithSsrFGuard.mockResolvedValueOnce({
+      release,
+      response: new Response(Buffer.from("ok"), {
+        status: 200,
+        headers: {
+          ...(contentDisposition ? { "content-disposition": contentDisposition } : {}),
+        },
+      }),
+    });
+
+    const result = await downloadZulipUpload(url, "https://zlp.pubnerd.app", "encoded-auth", 1024);
+
+    expect(result.filename).toBe(expected);
+    expect(release).toHaveBeenCalled();
+  });
+
   it("rejects chunked uploads above the configured max size after buffering", async () => {
     const release = vi.fn(async () => {});
     sdkState.fetchWithSsrFGuard.mockResolvedValueOnce({

--- a/src/zulip/uploads.ts
+++ b/src/zulip/uploads.ts
@@ -52,22 +52,45 @@ export function extractZulipUploadUrls(html: string, baseUrl: string): string[] 
   return Array.from(urls);
 }
 
+export function sanitizeUploadFilename(raw: string): string {
+  const cleaned = raw
+    .replace(/[\u0000-\u001f\u007f]/g, " ")
+    .replace(/[\\/]+/g, "_")
+    .split(/_+/g)
+    .filter((part) => part && part !== "." && part !== "..")
+    .join("_")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!cleaned || /^\.+$/.test(cleaned)) {
+    return "upload.bin";
+  }
+  return cleaned;
+}
+
+function decodeUploadFilename(raw: string): string {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}
+
 function resolveFilename(url: string, contentDisposition?: string | null): string {
   if (contentDisposition) {
     const encodedMatch = contentDisposition.match(/filename\*=UTF-8''([^;]+)/i);
     if (encodedMatch?.[1]) {
-      return decodeURIComponent(encodedMatch[1]);
+      return sanitizeUploadFilename(decodeUploadFilename(encodedMatch[1]));
     }
     const match = contentDisposition.match(/filename="?([^";]+)"?/i);
     if (match?.[1]) {
-      return match[1];
+      return sanitizeUploadFilename(decodeUploadFilename(match[1]));
     }
   }
   try {
     const parsed = new URL(url);
     const base = path.basename(parsed.pathname);
     if (base) {
-      return decodeURIComponent(base);
+      return sanitizeUploadFilename(decodeUploadFilename(base));
     }
   } catch {
     // ignore


### PR DESCRIPTION
## Summary
- sanitize upload filenames after content-disposition parsing and URL basename decoding
- strip path separators, traversal components, control characters, and fall back to upload.bin for empty results
- add coverage for encoded separators, traversal-ish names, and fallback temp-file saving

Follow-up hardening for the Codex review finding on merged PR #15.

## Verification
- npm test
- npm run build

No npm publish.