### PR TITLE
feat(zulip): surface private stream metadata

### DIFF
--- a/src/zulip/client.ts
+++ b/src/zulip/client.ts
@@ -55,6 +55,10 @@ export type ZulipStream = {
   id: string;
   name?: string | null;
   description?: string | null;
+  invite_only?: boolean;
+  is_web_public?: boolean;
+  history_public_to_subscribers?: boolean;
+  subscriber_count?: number;
 };
 
 export type ZulipSubscription = {
@@ -64,6 +68,8 @@ export type ZulipSubscription = {
   email_address?: string | null;
   invite_only?: boolean;
   is_web_public?: boolean;
+  history_public_to_subscribers?: boolean;
+  subscriber_count?: number;
 };
 
 export type ZulipMessage = {
@@ -323,7 +329,17 @@ export async function fetchZulipStream(
   streamId: string,
 ): Promise<ZulipStream> {
   const payload = await client.request<
-    ZulipApiResponse & { stream?: { stream_id: number; name?: string; description?: string } }
+    ZulipApiResponse & {
+      stream?: {
+        stream_id: number;
+        name?: string;
+        description?: string;
+        invite_only?: boolean;
+        is_web_public?: boolean;
+        history_public_to_subscribers?: boolean;
+        subscriber_count?: number;
+      };
+    }
   >(`/streams/${streamId}`);
   assertSuccess(payload, "Zulip /streams/{id} failed");
   const stream = payload.stream;
@@ -331,6 +347,10 @@ export async function fetchZulipStream(
     id: String(stream?.stream_id ?? streamId),
     name: stream?.name ?? null,
     description: stream?.description ?? null,
+    invite_only: stream?.invite_only,
+    is_web_public: stream?.is_web_public,
+    history_public_to_subscribers: stream?.history_public_to_subscribers,
+    subscriber_count: stream?.subscriber_count,
   };
 }
 
@@ -591,7 +611,15 @@ export async function fetchZulipSubscriptions(
 export async function fetchZulipStreams(client: ZulipClient): Promise<ZulipStream[]> {
   const payload = await client.request<
     ZulipApiResponse & {
-      streams?: Array<{ stream_id: number; name?: string; description?: string }>;
+      streams?: Array<{
+        stream_id: number;
+        name?: string;
+        description?: string;
+        invite_only?: boolean;
+        is_web_public?: boolean;
+        history_public_to_subscribers?: boolean;
+        subscriber_count?: number;
+      }>;
     }
   >("/streams");
   assertSuccess(payload, "Zulip /streams failed");
@@ -599,6 +627,10 @@ export async function fetchZulipStreams(client: ZulipClient): Promise<ZulipStrea
     id: String(stream.stream_id),
     name: stream.name ?? null,
     description: stream.description ?? null,
+    invite_only: stream.invite_only,
+    is_web_public: stream.is_web_public,
+    history_public_to_subscribers: stream.history_public_to_subscribers,
+    subscriber_count: stream.subscriber_count,
   }));
 }
 

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -73,6 +73,8 @@ const state = vi.hoisted(() => {
   return {
     abortController: undefined as AbortController | undefined,
     pollResponses: [] as Array<Record<string, unknown>>,
+    streamSubscriptions: [] as Array<Record<string, unknown>>,
+    streamLookups: new Map<string, Record<string, unknown> | Error>(),
     downloadedUploads: [] as Array<{ buffer: Buffer; contentType: string; filename: string }>,
     extractedUploadUrls: [] as string[],
     client: { authHeader: "fake-auth" },
@@ -113,11 +115,23 @@ const getZulipEventsWithRetryMock = vi.fn(async () => {
   return next;
 });
 const deleteZulipQueueMock = vi.fn(async () => {});
+const fetchZulipSubscriptionsMock = vi.fn(async () => state.streamSubscriptions);
+const fetchZulipStreamMock = vi.fn(async (_client: unknown, streamId: string) => {
+  const result = state.streamLookups.get(String(streamId));
+  if (result instanceof Error) {
+    throw result;
+  }
+  if (result) {
+    return result;
+  }
+  throw new Error(`unexpected stream metadata lookup: ${streamId}`);
+});
 
 vi.mock("./client.js", () => ({
   createZulipClient: vi.fn(() => state.client),
   fetchZulipMe: vi.fn(async () => state.botUser),
-  fetchZulipStream: vi.fn(),
+  fetchZulipStream: fetchZulipStreamMock,
+  fetchZulipSubscriptions: fetchZulipSubscriptionsMock,
   normalizeZulipBaseUrl: vi.fn((url?: string) => url ?? ""),
   registerZulipQueue: registerZulipQueueMock,
   getZulipEventsWithRetry: getZulipEventsWithRetryMock,
@@ -267,6 +281,17 @@ describe("monitorZulipProvider", () => {
       reactions: { enabled: false },
     };
     state.pollResponses = [];
+    state.streamSubscriptions = [
+      {
+        stream_id: 4,
+        name: "debbie",
+        invite_only: false,
+        is_web_public: false,
+        history_public_to_subscribers: true,
+        subscriber_count: 12,
+      },
+    ];
+    state.streamLookups = new Map();
     state.downloadedUploads = [];
     state.extractedUploadUrls = [];
     state.abortController = undefined;
@@ -275,6 +300,8 @@ describe("monitorZulipProvider", () => {
     registerZulipQueueMock.mockClear();
     getZulipEventsWithRetryMock.mockClear();
     deleteZulipQueueMock.mockClear();
+    fetchZulipSubscriptionsMock.mockClear();
+    fetchZulipStreamMock.mockClear();
   });
 
   it("wires typing idle cleanup into the reply dispatcher", async () => {
@@ -306,6 +333,109 @@ describe("monitorZulipProvider", () => {
     expect(state.core.channel.reply.finalizeInboundContext).toHaveBeenCalledTimes(1);
     expect(state.core.channel.reply.dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
     expect(state.core.system.enqueueSystemEvent).not.toHaveBeenCalled();
+  });
+
+  it("surfaces private invite-only stream metadata while keeping ChatType channel", async () => {
+    state.streamSubscriptions = [
+      {
+        stream_id: 4,
+        name: "debbie",
+        invite_only: true,
+        is_web_public: false,
+        history_public_to_subscribers: false,
+        subscriber_count: 3,
+      },
+    ];
+    state.pollResponses = [
+      {
+        result: "success",
+        events: [{ id: 1, type: "message", message: makeChannelMessage(1006) }],
+      },
+    ];
+
+    await runMonitorOnce();
+
+    expect(state.core.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ChatType: "channel",
+        ChannelPrivacy: "private",
+        IsPrivateChannel: true,
+        InviteOnly: true,
+        IsWebPublic: false,
+        HistoryPublicToSubscribers: false,
+        SubscriberCount: 3,
+        StreamId: "4",
+      }),
+    );
+    expect(fetchZulipStreamMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces public stream metadata from cached subscriptions", async () => {
+    state.streamSubscriptions = [
+      {
+        stream_id: 4,
+        name: "debbie",
+        invite_only: false,
+        is_web_public: true,
+        history_public_to_subscribers: true,
+        subscriber_count: 48,
+      },
+    ];
+    state.pollResponses = [
+      {
+        result: "success",
+        events: [{ id: 1, type: "message", message: makeChannelMessage(1007) }],
+      },
+    ];
+
+    await runMonitorOnce();
+
+    expect(state.core.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ChatType: "channel",
+        ChannelPrivacy: "public",
+        IsPrivateChannel: false,
+        InviteOnly: false,
+        IsWebPublic: true,
+        HistoryPublicToSubscribers: true,
+        SubscriberCount: 48,
+        StreamId: "4",
+      }),
+    );
+  });
+
+  it("falls back to unknown stream privacy when metadata lookup fails", async () => {
+    state.streamSubscriptions = [];
+    state.streamLookups.set("404", new Error("metadata unavailable"));
+    state.pollResponses = [
+      {
+        result: "success",
+        events: [
+          {
+            id: 1,
+            type: "message",
+            message: {
+              ...makeChannelMessage(1008),
+              stream_id: 404,
+              display_recipient: "missing-private",
+            },
+          },
+        ],
+      },
+    ];
+
+    await runMonitorOnce();
+
+    expect(fetchZulipStreamMock).toHaveBeenCalledWith(state.client, "404");
+    expect(state.core.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ChatType: "channel",
+        ChannelPrivacy: "unknown",
+        IsPrivateChannel: false,
+        StreamId: "404",
+      }),
+    );
+    expect(state.core.channel.reply.dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
   });
 
   it("falls back to temp-file media storage with a sanitized filename when runtime saveMediaBuffer is unavailable", async () => {

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -29,6 +29,7 @@ import {
   createZulipClient,
   fetchZulipMe,
   fetchZulipStream,
+  fetchZulipSubscriptions,
   normalizeZulipBaseUrl,
   registerZulipQueue,
   getZulipEventsWithRetry,
@@ -38,6 +39,7 @@ import {
   removeZulipReaction,
   type ZulipMessage,
   type ZulipStream,
+  type ZulipSubscription,
 } from "./client.js";
 import {
   createDedupeCache,
@@ -68,6 +70,106 @@ const recentInboundMessages = createDedupeCache({
   ttlMs: RECENT_MESSAGE_TTL_MS,
   maxSize: RECENT_MESSAGE_MAX,
 });
+
+type ZulipStreamMetadata = {
+  streamId: string;
+  name?: string | null;
+  inviteOnly?: boolean;
+  isWebPublic?: boolean;
+  historyPublicToSubscribers?: boolean;
+  subscriberCount?: number;
+};
+
+type ZulipStreamPrivacy = "private" | "public" | "unknown";
+
+const streamMetadataCache = new Map<string, ZulipStreamMetadata>();
+
+function streamMetadataCacheKey(accountId: string, streamId: string): string {
+  return `${accountId}:${streamId}`;
+}
+
+function normalizeZulipStreamMetadata(
+  stream: ZulipStream | ZulipSubscription,
+): ZulipStreamMetadata | null {
+  const rawStreamId = "id" in stream ? stream.id : stream.stream_id;
+  const streamId = String(rawStreamId ?? "").trim();
+  if (!streamId) {
+    return null;
+  }
+  return {
+    streamId,
+    name: stream.name ?? null,
+    inviteOnly: stream.invite_only,
+    isWebPublic: stream.is_web_public,
+    historyPublicToSubscribers: stream.history_public_to_subscribers,
+    subscriberCount: stream.subscriber_count,
+  };
+}
+
+function cacheZulipStreamMetadata(accountId: string, metadata: ZulipStreamMetadata): void {
+  streamMetadataCache.set(streamMetadataCacheKey(accountId, metadata.streamId), metadata);
+}
+
+function resolveZulipStreamPrivacy(
+  metadata: ZulipStreamMetadata | undefined,
+): ZulipStreamPrivacy {
+  if (!metadata) {
+    return "unknown";
+  }
+  if (metadata.inviteOnly === true) {
+    return "private";
+  }
+  if (metadata.inviteOnly === false || metadata.isWebPublic === true) {
+    return "public";
+  }
+  return "unknown";
+}
+
+async function seedZulipStreamMetadataCache(params: {
+  client: ReturnType<typeof createZulipClient>;
+  accountId: string;
+  log: (message: string) => void;
+}): Promise<void> {
+  try {
+    const subscriptions = await fetchZulipSubscriptions(params.client, { includeAllPublic: true });
+    for (const subscription of subscriptions) {
+      const metadata = normalizeZulipStreamMetadata(subscription);
+      if (metadata) {
+        cacheZulipStreamMetadata(params.accountId, metadata);
+      }
+    }
+  } catch (err) {
+    params.log(`zulip: stream metadata seed failed: ${String(err)}`);
+  }
+}
+
+async function resolveCachedZulipStreamMetadata(params: {
+  client: ReturnType<typeof createZulipClient>;
+  accountId: string;
+  streamId: string;
+  log: (message: string) => void;
+}): Promise<ZulipStreamMetadata | undefined> {
+  const streamId = params.streamId.trim();
+  if (!streamId) {
+    return undefined;
+  }
+  const key = streamMetadataCacheKey(params.accountId, streamId);
+  const cached = streamMetadataCache.get(key);
+  if (cached) {
+    return cached;
+  }
+  try {
+    const stream = await fetchZulipStream(params.client, streamId);
+    const metadata = normalizeZulipStreamMetadata(stream);
+    if (metadata) {
+      cacheZulipStreamMetadata(params.accountId, metadata);
+      return metadata;
+    }
+  } catch (err) {
+    params.log(`zulip: stream metadata lookup failed streamId=${streamId}: ${String(err)}`);
+  }
+  return undefined;
+}
 
 function resolveRuntime(opts: MonitorZulipOpts): RuntimeEnv {
   return (
@@ -291,6 +393,11 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
   const logVerboseMessage = core.logging.shouldLogVerbose()
     ? (message: string) => logger.debug?.(message)
     : () => {};
+  await seedZulipStreamMetadataCache({
+    client,
+    accountId: account.accountId,
+    log: logVerboseMessage,
+  });
 
   const defaultTopic = account.config.defaultTopic?.trim() ?? FALLBACK_TOPIC;
   const oncharPrefixes = resolveOncharPrefixes(account.oncharPrefixes);
@@ -611,6 +718,16 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
             streamId: channelId,
             topic,
           });
+    const streamMetadata =
+      kind === "dm"
+        ? undefined
+        : await resolveCachedZulipStreamMetadata({
+            client,
+            accountId: account.accountId,
+            streamId: channelId,
+            log: logVerboseMessage,
+          });
+    const channelPrivacy = kind === "dm" ? undefined : resolveZulipStreamPrivacy(streamMetadata);
 
     const route = core.channel.routing.resolveAgentRoute({
       cfg,
@@ -670,6 +787,13 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       ParentSessionKey: parentSessionKey,
       AccountId: route.accountId,
       ChatType: chatType,
+      ChannelPrivacy: channelPrivacy,
+      IsPrivateChannel: kind !== "dm" ? channelPrivacy === "private" : undefined,
+      InviteOnly: streamMetadata?.inviteOnly,
+      IsWebPublic: streamMetadata?.isWebPublic,
+      HistoryPublicToSubscribers: streamMetadata?.historyPublicToSubscribers,
+      SubscriberCount: streamMetadata?.subscriberCount,
+      StreamId: kind !== "dm" ? streamId : undefined,
       ConversationLabel: fromLabel,
       GroupSubject: kind !== "dm" ? roomLabel : undefined,
       GroupChannel: streamName ? `#${streamName}` : undefined,


### PR DESCRIPTION
## Summary
- Add Zulip stream metadata normalization and an account+stream keyed cache seeded from subscriptions.
- Surface stream privacy context on inbound stream messages without changing ChatType behavior.
- Fall back to ChannelPrivacy="unknown" when metadata lookup fails, while continuing inbound processing.

## Verification
- pnpm test
- pnpm build