### PR TITLE
refactor: migrate Zulip to focused stable plugin SDK APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ inbound records and deduplication tombstones retain their existing namespaces an
 retention; this update does not migrate or discard them. The newer ingress queue
 also requires host trust unavailable to ordinary third-party plugins.
 
+The stable setup adapter, session-store path resolver, human-delay resolver, and
+outbound media loader remain until supported replacements preserve their current
+contracts. The beta setup contract is not available in the pinned stable SDK;
+replacing the outbound loader must preserve host-provided file access limits.
+
 ### Via plugin manager (recommended)
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@
 
 ## Installation
 
+This source targets OpenClaw **2026.7.1-2**. It uses the focused channel SDK,
+ordered inbound media facts, buffered reply dispatch, and portable message
+presentations. The development dependency is pinned to that published SDK.
+
+Do not use this branch with the 2026.8 beta yet: that SDK removes the keyed-store
+receive journal before an external-plugin migration path is available. Pending
+inbound records and deduplication tombstones retain their existing namespaces and
+retention; this update does not migrate or discard them. The newer ingress queue
+also requires host trust unavailable to ordinary third-party plugins.
+
 ### Via plugin manager (recommended)
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@types/ws": "^8.18.1",
-    "openclaw": "^2026.5.26",
+    "openclaw": "2026.7.1-2",
     "typescript": "^5.7.0",
     "vitest": "^3.2.4"
   },
@@ -63,7 +63,7 @@
     "install": {
       "npmSpec": "openclaw-channel-zulip",
       "defaultChoice": "npm",
-      "minHostVersion": ">=2026.5.26"
+      "minHostVersion": ">=2026.7.1-2"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
         specifier: ^8.18.1
         version: 8.18.1
       openclaw:
-        specifier: ^2026.5.26
-        version: 2026.5.26
+        specifier: 2026.7.1-2
+        version: 2026.7.1-2(@aws-sdk/credential-provider-node@3.972.44)(@smithy/signature-v4@5.4.4)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -27,13 +27,13 @@ importers:
 
 packages:
 
-  '@agentclientprotocol/sdk@0.22.1':
-    resolution: {integrity: sha512-DfqXtl/8gO9NImq094MTaCXEU2vkhh6v7q/kT+9UjZxUqj8hYaya2OjLVIqn16MzNHcXEpShTR2RIauLSYeDQQ==}
+  '@agentclientprotocol/sdk@1.1.0':
+    resolution: {integrity: sha512-NT2KqphUJ3w6EksUL51ZhJgIYgq/ZLGcBPkyMKgRSO5PMVwe9DnKKX+Htnvk6KHh6dUuh34UHK4gKp+4te1Mdg==}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  '@anthropic-ai/sdk@0.91.1':
-    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
+  '@anthropic-ai/sdk@0.109.1':
+    resolution: {integrity: sha512-q9OnEKLr5H9nxSuXdgDgJhxfYMiE+AaUEBze2Gk91UcaaLnsN+Lx5fbCYywiqurU/APLdwv23x03Wm6WN3EBsg==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -57,10 +57,6 @@ packages:
 
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
-
-  '@aws-sdk/client-bedrock-runtime@3.1048.0':
-    resolution: {integrity: sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==}
-    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/core@3.974.13':
     resolution: {integrity: sha512-+Y5/4tHki0uYgyx8eun146DegRVQBpdKGK5RbV0FTKJPpaKTchvqVxrrRFK6Wk0JksO4iAZKw3eqxGEIwtO98w==}
@@ -98,28 +94,12 @@ packages:
     resolution: {integrity: sha512-wQtL34lUD/09VXjwAUo2T+I3aEXRDxMB3DKmTJL/Zj0Gi6sLDTrVhae1XVt01yzkquOWajI/sZW72JGDZ1ciTw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/eventstream-handler-node@3.972.17':
-    resolution: {integrity: sha512-WFwdNcjchKZr7jKYgGimUZO8sSKQF/le7GGqgeCzz/lHozInE6b0gFJ1YMr8NaIeAoWJwgtrF7RE4/qMgosAdQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-eventstream@3.972.13':
-    resolution: {integrity: sha512-ECfsw7mf6G/sxNbKbGE3/h1xeIArY/yRI1IjDGYkLgDIankh+aDOtDRSr40LVlIHGL9+jEH1cVuxmbJ8NLL/1A==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-websocket@3.972.21':
-    resolution: {integrity: sha512-yr+5+C7v9R55sAJ89A55Wrm7wIKPVn5cm6J3Hztnd5s/iwEUKxyJqCnIxJu4fVXgG9XBQD1Jc4rsWC1ozahJjA==}
-    engines: {node: '>= 14.0.0'}
-
   '@aws-sdk/nested-clients@3.997.11':
     resolution: {integrity: sha512-nWXXJ1r/r8N2Gw1pWolRgED38/A9A8DHR2ETWIv220zh4PZHcybbR4hUVWWktmNXTRHzDJwRluapHn0rZxuoqA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/signature-v4-multi-region@3.996.28':
     resolution: {integrity: sha512-qs9z5LqXO/CZC2Lg9SGKpoLU8Rhi+m2pFKZqfO9pytX1clc0katqtsDNupJxFy0xT9wsZSPzM2v1y+/H/zfp5Q==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/token-providers@3.1048.0':
-    resolution: {integrity: sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1052.0':
@@ -149,30 +129,16 @@ packages:
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
-  '@clack/core@1.3.1':
-    resolution: {integrity: sha512-fT1qHVGAag4IEkrupZ6lRRbNCs1vS9P01KB/sG8zKgvUztbYtFBtQpjSITNwooDZ83tpsPzP0mRNs1/KVszCRA==}
+  '@clack/core@1.4.2':
+    resolution: {integrity: sha512-0Ty/1Gfm+Kb07sXcuESjyKfwEhSy4Ns1AgeEisHb/bDY5fWme0tTeTkU14T1Gmcs17YIjB/teiDe4uaCghbYqQ==}
     engines: {node: '>= 20.12.0'}
 
-  '@clack/prompts@1.4.0':
-    resolution: {integrity: sha512-S0My7XPGIgpRWMDG8uRqalbgT+a6FmCUdOW+HaIOVVpUPHOb7RrpvjTjiODadKp06fsrVDJZlIzc6yCTp4AnxA==}
+  '@clack/prompts@1.6.0':
+    resolution: {integrity: sha512-EYlRokl8szrP9Z25qT5aepMdBjzBvHF9ZEhzIiUBc9guz/T31EqRgvD0QSgZcpE93xiwrr+OkB4nz0BZyF6fSA==}
     engines: {node: '>= 20.12.0'}
 
-  '@earendil-works/pi-agent-core@0.75.5':
-    resolution: {integrity: sha512-LHygOgsW2pgXKb3IkXkOAeZPovHr9VF+EixgXVsDNuB4jmhEOXgshy/zksZ7slkUAx10OQ9W1Ed/2jsnhd1NqA==}
-    engines: {node: '>=22.19.0'}
-
-  '@earendil-works/pi-ai@0.75.5':
-    resolution: {integrity: sha512-zf1F5kXk1pqZeFShXOqq9ibUk8QdtRoLCDPAjO+hj44e3EUs9/GFO2qnhTC5+JA2uwVCx+WCNe1PiCjlBYWm5w==}
-    engines: {node: '>=22.19.0'}
-    hasBin: true
-
-  '@earendil-works/pi-coding-agent@0.75.5':
-    resolution: {integrity: sha512-O3CCQDYy28D4uwtP6zZkdEwzHN6X22v49Sb0+SZTC7x37V/YfmogrWPiaFoWeoc2hmdKhSATI7ZAK5bQbJG5NA==}
-    engines: {node: '>=22.19.0'}
-    hasBin: true
-
-  '@earendil-works/pi-tui@0.75.5':
-    resolution: {integrity: sha512-LkXUM1/49pvzzeI39Y5wjBMlgafcCf67HCLhB9Z7yuXHy4XgT+VqxWcZVW5hBdhQsHZd0znjJotfGH1BzxMfiA==}
+  '@earendil-works/pi-tui@0.80.3':
+    resolution: {integrity: sha512-2BJI6qwRQfnM0Q7seL1+SbacU/jRRjBnN7Hu3n9BjAn7/s5FaBNnvdD1qBQYRsFTHfjqMaDsjYqanPyqwXj99w==}
     engines: {node: '>=22.19.0'}
 
   '@esbuild/aix-ppc64@0.27.7':
@@ -331,17 +297,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@google/genai@1.52.0':
-    resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      '@modelcontextprotocol/sdk': ^1.25.2
-    peerDependenciesMeta:
-      '@modelcontextprotocol/sdk':
-        optional: true
-
-  '@google/genai@2.6.0':
-    resolution: {integrity: sha512-HjoW3mPuEn7pnuKABJl9VbDoWDSF4nbwYKYvYYor7YjPeDxrrBxHzu2d1Prcd+BAuC4w+85UP6y7ZdcrQAoO7g==}
+  '@google/genai@2.10.0':
+    resolution: {integrity: sha512-e4cFxj3tiuMtsgOT4G9c1hXyGJhg7/Buj7VVeBacRY3fRtkRZZ59Q3nuVp2xbq8BGQXLXCDB253qMhklMOeUDg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.25.2
@@ -361,11 +318,11 @@ packages:
     peerDependencies:
       grammy: ^1.0.0
 
-  '@grammyjs/types@3.27.3':
-    resolution: {integrity: sha512-yUKMLliGsGbnxu96YUJ7km7B0zy4PzeH/Jvti5705R/LeKDMqkDV4DckMSt+OrliWQpTwQljHE0QLol5zgxBkg==}
+  '@grammyjs/types@3.28.0':
+    resolution: {integrity: sha512-4JvXCdxRZHCje0M4gHzLwtB4bLno3WD28xd8CNfk4POWIu73BFnSvGeW6OQ5gPem4eYTEwkD9yDaXssixl6tMQ==}
 
-  '@homebridge/ciao@1.3.8':
-    resolution: {integrity: sha512-lNhpCsZVbdbjz2trFjQdzQ3cUIMZQMIMksi7wd3ntTIYgdaGLqT1Ms97DfVIJYHzRuduf56ISvgU8RRLTpK/ng==}
+  '@homebridge/ciao@1.3.9':
+    resolution: {integrity: sha512-TMy9zy173jDOpnFXDqL3BPIQn5lfcAkSsivYQatCCakoHk4fLGd7QjfAaNGYE3Ox+/ZI6Lq0e1gGcz1qdw/IbA==}
     hasBin: true
 
   '@hono/node-server@1.19.14':
@@ -414,71 +371,13 @@ packages:
   '@lydell/node-pty@1.2.0-beta.12':
     resolution: {integrity: sha512-qIK890UwPupoj07osVvgOIa++1mxeHbcGry4PKRHhNVNs81V2SCG34eJr46GybiOmBtc8Sj5PB1/GGM5PL549g==}
 
-  '@mariozechner/clipboard-darwin-arm64@0.3.6':
-    resolution: {integrity: sha512-HjaisYCAbHi/1+N1yDAQHc8ZXGffufIUT5NSOSVR3f3AuMDusxTtnbK8tZ7JFDkShua1oNGZoNwQHsc8MPtE0Q==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@mariozechner/clipboard-darwin-universal@0.3.6':
-    resolution: {integrity: sha512-8BWtPjOtJOJoykml3w0fx0zRrfWP31mXrJwfoA7xzNprkZw1uolCNfgmjDiVBseoKjp16EGITz7bN+61qn8dWA==}
-    engines: {node: '>= 10'}
-    os: [darwin]
-
-  '@mariozechner/clipboard-darwin-x64@0.3.6':
-    resolution: {integrity: sha512-p9syiZD1kU4I+1ya7f7g+zD1GiUvR8fdlRlNmgsZNWlyjtc8rlV2EjTLd/35x1LsdBq020GVvtzp0ZmPgBI09Q==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@mariozechner/clipboard-linux-arm64-gnu@0.3.6':
-    resolution: {integrity: sha512-5JFf5rGofrm+V29HNF+wLthXphHdQpMbKDUYJ5tML6/Z5DLlLOV/9Ak4kDPtYyZ+Dzf+kAusE0VsFg4+tfP1IA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@mariozechner/clipboard-linux-arm64-musl@0.3.6':
-    resolution: {integrity: sha512-JlVjxxw0GbGC0djXYWRIqyteO3J1KZ/QG3udlEFaOD5TLOM1FnmXXAPDQBqr+aBVr720ef9K00dirYnJ0LDCtw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.6':
-    resolution: {integrity: sha512-4t8BUi5zZ+L77otFQVnVSlaTyAX4TVk9EqQm4syMrEQp96trFEHEwwNHcNEBGzYv5+K7mxay50TthYkz47OWzQ==}
-    engines: {node: '>= 10'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@mariozechner/clipboard-linux-x64-gnu@0.3.6':
-    resolution: {integrity: sha512-trtPwcNLW37irwQCJLtCxLw757jjJZk3TSnY/MU9bhtWtA3K9b/eLW0e4RGhUXDoFRds9opNWWaUDuFLa8dm0w==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
-  '@mariozechner/clipboard-linux-x64-musl@0.3.6':
-    resolution: {integrity: sha512-WfnzIvOCCWQiN0MmltCEo6cLceUDbYe+I7xyFZjaps5A+2Op/M2CY7Rey+C4ucQhrvmpoHmTSFgY9ODWk7snoA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
-  '@mariozechner/clipboard-win32-arm64-msvc@0.3.6':
-    resolution: {integrity: sha512-+8+1aHYsBPUjmW3otmWlg+Hijt0iJvoBBs5e0mxFeUd4gDaKMB8Bn6x7c6KVtscg7E5j5NFXnwQqNSIAO4p8zQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@mariozechner/clipboard-win32-x64-msvc@0.3.6':
-    resolution: {integrity: sha512-S4xfPmERC8ZkiLHe3vekZCjdDwNEETCuvCgQK2kP6/TnvmUkq1y2Pk+DjM4t8uh9KMX9bH4zs5ePcKa8GTXmfg==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@mariozechner/clipboard@0.3.6':
-    resolution: {integrity: sha512-MXdtr+6+ntlIVHdrZYuZNQydu6o8yZswFJ2Ln81j2O/Y9B/LDHvEaIm95xWNPkjGTWriSOeLnQJRFs6dYb60bg==}
-    engines: {node: '>= 10'}
-
-  '@mistralai/mistralai@2.2.1':
-    resolution: {integrity: sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==}
+  '@mistralai/mistralai@2.4.0':
+    resolution: {integrity: sha512-t6hCx242MTGolB76CI+17jDtPIe/bzLsMdUTMMoMn9Qo1h02N2G5jQYHmKDGU3X//OgR2wvngTD7tO6tPp5poQ==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -494,88 +393,26 @@ packages:
     resolution: {integrity: sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==}
     engines: {node: '>=14.0.0'}
 
-  '@napi-rs/canvas-android-arm64@0.1.100':
-    resolution: {integrity: sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [android]
-
-  '@napi-rs/canvas-darwin-arm64@0.1.100':
-    resolution: {integrity: sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@napi-rs/canvas-darwin-x64@0.1.100':
-    resolution: {integrity: sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
-    resolution: {integrity: sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==}
-    engines: {node: '>= 10'}
-    cpu: [arm]
-    os: [linux]
-
-  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
-    resolution: {integrity: sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
-    resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
-    resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
-    engines: {node: '>= 10'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
-    resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
-  '@napi-rs/canvas-linux-x64-musl@0.1.100':
-    resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
-  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
-    resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
-    resolution: {integrity: sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@napi-rs/canvas@0.1.100':
-    resolution: {integrity: sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==}
-    engines: {node: '>= 10'}
-
   '@nodable/entities@2.1.0':
     resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
 
-  '@openclaw/fs-safe@0.3.0':
-    resolution: {integrity: sha512-uIBE441CIt1kIURoP9qRGKZ8LkGyfD9ZzeESjwAd29ZPWtghws/5GR3Pjb67jKdcJHP1I6roNXcvnhzAU7lHlA==}
-    engines: {node: '>=20.11'}
+  '@openclaw/ai@2026.7.1-2':
+    resolution: {integrity: sha512-st+NH0cxlQqdbEur//yYqM7WlYBjeEBnop3cztJTSCONKjv6LNoGguI9cH65asZG94FdM/39z857isRGPnZvEw==}
+    engines: {node: '>=22.19.0'}
+
+  '@openclaw/fs-safe@0.4.1':
+    resolution: {integrity: sha512-hQi+BxO10KdRFlYUot1syC+hTaUnGeQNdqX5kwkKJig8CFq1tKsYJLPm+zkiiGsSKOprPAquQl/txejEhpKPgg==}
+    engines: {node: '>=22'}
 
   '@openclaw/proxyline@0.3.3':
     resolution: {integrity: sha512-sftHnW69NHQqLjCxBTvQ8f/eQl+peZ5pHCBQtuTWBbeuYRHZ0/GXVTmw/O/YKsShMbqPWhJB0UYtPPdvCUSS8w==}
     engines: {node: '>=22.19.0'}
     peerDependencies:
       undici: '>=8.3.0 <9'
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -751,10 +588,6 @@ packages:
     resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
     engines: {node: '>=14.0.0'}
 
-  '@smithy/node-http-handler@4.7.3':
-    resolution: {integrity: sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/node-http-handler@4.7.4':
     resolution: {integrity: sha512-HIeF+1vrDGzPkkv39Hj2vlHSXHY3p958jd/8ZnePIY6+ZOsQX8coyEUKO5yQu4r0bQIVsbpotVIrXXwyycMStQ==}
     engines: {node: '>=18.0.0'}
@@ -774,6 +607,9 @@ packages:
   '@smithy/util-utf8@2.3.0':
     resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
     engines: {node: '>=14.0.0'}
+
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
   '@tokenizer/inflate@0.4.1':
     resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
@@ -863,9 +699,6 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
-  argparse@2.0.1:
-    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
-
   asn1.js@5.4.1:
     resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
 
@@ -949,6 +782,11 @@ packages:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
 
+  clawpdf@0.3.0:
+    resolution: {integrity: sha512-41+3AnKk9yek2sm+/9XvUlDTN8Wi+ag7fmxZuqw+ySn4lqaf/fCgLeamqPLiXY4gVbizKEHGoTG/JrIIFNE2rw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
@@ -963,9 +801,9 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  commander@14.0.3:
-    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
-    engines: {node: '>=20'}
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
 
   content-disposition@1.1.0:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
@@ -1037,8 +875,8 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
-  diff@8.0.4:
-    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
     engines: {node: '>=0.3.1'}
 
   dijkstrajs@1.0.3:
@@ -1152,6 +990,9 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
 
@@ -1259,8 +1100,8 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  grammy@1.43.0:
-    resolution: {integrity: sha512-7dYm06A945mXuIk/5HUlSjeyIYChW8vCEiU2dkOKKqJJzwAWxTkCc91Eqbz7TgODh2rtFFKWI/fekowWHOkmjQ==}
+  grammy@1.44.0:
+    resolution: {integrity: sha512-gGVykS5+c5f1tPV97LuU6IDRMawE2NzpwM9pNz58HQ35IZXDnYL3VOLvNzYognPSeBIOSzQXRu5w96V0aY8y8A==}
     engines: {node: ^12.20.0 || >=14.13.1}
 
   has-symbols@1.1.0:
@@ -1271,16 +1112,17 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
-  highlight.js@10.7.3:
-    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
 
   hono@4.12.23:
     resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
     engines: {node: '>=16.9.0'}
 
-  hosted-git-info@9.0.3:
-    resolution: {integrity: sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  hosted-git-info@10.1.1:
+    resolution: {integrity: sha512-DeOnSPAvOndYKfw075gt8yZzQ7S2hNztw34zBTfhIzLhmBTswIBg5/y+pqu/VD5cYWm5goAFTusDmUEmKZ0PEQ==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
@@ -1291,10 +1133,6 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
-
-  http-proxy-agent@7.0.2:
-    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
-    engines: {node: '>= 14'}
 
   http_ece@1.2.0:
     resolution: {integrity: sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==}
@@ -1328,10 +1166,6 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
-
-  ipaddr.js@2.4.0:
-    resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
-    engines: {node: '>= 10'}
 
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
@@ -1399,9 +1233,6 @@ packages:
       canvas:
         optional: true
 
-  linkify-it@5.0.1:
-    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
-
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -1419,21 +1250,14 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  markdown-it@14.1.1:
-    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
-    hasBin: true
-
-  marked@15.0.12:
-    resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
-    engines: {node: '>= 18'}
+  marked@18.0.5:
+    resolution: {integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==}
+    engines: {node: '>= 20'}
     hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
-
-  mdurl@2.0.0:
-    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -1529,33 +1353,29 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
-  openai@6.26.0:
-    resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
-    hasBin: true
+  openai@6.45.0:
+    resolution: {integrity: sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==}
     peerDependencies:
+      '@aws-sdk/credential-provider-node': '>=3.972.0 <4'
+      '@smithy/hash-node': '>=4.3.0 <5'
+      '@smithy/signature-v4': '>=5.4.0 <6'
       ws: ^8.18.0
       zod: ^3.25 || ^4.0
     peerDependenciesMeta:
+      '@aws-sdk/credential-provider-node':
+        optional: true
+      '@smithy/hash-node':
+        optional: true
+      '@smithy/signature-v4':
+        optional: true
       ws:
         optional: true
       zod:
         optional: true
 
-  openai@6.39.0:
-    resolution: {integrity: sha512-O61LIsimY3acVabwvomwFhwrnN36yvHY2quIfy9keEcFytGgWeV35yLHQ6NVMLSBxRpHmcg2yuhCnlu2HT4pLQ==}
-    hasBin: true
-    peerDependencies:
-      ws: ^8.18.0
-      zod: ^3.25 || ^4.0
-    peerDependenciesMeta:
-      ws:
-        optional: true
-      zod:
-        optional: true
-
-  openclaw@2026.5.26:
-    resolution: {integrity: sha512-ne6ESyXmspmWO7JlSAWFp1ACmk/um2bnEGnEkiHd4BK62XRUt82DBCCpBGcLsMKA+zNG9G938dA+zCNJCKvUFA==}
-    engines: {node: '>=22.19.0'}
+  openclaw@2026.7.1-2:
+    resolution: {integrity: sha512-ycF3yPcbjN6bUPeaUx6Mh6vze1hQWoD3CT/wWcmD7a8xaHHHRUaAlaq+lFxMHf1ssEgODVAwjlzYqp2twkYZ7g==}
+    engines: {node: '>=22.22.3 <23 || >=24.15.0 <25 || >=25.9.0'}
     hasBin: true
 
   p-limit@2.3.0:
@@ -1610,10 +1430,6 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
-  pdfjs-dist@5.7.284:
-    resolution: {integrity: sha512-h4EdYQczmGhbOlqc3PPZwxevn7ApdWPbovAuWXOB/DjIyigSnwfy2oze7c6mRcSr9XgLp3eN3EeL4DyySTPMFw==}
-    engines: {node: '>=22.13.0 || >=24'}
-
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1625,8 +1441,8 @@ packages:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
-  playwright-core@1.60.0:
-    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1652,10 +1468,6 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  punycode.js@2.3.1:
-    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
-    engines: {node: '>=6'}
-
   qrcode@1.5.4:
     resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
     engines: {node: '>=10.13.0'}
@@ -1665,16 +1477,16 @@ packages:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
-  quickjs-wasi@2.2.0:
-    resolution: {integrity: sha512-zQxXmQMrEoD3S+jQdYsloq4qAuaxKFHZj6hHqOYGwB2iQZH+q9e/lf5zQPXCKOk0WJuAjzRFbO4KwHIp2D05Iw==}
+  quickjs-wasi@3.0.2:
+    resolution: {integrity: sha512-SyfPzlrfz67/kv0SogmQgW4c2I1klkLcbvj9Y2gc1h7+VylmvuGevFljLXibGKajKJKiJV29d4S6FQLA6Sc80A==}
 
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
 
-  rastermill@0.3.0:
-    resolution: {integrity: sha512-4g2i0I7M5sba//lFBh19Wi0hDGw8o+isnt/BtEyqQXIZaYclhcNBwL/Fw/6gDCp7aaLwQHADuUvyHCB0Oat5Vw==}
-    engines: {node: '>=20'}
+  rastermill@0.3.1:
+    resolution: {integrity: sha512-CX4nij6+ZLHYIaojJNfLTr7W+AiH/IPJi6E9Aw1br2///1KZL2KBOHd68rkcLedc47MPvb4hhH+fzYeGFa4A/Q==}
+    engines: {node: '>=22'}
 
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
@@ -1816,6 +1628,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -1844,12 +1659,8 @@ packages:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
     engines: {node: '>=18'}
 
-  tar@7.5.13:
-    resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
-    engines: {node: '>=18'}
-
-  tar@7.5.15:
-    resolution: {integrity: sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==}
+  tar@7.5.19:
+    resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
     engines: {node: '>=18'}
 
   tinybench@2.9.0:
@@ -1882,11 +1693,6 @@ packages:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
 
-  tokenjuice@0.7.1:
-    resolution: {integrity: sha512-eO048hm9UcGHASjYkIWEij8QN68amGp+S1nJyo685qB1/ol+VGEYjPglcVPvCbJbZyFHvI+BBAMvOfnqYCtpsQ==}
-    engines: {node: '>=20'}
-    hasBin: true
-
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
@@ -1912,8 +1718,8 @@ packages:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
 
-  typebox@1.1.38:
-    resolution: {integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==}
+  typebox@1.3.3:
+    resolution: {integrity: sha512-URXGUE31PJDQC+PtRMJeLdF4kmmOdFoVPikPCtV2oOIhUpNpppEdIz7W8bH8cFYPYHdDpaRvqwdegMTmHliudg==}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -1924,9 +1730,6 @@ packages:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
-
-  uc.micro@2.1.0:
-    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   uhyphen@0.2.0:
     resolution: {integrity: sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==}
@@ -1941,8 +1744,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@8.3.0:
-    resolution: {integrity: sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==}
+  undici@8.5.0:
+    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
     engines: {node: '>=22.19.0'}
 
   unpipe@1.0.0:
@@ -2038,8 +1841,8 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
-  web-tree-sitter@0.26.9:
-    resolution: {integrity: sha512-YJwSHANl6XFgeEjB8nitgj0qZYt5gkIesJ4w2srS2wcLB4GUa4xcOkM0YaMsU6WNR53YVIkDSY7Ej4pf3IXtCA==}
+  web-tree-sitter@0.26.10:
+    resolution: {integrity: sha512-vengBGYS7FpAerkR3o04oBL4L8MkVmjawK50AFBu7v0HZBkmF9ZavPGKoXLSSmRhp7T/YgsJ7joAS3yAxHPEqQ==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -2129,13 +1932,14 @@ packages:
 
 snapshots:
 
-  '@agentclientprotocol/sdk@0.22.1(zod@4.4.3)':
+  '@agentclientprotocol/sdk@1.1.0(zod@4.4.3)':
     dependencies:
       zod: 4.4.3
 
-  '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
+  '@anthropic-ai/sdk@0.109.1(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
     optionalDependencies:
       zod: 4.4.3
 
@@ -2144,6 +1948,7 @@ snapshots:
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/types': 3.973.9
       tslib: 2.8.1
+    optional: true
 
   '@aws-crypto/sha256-browser@5.2.0':
     dependencies:
@@ -2154,39 +1959,26 @@ snapshots:
       '@aws-sdk/util-locate-window': 3.965.5
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
+    optional: true
 
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/types': 3.973.9
       tslib: 2.8.1
+    optional: true
 
   '@aws-crypto/supports-web-crypto@5.2.0':
     dependencies:
       tslib: 2.8.1
+    optional: true
 
   '@aws-crypto/util@5.2.0':
     dependencies:
       '@aws-sdk/types': 3.973.9
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
-
-  '@aws-sdk/client-bedrock-runtime@3.1048.0':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.13
-      '@aws-sdk/credential-provider-node': 3.972.44
-      '@aws-sdk/eventstream-handler-node': 3.972.17
-      '@aws-sdk/middleware-eventstream': 3.972.13
-      '@aws-sdk/middleware-websocket': 3.972.21
-      '@aws-sdk/token-providers': 3.1048.0
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/fetch-http-handler': 5.4.4
-      '@smithy/node-http-handler': 4.7.4
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/core@3.974.13':
     dependencies:
@@ -2198,6 +1990,7 @@ snapshots:
       '@smithy/types': 4.14.2
       bowser: 2.14.1
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/credential-provider-env@3.972.39':
     dependencies:
@@ -2206,6 +1999,7 @@ snapshots:
       '@smithy/core': 3.24.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/credential-provider-http@3.972.41':
     dependencies:
@@ -2216,6 +2010,7 @@ snapshots:
       '@smithy/node-http-handler': 4.7.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/credential-provider-ini@3.972.43':
     dependencies:
@@ -2232,6 +2027,7 @@ snapshots:
       '@smithy/credential-provider-imds': 4.3.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/credential-provider-login@3.972.43':
     dependencies:
@@ -2241,6 +2037,7 @@ snapshots:
       '@smithy/core': 3.24.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/credential-provider-node@3.972.44':
     dependencies:
@@ -2255,6 +2052,7 @@ snapshots:
       '@smithy/credential-provider-imds': 4.3.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/credential-provider-process@3.972.39':
     dependencies:
@@ -2263,6 +2061,7 @@ snapshots:
       '@smithy/core': 3.24.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/credential-provider-sso@3.972.43':
     dependencies:
@@ -2273,6 +2072,7 @@ snapshots:
       '@smithy/core': 3.24.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/credential-provider-web-identity@3.972.43':
     dependencies:
@@ -2282,30 +2082,7 @@ snapshots:
       '@smithy/core': 3.24.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
-
-  '@aws-sdk/eventstream-handler-node@3.972.17':
-    dependencies:
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-eventstream@3.972.13':
-    dependencies:
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-websocket@3.972.21':
-    dependencies:
-      '@aws-sdk/core': 3.974.13
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/fetch-http-handler': 5.4.4
-      '@smithy/signature-v4': 5.4.4
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/nested-clients@3.997.11':
     dependencies:
@@ -2319,6 +2096,7 @@ snapshots:
       '@smithy/node-http-handler': 4.7.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/signature-v4-multi-region@3.996.28':
     dependencies:
@@ -2327,15 +2105,7 @@ snapshots:
       '@smithy/signature-v4': 5.4.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
-
-  '@aws-sdk/token-providers@3.1048.0':
-    dependencies:
-      '@aws-sdk/core': 3.974.13
-      '@aws-sdk/nested-clients': 3.997.11
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/token-providers@3.1052.0':
     dependencies:
@@ -2345,15 +2115,18 @@ snapshots:
       '@smithy/core': 3.24.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/types@3.973.9':
     dependencies:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/util-locate-window@3.965.5':
     dependencies:
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/xml-builder@3.972.25':
     dependencies:
@@ -2361,92 +2134,31 @@ snapshots:
       '@smithy/types': 4.14.2
       fast-xml-parser: 5.7.3
       tslib: 2.8.1
+    optional: true
 
-  '@aws/lambda-invoke-store@0.2.4': {}
+  '@aws/lambda-invoke-store@0.2.4':
+    optional: true
 
   '@babel/runtime@7.29.7': {}
 
   '@borewit/text-codec@0.2.2': {}
 
-  '@clack/core@1.3.1':
+  '@clack/core@1.4.2':
     dependencies:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
-  '@clack/prompts@1.4.0':
+  '@clack/prompts@1.6.0':
     dependencies:
-      '@clack/core': 1.3.1
+      '@clack/core': 1.4.2
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
-  '@earendil-works/pi-agent-core@0.75.5(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
-    dependencies:
-      '@earendil-works/pi-ai': 0.75.5(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      ignore: 7.0.5
-      typebox: 1.1.38
-      yaml: 2.9.0
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@earendil-works/pi-ai@0.75.5(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
-    dependencies:
-      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
-      '@aws-sdk/client-bedrock-runtime': 3.1048.0
-      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
-      '@mistralai/mistralai': 2.2.1
-      '@smithy/node-http-handler': 4.7.3
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
-      openai: 6.26.0(ws@8.21.0)(zod@4.4.3)
-      partial-json: 0.1.7
-      typebox: 1.1.38
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@earendil-works/pi-coding-agent@0.75.5(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
-    dependencies:
-      '@earendil-works/pi-agent-core': 0.75.5(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.75.5(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.75.5
-      '@silvia-odwyer/photon-node': 0.3.4
-      chalk: 5.6.2
-      cross-spawn: 7.0.6
-      diff: 8.0.4
-      glob: 13.0.6
-      highlight.js: 10.7.3
-      hosted-git-info: 9.0.3
-      ignore: 7.0.5
-      jiti: 2.7.0
-      minimatch: 10.2.5
-      proper-lockfile: 4.1.2
-      typebox: 1.1.38
-      undici: 8.3.0
-      yaml: 2.9.0
-    optionalDependencies:
-      '@mariozechner/clipboard': 0.3.6
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@earendil-works/pi-tui@0.75.5':
+  '@earendil-works/pi-tui@0.80.3':
     dependencies:
       get-east-asian-width: 1.6.0
-      marked: 15.0.12
+      marked: 18.0.5
 
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
@@ -2526,7 +2238,7 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
+  '@google/genai@2.10.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
     dependencies:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
@@ -2539,32 +2251,19 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@google/genai@2.6.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
-    dependencies:
-      google-auth-library: 10.6.2
-      p-retry: 4.6.2
-      protobufjs: 7.6.1
-      ws: 8.21.0
-    optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@grammyjs/runner@2.0.3(grammy@1.43.0)':
+  '@grammyjs/runner@2.0.3(grammy@1.44.0)':
     dependencies:
       abort-controller: 3.0.0
-      grammy: 1.43.0
+      grammy: 1.44.0
 
-  '@grammyjs/transformer-throttler@1.2.1(grammy@1.43.0)':
+  '@grammyjs/transformer-throttler@1.2.1(grammy@1.44.0)':
     dependencies:
       bottleneck: 2.19.5
-      grammy: 1.43.0
+      grammy: 1.44.0
 
-  '@grammyjs/types@3.27.3': {}
+  '@grammyjs/types@3.28.0': {}
 
-  '@homebridge/ciao@1.3.8':
+  '@homebridge/ciao@1.3.9':
     dependencies:
       debug: 4.4.3
       fast-deep-equal: 3.1.3
@@ -2610,52 +2309,9 @@ snapshots:
       '@lydell/node-pty-win32-arm64': 1.2.0-beta.12
       '@lydell/node-pty-win32-x64': 1.2.0-beta.12
 
-  '@mariozechner/clipboard-darwin-arm64@0.3.6':
-    optional: true
-
-  '@mariozechner/clipboard-darwin-universal@0.3.6':
-    optional: true
-
-  '@mariozechner/clipboard-darwin-x64@0.3.6':
-    optional: true
-
-  '@mariozechner/clipboard-linux-arm64-gnu@0.3.6':
-    optional: true
-
-  '@mariozechner/clipboard-linux-arm64-musl@0.3.6':
-    optional: true
-
-  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.6':
-    optional: true
-
-  '@mariozechner/clipboard-linux-x64-gnu@0.3.6':
-    optional: true
-
-  '@mariozechner/clipboard-linux-x64-musl@0.3.6':
-    optional: true
-
-  '@mariozechner/clipboard-win32-arm64-msvc@0.3.6':
-    optional: true
-
-  '@mariozechner/clipboard-win32-x64-msvc@0.3.6':
-    optional: true
-
-  '@mariozechner/clipboard@0.3.6':
-    optionalDependencies:
-      '@mariozechner/clipboard-darwin-arm64': 0.3.6
-      '@mariozechner/clipboard-darwin-universal': 0.3.6
-      '@mariozechner/clipboard-darwin-x64': 0.3.6
-      '@mariozechner/clipboard-linux-arm64-gnu': 0.3.6
-      '@mariozechner/clipboard-linux-arm64-musl': 0.3.6
-      '@mariozechner/clipboard-linux-riscv64-gnu': 0.3.6
-      '@mariozechner/clipboard-linux-x64-gnu': 0.3.6
-      '@mariozechner/clipboard-linux-x64-musl': 0.3.6
-      '@mariozechner/clipboard-win32-arm64-msvc': 0.3.6
-      '@mariozechner/clipboard-win32-x64-msvc': 0.3.6
-    optional: true
-
-  '@mistralai/mistralai@2.2.1':
+  '@mistralai/mistralai@2.4.0':
     dependencies:
+      '@opentelemetry/semantic-conventions': 1.43.0
       ws: 8.21.0
       zod: 4.4.3
       zod-to-json-schema: 3.25.2(zod@4.4.3)
@@ -2687,64 +2343,39 @@ snapshots:
 
   '@mozilla/readability@0.6.0': {}
 
-  '@napi-rs/canvas-android-arm64@0.1.100':
+  '@nodable/entities@2.1.0':
     optional: true
 
-  '@napi-rs/canvas-darwin-arm64@0.1.100':
-    optional: true
+  '@openclaw/ai@2026.7.1-2(@aws-sdk/credential-provider-node@3.972.44)(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@smithy/signature-v4@5.4.4)(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.109.1(zod@4.4.3)
+      '@google/genai': 2.10.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
+      '@mistralai/mistralai': 2.4.0
+      openai: 6.45.0(@aws-sdk/credential-provider-node@3.972.44)(@smithy/signature-v4@5.4.4)(ws@8.21.0)(zod@4.4.3)
+      partial-json: 0.1.7
+      typebox: 1.3.3
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-node'
+      - '@modelcontextprotocol/sdk'
+      - '@opentelemetry/api'
+      - '@smithy/hash-node'
+      - '@smithy/signature-v4'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
 
-  '@napi-rs/canvas-darwin-x64@0.1.100':
-    optional: true
-
-  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
-    optional: true
-
-  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
-    optional: true
-
-  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
-    optional: true
-
-  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
-    optional: true
-
-  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
-    optional: true
-
-  '@napi-rs/canvas-linux-x64-musl@0.1.100':
-    optional: true
-
-  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
-    optional: true
-
-  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
-    optional: true
-
-  '@napi-rs/canvas@0.1.100':
-    optionalDependencies:
-      '@napi-rs/canvas-android-arm64': 0.1.100
-      '@napi-rs/canvas-darwin-arm64': 0.1.100
-      '@napi-rs/canvas-darwin-x64': 0.1.100
-      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.100
-      '@napi-rs/canvas-linux-arm64-gnu': 0.1.100
-      '@napi-rs/canvas-linux-arm64-musl': 0.1.100
-      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.100
-      '@napi-rs/canvas-linux-x64-gnu': 0.1.100
-      '@napi-rs/canvas-linux-x64-musl': 0.1.100
-      '@napi-rs/canvas-win32-arm64-msvc': 0.1.100
-      '@napi-rs/canvas-win32-x64-msvc': 0.1.100
-    optional: true
-
-  '@nodable/entities@2.1.0': {}
-
-  '@openclaw/fs-safe@0.3.0':
+  '@openclaw/fs-safe@0.4.1':
     optionalDependencies:
       jszip: 3.10.1
-      tar: 7.5.13
+      tar: 7.5.19
 
-  '@openclaw/proxyline@0.3.3(undici@8.3.0)':
+  '@openclaw/proxyline@0.3.3(undici@8.5.0)':
     dependencies:
-      undici: 8.3.0
+      undici: 8.5.0
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -2850,54 +2481,59 @@ snapshots:
       '@aws-crypto/crc32': 5.2.0
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@smithy/credential-provider-imds@4.3.4':
     dependencies:
       '@smithy/core': 3.24.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@smithy/fetch-http-handler@5.4.4':
     dependencies:
       '@smithy/core': 3.24.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@smithy/is-array-buffer@2.2.0':
     dependencies:
       tslib: 2.8.1
-
-  '@smithy/node-http-handler@4.7.3':
-    dependencies:
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
+    optional: true
 
   '@smithy/node-http-handler@4.7.4':
     dependencies:
       '@smithy/core': 3.24.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@smithy/signature-v4@5.4.4':
     dependencies:
       '@smithy/core': 3.24.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@smithy/types@4.14.2':
     dependencies:
       tslib: 2.8.1
+    optional: true
 
   '@smithy/util-buffer-from@2.2.0':
     dependencies:
       '@smithy/is-array-buffer': 2.2.0
       tslib: 2.8.1
+    optional: true
 
   '@smithy/util-utf8@2.3.0':
     dependencies:
       '@smithy/util-buffer-from': 2.2.0
       tslib: 2.8.1
+    optional: true
+
+  '@stablelib/base64@1.0.1': {}
 
   '@tokenizer/inflate@0.4.1':
     dependencies:
@@ -3001,8 +2637,6 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
-  argparse@2.0.1: {}
-
   asn1.js@5.4.1:
     dependencies:
       bn.js: 4.12.3
@@ -3038,7 +2672,8 @@ snapshots:
 
   bottleneck@2.19.5: {}
 
-  bowser@2.14.1: {}
+  bowser@2.14.1:
+    optional: true
 
   brace-expansion@5.0.6:
     dependencies:
@@ -3082,6 +2717,8 @@ snapshots:
 
   chownr@3.0.0: {}
 
+  clawpdf@0.3.0: {}
+
   cliui@6.0.0:
     dependencies:
       string-width: 4.2.3
@@ -3100,7 +2737,7 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  commander@14.0.3: {}
+  commander@15.0.0: {}
 
   content-disposition@1.1.0: {}
 
@@ -3151,7 +2788,7 @@ snapshots:
 
   depd@2.0.0: {}
 
-  diff@8.0.4: {}
+  diff@9.0.0: {}
 
   dijkstrajs@1.0.3: {}
 
@@ -3296,6 +2933,8 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-string-truncated-width@3.0.3: {}
 
   fast-string-width@3.0.2:
@@ -3312,6 +2951,7 @@ snapshots:
     dependencies:
       path-expression-matcher: 1.5.0
       xml-naming: 0.1.0
+    optional: true
 
   fast-xml-parser@5.7.3:
     dependencies:
@@ -3319,6 +2959,7 @@ snapshots:
       fast-xml-builder: 1.2.0
       path-expression-matcher: 1.5.0
       strnum: 2.3.0
+    optional: true
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -3428,9 +3069,9 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  grammy@1.43.0:
+  grammy@1.44.0:
     dependencies:
-      '@grammyjs/types': 3.27.3
+      '@grammyjs/types': 3.28.0
       abort-controller: 3.0.0
       debug: 4.4.3
       node-fetch: 2.7.0
@@ -3444,11 +3085,11 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  highlight.js@10.7.3: {}
+  highlight.js@11.11.1: {}
 
   hono@4.12.23: {}
 
-  hosted-git-info@9.0.3:
+  hosted-git-info@10.1.1:
     dependencies:
       lru-cache: 11.5.0
 
@@ -3468,13 +3109,6 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
-
-  http-proxy-agent@7.0.2:
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   http_ece@1.2.0: {}
 
@@ -3500,8 +3134,6 @@ snapshots:
   ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
-
-  ipaddr.js@2.4.0: {}
 
   is-fullwidth-code-point@3.0.0: {}
 
@@ -3564,10 +3196,6 @@ snapshots:
       htmlparser2: 10.1.0
       uhyphen: 0.2.0
 
-  linkify-it@5.0.1:
-    dependencies:
-      uc.micro: 2.1.0
-
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -3582,20 +3210,9 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  markdown-it@14.1.1:
-    dependencies:
-      argparse: 2.0.1
-      entities: 4.5.0
-      linkify-it: 5.0.1
-      mdurl: 2.0.0
-      punycode.js: 2.3.1
-      uc.micro: 2.1.0
-
-  marked@15.0.12: {}
+  marked@18.0.5: {}
 
   math-intrinsics@1.1.0: {}
-
-  mdurl@2.0.0: {}
 
   media-typer@1.1.0: {}
 
@@ -3669,72 +3286,79 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  openai@6.26.0(ws@8.21.0)(zod@4.4.3):
+  openai@6.45.0(@aws-sdk/credential-provider-node@3.972.44)(@smithy/signature-v4@5.4.4)(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:
+      '@aws-sdk/credential-provider-node': 3.972.44
+      '@smithy/signature-v4': 5.4.4
       ws: 8.21.0
       zod: 4.4.3
 
-  openai@6.39.0(ws@8.21.0)(zod@4.4.3):
-    optionalDependencies:
-      ws: 8.21.0
-      zod: 4.4.3
-
-  openclaw@2026.5.26:
+  openclaw@2026.7.1-2(@aws-sdk/credential-provider-node@3.972.44)(@smithy/signature-v4@5.4.4):
     dependencies:
-      '@agentclientprotocol/sdk': 0.22.1(zod@4.4.3)
-      '@clack/core': 1.3.1
-      '@clack/prompts': 1.4.0
-      '@earendil-works/pi-agent-core': 0.75.5(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.75.5(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-coding-agent': 0.75.5(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.75.5
-      '@google/genai': 2.6.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
-      '@grammyjs/runner': 2.0.3(grammy@1.43.0)
-      '@grammyjs/transformer-throttler': 1.2.1(grammy@1.43.0)
-      '@homebridge/ciao': 1.3.8
+      '@agentclientprotocol/sdk': 1.1.0(zod@4.4.3)
+      '@anthropic-ai/sdk': 0.109.1(zod@4.4.3)
+      '@clack/core': 1.4.2
+      '@clack/prompts': 1.6.0
+      '@earendil-works/pi-tui': 0.80.3
+      '@google/genai': 2.10.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
+      '@grammyjs/runner': 2.0.3(grammy@1.44.0)
+      '@grammyjs/transformer-throttler': 1.2.1(grammy@1.44.0)
+      '@homebridge/ciao': 1.3.9
       '@lydell/node-pty': 1.2.0-beta.12
+      '@mistralai/mistralai': 2.4.0
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       '@mozilla/readability': 0.6.0
-      '@openclaw/fs-safe': 0.3.0
-      '@openclaw/proxyline': 0.3.3(undici@8.3.0)
+      '@openclaw/ai': 2026.7.1-2(@aws-sdk/credential-provider-node@3.972.44)(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@smithy/signature-v4@5.4.4)(ws@8.21.0)(zod@4.4.3)
+      '@openclaw/fs-safe': 0.4.1
+      '@openclaw/proxyline': 0.3.3(undici@8.5.0)
+      '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       chokidar: 5.0.0
-      commander: 14.0.3
+      clawpdf: 0.3.0
+      commander: 15.0.0
       croner: 10.0.1
+      diff: 9.0.0
       dotenv: 17.4.2
       express: 5.2.1
       file-type: 22.0.1
-      grammy: 1.43.0
-      ipaddr.js: 2.4.0
+      glob: 13.0.6
+      grammy: 1.44.0
+      highlight.js: 11.11.1
+      hosted-git-info: 10.1.1
+      ignore: 7.0.5
       jiti: 2.7.0
       json5: 2.2.3
       jszip: 3.10.1
       kysely: 0.29.2
       linkedom: 0.18.12
-      markdown-it: 14.1.1
+      minimatch: 10.2.5
       node-edge-tts: 1.2.10
-      openai: 6.39.0(ws@8.21.0)(zod@4.4.3)
-      pdfjs-dist: 5.7.284
-      playwright-core: 1.60.0
+      openai: 6.45.0(@aws-sdk/credential-provider-node@3.972.44)(@smithy/signature-v4@5.4.4)(ws@8.21.0)(zod@4.4.3)
+      partial-json: 0.1.7
+      playwright-core: 1.61.1
+      proper-lockfile: 4.1.2
       qrcode: 1.5.4
-      quickjs-wasi: 2.2.0
-      rastermill: 0.3.0
-      tar: 7.5.15
-      tokenjuice: 0.7.1
+      quickjs-wasi: 3.0.2
+      rastermill: 0.3.1
+      tar: 7.5.19
       tree-sitter-bash: 0.25.1
       tslog: 4.10.2
-      typebox: 1.1.38
+      typebox: 1.3.3
       typescript: 6.0.3
-      undici: 8.3.0
+      undici: 8.5.0
       web-push: 3.6.7
-      web-tree-sitter: 0.26.9
+      web-tree-sitter: 0.26.10
       ws: 8.21.0
       yaml: 2.9.0
       zod: 4.4.3
     optionalDependencies:
       sqlite-vec: 0.1.9
     transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-node'
       - '@cfworker/json-schema'
+      - '@opentelemetry/api'
+      - '@smithy/hash-node'
+      - '@smithy/signature-v4'
       - bufferutil
       - canvas
       - encoding
@@ -3765,7 +3389,8 @@ snapshots:
 
   path-exists@4.0.0: {}
 
-  path-expression-matcher@1.5.0: {}
+  path-expression-matcher@1.5.0:
+    optional: true
 
   path-key@3.1.1: {}
 
@@ -3780,17 +3405,13 @@ snapshots:
 
   pathval@2.0.1: {}
 
-  pdfjs-dist@5.7.284:
-    optionalDependencies:
-      '@napi-rs/canvas': 0.1.100
-
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
 
   pkce-challenge@5.0.1: {}
 
-  playwright-core@1.60.0: {}
+  playwright-core@1.61.1: {}
 
   pngjs@5.0.0: {}
 
@@ -3828,8 +3449,6 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  punycode.js@2.3.1: {}
-
   qrcode@1.5.4:
     dependencies:
       dijkstrajs: 1.0.3
@@ -3840,11 +3459,11 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
-  quickjs-wasi@2.2.0: {}
+  quickjs-wasi@3.0.2: {}
 
   range-parser@1.2.1: {}
 
-  rastermill@0.3.0:
+  rastermill@0.3.1:
     dependencies:
       '@silvia-odwyer/photon-node': 0.3.4
 
@@ -4030,6 +3649,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
@@ -4052,22 +3676,14 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  strnum@2.3.0: {}
+  strnum@2.3.0:
+    optional: true
 
   strtok3@10.3.5:
     dependencies:
       '@tokenizer/token': 0.3.0
 
-  tar@7.5.13:
-    dependencies:
-      '@isaacs/fs-minipass': 4.0.1
-      chownr: 3.0.0
-      minipass: 7.1.3
-      minizlib: 3.1.0
-      yallist: 5.0.0
-    optional: true
-
-  tar@7.5.15:
+  tar@7.5.19:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
@@ -4098,8 +3714,6 @@ snapshots:
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
 
-  tokenjuice@0.7.1: {}
-
   tr46@0.0.3: {}
 
   tree-sitter-bash@0.25.1:
@@ -4119,13 +3733,11 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typebox@1.1.38: {}
+  typebox@1.3.3: {}
 
   typescript@5.9.3: {}
 
   typescript@6.0.3: {}
-
-  uc.micro@2.1.0: {}
 
   uhyphen@0.2.0: {}
 
@@ -4135,7 +3747,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@8.3.0: {}
+  undici@8.5.0: {}
 
   unpipe@1.0.0: {}
 
@@ -4231,7 +3843,7 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
-  web-tree-sitter@0.26.9: {}
+  web-tree-sitter@0.26.10: {}
 
   webidl-conversions@3.0.1: {}
 
@@ -4267,7 +3879,8 @@ snapshots:
 
   ws@8.21.0: {}
 
-  xml-naming@0.1.0: {}
+  xml-naming@0.1.0:
+    optional: true
 
   y18n@4.0.3: {}
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -3,7 +3,7 @@ import type {
   ChannelMessageActionName,
   OpenClawConfig,
 } from "./sdk.js";
-import { jsonResult, readNumberParam, readStringParam } from "./sdk.js";
+import { jsonResult, normalizeMessagePresentation, readNumberParam, readStringParam } from "./sdk.js";
 import {
   isZulipAccountConfigured,
   resolveZulipAccount,
@@ -37,7 +37,7 @@ import {
   updateZulipRealm,
   updateZulipStream,
 } from "./zulip/client.js";
-import { interactiveToZulipWidgetContent } from "./zulip/send.js";
+import { presentationToZulipWidgetContent } from "./zulip/send.js";
 
 const providerId = "zulip";
 const MAX_STRING_LENGTH = 10000;
@@ -552,7 +552,7 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
     // actions.add("user-reactivate" as ChannelMessageActionName);
     // actions.add("org-settings" as ChannelMessageActionName);
     // actions.add("org-settings-edit" as ChannelMessageActionName);
-    return { actions: Array.from(actions) };
+    return { actions: Array.from(actions), capabilities: ["presentation"] };
   },
   supportsAction: ({ action }) => action !== "poll",
   extractToolSend: ({ args }) => {
@@ -575,17 +575,16 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
       const to = readStringParam(params, "to", { required: true });
       const content = readSendMessageContent(params);
       const target = parseSendTarget(to);
-      const interactive =
-        params.interactive && typeof params.interactive === "object"
-          ? interactiveToZulipWidgetContent(params.interactive as any)
-          : undefined;
+      const widgetContent = presentationToZulipWidgetContent(
+        normalizeMessagePresentation(params.presentation),
+      );
 
       if (target.kind === "stream") {
         const result = await sendZulipStreamMessage(client, {
           stream: target.stream,
           topic: target.topic,
           content,
-          widgetContent: interactive,
+          widgetContent,
         });
         return jsonResult({ success: true, messageId: result.id });
       }
@@ -593,7 +592,7 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
       const result = await sendZulipPrivateMessage(client, {
         to: [target.email],
         content,
-        widgetContent: interactive,
+        widgetContent,
       });
       return jsonResult({ success: true, messageId: result.id });
     }

--- a/src/channel.test.ts
+++ b/src/channel.test.ts
@@ -1,5 +1,5 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
-import { createReplyPrefixOptions } from "openclaw/plugin-sdk/channel-runtime";
+import { createReplyPrefixOptions } from "openclaw/plugin-sdk/channel-outbound";
 import { describe, expect, it } from "vitest";
 import { zulipPlugin } from "./channel.js";
 import { resolveZulipSessionConversation } from "./session-conversation.js";

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1,6 +1,5 @@
 import {
   applyAccountNameToChannelSection,
-  buildChannelConfigSchema,
   DEFAULT_ACCOUNT_ID,
   deleteAccountFromConfigSection,
   formatPairingApproveHint,
@@ -15,11 +14,11 @@ import {
   type ReplyPayload,
 } from "./sdk.js";
 import { zulipMessageActions } from "./actions.js";
-import { ZulipConfigSchema } from "./config-schema.js";
+import { zulipChannelConfigSchema } from "./config-schema.js";
 import { resolveZulipGroupRequireMention } from "./group-mentions.js";
 import { looksLikeZulipTargetId, normalizeZulipMessagingTarget } from "./normalize.js";
 import { getZulipRuntime } from "./runtime.js";
-import type { ZulipAccountConfig, ZulipAgentReactionGuidance, ZulipConfig } from "./types.js";
+import type { ZulipAccountConfig, ZulipAgentReactionGuidance, ZulipConfig, ZulipSetupInput } from "./types.js";
 import {
   isZulipAccountConfigured,
   listZulipAccountIds,
@@ -121,7 +120,7 @@ export const zulipOutboundAdapter: ChannelOutboundAdapter = {
       accountId: ctx.accountId ?? "default",
       textLength: text.length,
       mediaCount: mediaUrls.length,
-      hasInteractive: Boolean(ctx.payload.interactive?.blocks?.length),
+      hasPresentation: Boolean(ctx.payload.presentation?.blocks?.length),
       channelDataKeys: Object.keys(ctx.payload.channelData ?? {}),
     });
     if (mediaUrls.length > 0) {
@@ -135,7 +134,7 @@ export const zulipOutboundAdapter: ChannelOutboundAdapter = {
           mediaAccess: ctx.mediaAccess,
           mediaLocalRoots: ctx.mediaLocalRoots,
           mediaReadFile: ctx.mediaReadFile,
-          interactive: i === 0 ? ctx.payload.interactive : undefined,
+          presentation: i === 0 ? ctx.payload.presentation : undefined,
           channelData: i === 0 ? (ctx.payload.channelData as ReplyPayload["channelData"] | undefined) : undefined,
         });
         results.push(result);
@@ -173,7 +172,7 @@ export const zulipOutboundAdapter: ChannelOutboundAdapter = {
       cfg: ctx.cfg,
       accountId: ctx.accountId ?? undefined,
       topic: ctx.threadId == null ? undefined : String(ctx.threadId),
-      interactive: ctx.payload.interactive,
+      presentation: ctx.payload.presentation,
       channelData: ctx.payload.channelData as ReplyPayload["channelData"] | undefined,
     });
     return { channel: "zulip", ...result };
@@ -238,13 +237,12 @@ export const zulipPlugin = {
     threads: true,
     media: true,
     polls: true,
-    interactiveReplies: true,
   },
   streaming: {
     blockStreamingCoalesceDefaults: { minChars: 1500, idleMs: 1000 },
   },
   reload: { configPrefixes: ["channels.zulip"] },
-  configSchema: buildChannelConfigSchema(ZulipConfigSchema),
+  configSchema: zulipChannelConfigSchema,
   secrets: zulipSecrets,
   config: {
     listAccountIds: (cfg) => listZulipAccountIds(cfg),
@@ -451,13 +449,13 @@ export const zulipPlugin = {
         name,
       }),
     validateInput: ({ accountId, input }) => {
-      const inputAny = input as Record<string, string | boolean | undefined>;
+      const zulipInput = input as ZulipSetupInput;
       if (input.useEnv && accountId !== DEFAULT_ACCOUNT_ID) {
         return "Zulip env vars can only be used for the default account.";
       }
-      const apiKey = (inputAny.apiKey as string | undefined) ?? input.botToken ?? input.token;
-      const email = inputAny.email as string | undefined;
-      const baseUrl = input.httpUrl;
+      const apiKey = zulipInput.apiKey ?? zulipInput.botToken ?? input.token;
+      const email = zulipInput.email;
+      const baseUrl = zulipInput.httpUrl;
       if (!input.useEnv && (!apiKey || !email || !baseUrl)) {
         return "Zulip requires --api-key, --email, and --http-url (or --use-env).";
       }
@@ -467,10 +465,10 @@ export const zulipPlugin = {
       return null;
     },
     applyAccountConfig: ({ cfg, accountId, input }) => {
-      const inputAny = input as Record<string, string | boolean | undefined>;
-      const apiKey = (inputAny.apiKey as string | undefined) ?? input.botToken ?? input.token;
-      const email = inputAny.email as string | undefined;
-      const baseUrl = input.httpUrl?.trim();
+      const zulipInput = input as ZulipSetupInput;
+      const apiKey = zulipInput.apiKey ?? zulipInput.botToken ?? input.token;
+      const email = zulipInput.email;
+      const baseUrl = zulipInput.httpUrl?.trim();
       const namedConfig = applyAccountNameToChannelSection({
         cfg,
         channelKey: "zulip",

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { buildJsonChannelConfigSchema } from "openclaw/plugin-sdk/channel-config-schema";
 import { buildOptionalSecretInputSchema } from "openclaw/plugin-sdk/secret-input";
 
 // Inlined from openclaw/plugin-sdk to avoid module resolution issues
@@ -108,7 +109,7 @@ const ZulipAccountSchema = ZulipAccountSchemaBase.superRefine((value, ctx) => {
   });
 });
 
-export const ZulipConfigSchema = ZulipAccountSchemaBase.extend({
+const ZulipConfigSchema = ZulipAccountSchemaBase.extend({
   accounts: z.record(z.string(), ZulipAccountSchema.optional()).optional(),
   defaultAccount: z.string().optional(),
 }).superRefine((value, ctx) => {
@@ -120,3 +121,22 @@ export const ZulipConfigSchema = ZulipAccountSchemaBase.extend({
     message: 'channels.zulip.dmPolicy="open" requires channels.zulip.allowFrom to include "*"',
   });
 });
+
+// Cross the SDK boundary as JSON Schema; retain this plugin's Zod refinements at runtime.
+export const zulipChannelConfigSchema: ReturnType<typeof buildJsonChannelConfigSchema> = buildJsonChannelConfigSchema(
+  ZulipConfigSchema.toJSONSchema({ target: "draft-07", unrepresentable: "any" }),
+  {
+    runtime: {
+      safeParse(value) {
+        const result = ZulipConfigSchema.safeParse(value);
+        return result.success ? result : {
+          success: false,
+          issues: result.error.issues.map((issue) => ({
+            ...issue,
+            path: issue.path.filter((part): part is string | number => typeof part !== "symbol"),
+          })),
+        };
+      },
+    },
+  },
+);

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -36,4 +36,3 @@ export { readNumberParam, readStringParam } from "openclaw/plugin-sdk/param-read
 export { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 
 export { createChannelPairingController } from "openclaw/plugin-sdk/channel-pairing";
-export type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,14 +1,13 @@
-import type { PluginRuntime as OpenClawPluginRuntime } from "openclaw/plugin-sdk/core";
-
 export type { ChannelPlugin, OpenClawConfig, OpenClawPluginApi, PluginRuntime } from "openclaw/plugin-sdk/core";
 export { emptyPluginConfigSchema } from "openclaw/plugin-sdk/core";
 export type { ChannelAccountSnapshot, ChannelMessageActionAdapter, ChannelMessageActionName } from "openclaw/plugin-sdk/channel-contract";
 export type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
-export type { InteractiveReply } from "openclaw/plugin-sdk/interactive-runtime";
+export type { MessagePresentation } from "openclaw/plugin-sdk/interactive-runtime";
+export { normalizeMessagePresentation, resolveMessagePresentationActionValue } from "openclaw/plugin-sdk/interactive-runtime";
 export type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 export type { WizardPrompter } from "openclaw/plugin-sdk/setup";
 
-export type { ChannelGroupContext } from "openclaw/plugin-sdk/channel-runtime";
+export type { ChannelGroupContext } from "openclaw/plugin-sdk/channel-contract";
 
 export type { ChannelOutboundAdapter } from "openclaw/plugin-sdk/channel-send-result";
 export { loadOutboundMediaFromUrl } from "openclaw/plugin-sdk/outbound-media";
@@ -16,17 +15,16 @@ export { loadOutboundMediaFromUrl } from "openclaw/plugin-sdk/outbound-media";
 export {
   createChannelMessageAdapterFromOutbound,
   verifyChannelMessageAdapterCapabilityProofs,
-} from "openclaw/plugin-sdk/channel-message";
-export type { ChannelMessageAdapterShape } from "openclaw/plugin-sdk/channel-message";
+} from "openclaw/plugin-sdk/channel-outbound";
+export type { ChannelMessageAdapterShape } from "openclaw/plugin-sdk/channel-outbound";
 
-export type { ChannelSetupWizardAdapter, DmPolicy, GroupPolicy } from "openclaw/plugin-sdk/setup";
+export type { ChannelSetupInput, ChannelSetupWizardAdapter, DmPolicy, GroupPolicy } from "openclaw/plugin-sdk/setup";
 
 export {
   DEFAULT_ACCOUNT_ID,
   normalizeAccountId,
   applyAccountNameToChannelSection,
   buildChannelOutboundSessionRoute,
-  buildChannelConfigSchema,
   deleteAccountFromConfigSection,
   formatPairingApproveHint,
   migrateBaseNameToDefaultAccount,
@@ -37,32 +35,5 @@ export { jsonResult } from "openclaw/plugin-sdk/core";
 export { readNumberParam, readStringParam } from "openclaw/plugin-sdk/param-readers";
 export { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 
-export function createScopedPairingAccess(params: {
-  core: OpenClawPluginRuntime;
-  channel: string;
-  accountId: string;
-}) {
-  const pairing = params.core.channel.pairing;
-  return {
-    accountId: params.accountId,
-    readAllowFromStore: () =>
-      pairing.readAllowFromStore({
-        channel: params.channel,
-        accountId: params.accountId,
-      }),
-    readStoreForDmPolicy: async () =>
-      pairing.readAllowFromStore({
-        channel: params.channel,
-        accountId: params.accountId,
-      }),
-    upsertPairingRequest: (
-      input: Omit<Parameters<typeof pairing.upsertPairingRequest>[0], "channel" | "accountId">,
-    ) =>
-      pairing.upsertPairingRequest({
-        channel: params.channel,
-        accountId: params.accountId,
-        ...input,
-      }),
-  };
-}
+export { createChannelPairingController } from "openclaw/plugin-sdk/channel-pairing";
 export type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";

--- a/src/secret-contract.test.ts
+++ b/src/secret-contract.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { ZulipConfigSchema } from "./config-schema.js";
+import { zulipChannelConfigSchema } from "./config-schema.js";
 import { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from "./secret-contract.js";
 
 describe("Zulip secret contract", () => {
@@ -18,9 +18,9 @@ describe("Zulip secret contract", () => {
   });
 
   it("schema accepts plain strings and structured SecretRefs", () => {
-    expect(ZulipConfigSchema.safeParse({ apiKey: "plain" }).success).toBe(true);
+    expect(zulipChannelConfigSchema.runtime!.safeParse({ apiKey: "plain" }).success).toBe(true);
     expect(
-      ZulipConfigSchema.safeParse({
+      zulipChannelConfigSchema.runtime!.safeParse({
         accounts: {
           default: { apiKey: { source: "env", provider: "default", id: "ZULIP_API_KEY" } },
         },
@@ -29,15 +29,25 @@ describe("Zulip secret contract", () => {
   });
 
   it("schema validates model-controlled reaction guidance levels", () => {
-    expect(ZulipConfigSchema.safeParse({ agentReactionGuidance: "minimal" }).success).toBe(true);
+    expect(zulipChannelConfigSchema.runtime!.safeParse({ agentReactionGuidance: "minimal" }).success).toBe(true);
     expect(
-      ZulipConfigSchema.safeParse({
+      zulipChannelConfigSchema.runtime!.safeParse({
         accounts: {
           work: { agentReactionGuidance: "extensive" },
         },
       }).success,
     ).toBe(true);
-    expect(ZulipConfigSchema.safeParse({ agentReactionGuidance: "ack" }).success).toBe(false);
+    expect(zulipChannelConfigSchema.runtime!.safeParse({ agentReactionGuidance: "ack" }).success).toBe(false);
+  });
+
+  it.each([
+    { value: { dmPolicy: "open" }, path: ["allowFrom"] },
+    { value: { accounts: { work: { dmPolicy: "open" } } }, path: ["accounts", "work", "allowFrom"] },
+  ])("preserves open-DM allowlist refinements through the SDK schema", ({ value, path }) => {
+    expect(zulipChannelConfigSchema.runtime!.safeParse(value)).toMatchObject({
+      success: false,
+      issues: [expect.objectContaining({ path })],
+    });
   });
 
   it("registers apiKey targets", () => {

--- a/src/secret-contract.test.ts
+++ b/src/secret-contract.test.ts
@@ -10,10 +10,10 @@ describe("Zulip secret contract", () => {
       path: ["accounts", "work", "allowFrom"],
     },
   ])("rejects open DM policy without a wildcard at $path", ({ input, path }) => {
-    const result = ZulipConfigSchema.safeParse(input);
+    const result = zulipChannelConfigSchema.runtime!.safeParse(input);
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues).toContainEqual(expect.objectContaining({ code: "custom", path }));
+      expect(result.issues).toContainEqual(expect.objectContaining({ code: "custom", path }));
     }
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,12 @@
-import type { DmPolicy, GroupPolicy } from "./sdk.js";
+import type { ChannelSetupInput, DmPolicy, GroupPolicy } from "./sdk.js";
 import type { SecretInput } from "openclaw/plugin-sdk/secret-input";
+
+export type ZulipSetupInput = ChannelSetupInput & {
+  apiKey?: string;
+  email?: string;
+  botToken?: string;
+  httpUrl?: string;
+};
 
 type BlockStreamingCoalesceConfig = {
   minChars?: number;

--- a/src/zulip/durable-receive.ts
+++ b/src/zulip/durable-receive.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { createDurableInboundReceiveJournal } from "openclaw/plugin-sdk/channel-message";
+import { createDurableInboundReceiveJournal } from "openclaw/plugin-sdk/channel-outbound";
 import type { PluginJsonValue } from "openclaw/plugin-sdk/plugin-entry";
 
 import { getZulipRuntime } from "../runtime.js";

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -360,6 +360,101 @@ describe("monitorZulipProvider", () => {
     expect(dispatcherCall?.onIdle).toBe(typingCallbacks?.onIdle);
   });
 
+  it("forwards presentation and channel data only with the first text chunk", async () => {
+    const { sendMessageZulip } = await import("./send.js");
+    const sendMessageZulipMock = vi.mocked(sendMessageZulip);
+    sendMessageZulipMock.mockClear();
+    state.core.channel.text.chunkMarkdownTextWithMode.mockReturnValue(["first chunk", "second chunk"]);
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({
+        text: "reply text",
+        presentation: { blocks: [{ type: "buttons", buttons: [{ label: "Confirm", action: "confirm" }] }] },
+        channelData: { zulip: { widgetContent: { widget_type: "zform" } } },
+      });
+    });
+    state.pollResponses = [{ result: "success", events: [{ id: 1, type: "message", message: makeChannelMessage(1009) }] }];
+
+    await runMonitorOnce();
+
+    expect(sendMessageZulipMock).toHaveBeenCalledTimes(2);
+    expect(sendMessageZulipMock).toHaveBeenNthCalledWith(1, "stream:debbie:zulip-plugin-pr", "first chunk", expect.objectContaining({
+      presentation: expect.any(Object),
+      channelData: { zulip: { widgetContent: { widget_type: "zform" } } },
+    }));
+    expect(sendMessageZulipMock).toHaveBeenNthCalledWith(2, "stream:debbie:zulip-plugin-pr", "second chunk", expect.objectContaining({
+      presentation: undefined,
+      channelData: undefined,
+    }));
+  });
+
+  it("forwards presentation and channel data only with the first media send", async () => {
+    const { sendMessageZulip } = await import("./send.js");
+    const sendMessageZulipMock = vi.mocked(sendMessageZulip);
+    sendMessageZulipMock.mockClear();
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({
+        text: "caption",
+        mediaUrls: ["https://example.com/one.png", "https://example.com/two.png"],
+        presentation: { blocks: [{ type: "buttons", buttons: [{ label: "Confirm", action: "confirm" }] }] },
+        channelData: { zulip: { widgetContent: { widget_type: "zform" } } },
+      });
+    });
+    state.pollResponses = [{ result: "success", events: [{ id: 1, type: "message", message: makeChannelMessage(1010) }] }];
+
+    await runMonitorOnce();
+
+    expect(sendMessageZulipMock).toHaveBeenCalledTimes(2);
+    expect(sendMessageZulipMock).toHaveBeenNthCalledWith(1, "stream:debbie:zulip-plugin-pr", "caption", expect.objectContaining({
+      mediaUrl: "https://example.com/one.png",
+      presentation: expect.any(Object),
+      channelData: { zulip: { widgetContent: { widget_type: "zform" } } },
+    }));
+    expect(sendMessageZulipMock).toHaveBeenNthCalledWith(2, "stream:debbie:zulip-plugin-pr", "", expect.objectContaining({
+      mediaUrl: "https://example.com/two.png",
+      presentation: undefined,
+      channelData: undefined,
+    }));
+  });
+
+  it("sends presentation-only replies instead of treating them as delivered without an outbound send", async () => {
+    const { sendMessageZulip } = await import("./send.js");
+    const sendMessageZulipMock = vi.mocked(sendMessageZulip);
+    sendMessageZulipMock.mockClear();
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({
+        presentation: { blocks: [{ type: "buttons", buttons: [{ label: "Confirm", action: "confirm" }] }] },
+      });
+    });
+    state.pollResponses = [{ result: "success", events: [{ id: 1, type: "message", message: makeChannelMessage(1011) }] }];
+
+    await runMonitorOnce();
+
+    expect(sendMessageZulipMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageZulipMock).toHaveBeenCalledWith("stream:debbie:zulip-plugin-pr", "", expect.objectContaining({
+      presentation: expect.any(Object),
+    }));
+  });
+
+  it("surfaces a send failure for channel-data-only replies", async () => {
+    const { sendMessageZulip } = await import("./send.js");
+    const sendMessageZulipMock = vi.mocked(sendMessageZulip);
+    sendMessageZulipMock.mockClear();
+    sendMessageZulipMock.mockRejectedValueOnce(new Error("Zulip message is empty"));
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await expect(dispatcherOptions.deliver({
+        channelData: { execApproval: { approvalId: "approval-1" } },
+      })).rejects.toThrow("Zulip message is empty");
+    });
+    state.pollResponses = [{ result: "success", events: [{ id: 1, type: "message", message: makeChannelMessage(1012) }] }];
+
+    await runMonitorOnce();
+
+    expect(sendMessageZulipMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageZulipMock).toHaveBeenCalledWith("stream:debbie:zulip-plugin-pr", "", expect.objectContaining({
+      channelData: { execApproval: { approvalId: "approval-1" } },
+    }));
+  });
+
   it("processes ordinary inbound messages without enqueueing a synthetic system event", async () => {
     state.pollResponses = [
       {

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -116,6 +116,7 @@ const state = vi.hoisted(() => {
     abortController: undefined as AbortController | undefined,
     durableStores: new Map<string, ReturnType<typeof createMemoryKeyedStore>>(),
     pollResponses: [] as Array<Record<string, unknown>>,
+    pairingAllowFrom: [] as string[],
     streamSubscriptions: [] as Array<Record<string, unknown>>,
     streamLookups: new Map<string, Record<string, unknown> | Error>(),
     downloadedUploads: [] as Array<{ buffer: Buffer; contentType: string; filename: string }>,
@@ -225,7 +226,7 @@ const typingCallbacksMock = vi.fn(() => ({
 vi.mock("../sdk.js", () => ({
   createChannelPairingController: vi.fn(() => ({
     upsertPairingRequest: vi.fn(async () => ({ code: "123456", created: false })),
-    readStoreForDmPolicy: vi.fn(async () => []),
+    readStoreForDmPolicy: vi.fn(async () => state.pairingAllowFrom),
   })),
 }));
 
@@ -245,29 +246,8 @@ vi.mock("openclaw/plugin-sdk/channel-feedback", () => ({
   logTypingFailure: vi.fn(),
 }));
 
-vi.mock("openclaw/plugin-sdk/reply-history", () => ({
-  buildPendingHistoryContextFromMap: vi.fn(() => undefined),
-  clearHistoryEntriesIfEnabled: vi.fn(),
-  DEFAULT_GROUP_HISTORY_LIMIT: 20,
-  recordPendingHistoryEntryIfEnabled: vi.fn(),
-}));
-
-vi.mock("openclaw/plugin-sdk/command-auth", () => ({
-  resolveControlCommandGate: vi.fn(() => ({ shouldBlock: false, commandAuthorized: true })),
-}));
-
 vi.mock("openclaw/plugin-sdk/temp-path", () => ({
   resolvePreferredOpenClawTmpDir: vi.fn(() => "/tmp"),
-}));
-
-vi.mock("openclaw/plugin-sdk/channel-policy", () => ({
-  readStoreAllowFromForDmPolicy: vi.fn(async () => []),
-  resolveDmGroupAccessWithLists: vi.fn(
-    ({ allowFrom, groupAllowFrom }: { allowFrom: string[]; groupAllowFrom: string[] }) => ({
-      effectiveAllowFrom: allowFrom,
-      effectiveGroupAllowFrom: groupAllowFrom,
-    }),
-  ),
 }));
 
 function makeChannelMessage(id: number) {
@@ -334,6 +314,7 @@ describe("monitorZulipProvider", () => {
     state.core = state.createCore();
     state.core.channel.inbound.buildContext.mockImplementation(buildChannelInboundEventContext);
     state.durableStores = new Map();
+    state.pairingAllowFrom = [];
     state.account.config = {
       dmPolicy: "open",
       groupPolicy: "open",
@@ -516,7 +497,7 @@ describe("monitorZulipProvider", () => {
 
     await runMonitorOnce();
 
-    expect(state.core.channel.inbound.buildContext).toHaveReturnedWith(
+    expect(state.core.channel.inbound.buildContext).toHaveBeenCalledWith(
       expect.objectContaining({
         media: [expect.objectContaining({
           path: expect.stringMatching(/^\/tmp\/zulip-upload-[^/]+\/evil_name\.pdf$/),
@@ -559,7 +540,12 @@ describe("monitorZulipProvider", () => {
       5 * 1024 * 1024,
     );
     expect(state.core.channel.media.saveMediaBuffer).toHaveBeenCalledTimes(3);
-    expect(state.core.channel.inbound.buildContext).toHaveReturnedWith(
+    // The stable SDK projects canonical input facts into its older dispatch context.
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0]?.[0]?.ctx).toMatchObject({
+      MediaPaths: ["/managed/song.mp3", "/managed/image.png", "/managed/report.pdf"],
+      MediaTypes: ["audio/mpeg", "image/png", "application/pdf"],
+    });
+    expect(state.core.channel.inbound.buildContext).toHaveBeenCalledWith(
       expect.objectContaining({
         media: [
           expect.objectContaining({ path: "/managed/song.mp3", contentType: "audio/mpeg" }),
@@ -756,6 +742,24 @@ describe("monitorZulipProvider", () => {
 
     expect(state.core.channel.inbound.buildContext).toHaveBeenCalledTimes(1);
     expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { paired: true, expectedDispatches: 1 },
+    { paired: false, expectedDispatches: 0 },
+  ])("preserves paired command authorization in open streams (paired=$paired)", async ({ paired, expectedDispatches }) => {
+    state.account.config.dmPolicy = "pairing";
+    state.pairingAllowFrom = paired ? ["user8@zlp.pubnerd.app"] : [];
+    state.core.channel.commands.shouldHandleTextCommands.mockReturnValue(true);
+    state.core.channel.text.hasControlCommand.mockReturnValue(true);
+    state.pollResponses = [{ result: "success", events: [{
+      id: 1, type: "message", message: { ...makeChannelMessage(paired ? 1201 : 1202), content: "/status" },
+    }] }];
+    await runMonitorOnce();
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(expectedDispatches);
+    if (paired) {
+      expect(state.core.channel.inbound.buildContext).toHaveReturnedWith(expect.objectContaining({ CommandAuthorized: true }));
+    }
   });
 
   it("records and completes durable inbound messages when plugin state is available", async () => {

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -753,7 +753,7 @@ describe("monitorZulipProvider", () => {
     state.core.channel.commands.shouldHandleTextCommands.mockReturnValue(true);
     state.core.channel.text.hasControlCommand.mockReturnValue(true);
     state.pollResponses = [{ result: "success", events: [{
-      id: 1, type: "message", message: { ...makeChannelMessage(paired ? 1201 : 1202), content: "/status" },
+      id: 1, type: "message", message: { ...makeChannelMessage(paired ? 2201 : 2202), content: "/status" },
     }] }];
     await runMonitorOnce();
     expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(expectedDispatches);

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
 
 const state = vi.hoisted(() => {
   const createMemoryKeyedStore = <T>(maxEntries = Number.MAX_SAFE_INTEGER) => {
@@ -94,16 +95,12 @@ const state = vi.hoisted(() => {
           mainSessionKey: "agent:debbie:main",
         })),
       },
+      inbound: {
+        buildContext: vi.fn(),
+      },
       reply: {
-        formatInboundEnvelope: vi.fn(({ body }: { body: string }) => body),
-        finalizeInboundContext: vi.fn((payload: Record<string, unknown>) => payload),
         resolveHumanDelayConfig: vi.fn(() => undefined),
-        createReplyDispatcherWithTyping: vi.fn(() => ({
-          dispatcher: {},
-          replyOptions: {},
-          markDispatchIdle: vi.fn(),
-        })),
-        dispatchReplyFromConfig: vi.fn(async () => {}),
+        dispatchReplyWithBufferedBlockDispatcher: vi.fn(async () => {}),
       },
       session: {
         updateLastRoute: vi.fn(async () => {}),
@@ -226,18 +223,21 @@ const typingCallbacksMock = vi.fn(() => ({
 }));
 
 vi.mock("../sdk.js", () => ({
-  createScopedPairingAccess: vi.fn(() => ({
+  createChannelPairingController: vi.fn(() => ({
     upsertPairingRequest: vi.fn(async () => ({ code: "123456", created: false })),
     readStoreForDmPolicy: vi.fn(async () => []),
   })),
 }));
 
-vi.mock("openclaw/plugin-sdk/channel-runtime", () => ({
+vi.mock("openclaw/plugin-sdk/channel-outbound", async (importOriginal) => ({
+  ...await importOriginal<typeof import("openclaw/plugin-sdk/channel-outbound")>(),
   createReplyPrefixOptions: vi.fn(() => ({ onModelSelected: vi.fn() })),
   createTypingCallbacks: typingCallbacksMock,
 }));
 
-vi.mock("openclaw/plugin-sdk/channel-inbound", () => ({
+vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => ({
+  ...await importOriginal<typeof import("openclaw/plugin-sdk/channel-inbound")>(),
+  formatInboundEnvelope: vi.fn(({ body }: { body: string }) => body),
   logInboundDrop: vi.fn(),
 }));
 
@@ -254,10 +254,6 @@ vi.mock("openclaw/plugin-sdk/reply-history", () => ({
 
 vi.mock("openclaw/plugin-sdk/command-auth", () => ({
   resolveControlCommandGate: vi.fn(() => ({ shouldBlock: false, commandAuthorized: true })),
-}));
-
-vi.mock("openclaw/plugin-sdk/media-runtime", () => ({
-  resolveChannelMediaMaxBytes: vi.fn(() => undefined),
 }));
 
 vi.mock("openclaw/plugin-sdk/temp-path", () => ({
@@ -336,6 +332,7 @@ function enableDurableInboundJournal() {
 describe("monitorZulipProvider", () => {
   beforeEach(() => {
     state.core = state.createCore();
+    state.core.channel.inbound.buildContext.mockImplementation(buildChannelInboundEventContext);
     state.durableStores = new Map();
     state.account.config = {
       dmPolicy: "open",
@@ -376,7 +373,7 @@ describe("monitorZulipProvider", () => {
 
     await runMonitorOnce();
 
-    const dispatcherCall = state.core.channel.reply.createReplyDispatcherWithTyping.mock.calls[0]?.[0];
+    const dispatcherCall = state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0]?.[0]?.dispatcherOptions;
     const typingCallbacks = typingCallbacksMock.mock.results[0]?.value;
     expect(dispatcherCall?.onReplyStart).toBe(typingCallbacks?.onReplyStart);
     expect(dispatcherCall?.onIdle).toBe(typingCallbacks?.onIdle);
@@ -392,8 +389,8 @@ describe("monitorZulipProvider", () => {
 
     await runMonitorOnce();
 
-    expect(state.core.channel.reply.finalizeInboundContext).toHaveBeenCalledTimes(1);
-    expect(state.core.channel.reply.dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+    expect(state.core.channel.inbound.buildContext).toHaveBeenCalledTimes(1);
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
     expect(state.core.system.enqueueSystemEvent).not.toHaveBeenCalled();
   });
 
@@ -417,7 +414,7 @@ describe("monitorZulipProvider", () => {
 
     await runMonitorOnce();
 
-    expect(state.core.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
+    expect(state.core.channel.inbound.buildContext).toHaveReturnedWith(
       expect.objectContaining({
         ChatType: "channel",
         ChannelPrivacy: "private",
@@ -456,7 +453,7 @@ describe("monitorZulipProvider", () => {
 
     await runMonitorOnce();
 
-    expect(state.core.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
+    expect(state.core.channel.inbound.buildContext).toHaveReturnedWith(
       expect.objectContaining({
         ChatType: "channel",
         ChannelPrivacy: "public",
@@ -493,7 +490,7 @@ describe("monitorZulipProvider", () => {
     await runMonitorOnce();
 
     expect(fetchZulipStreamMock).toHaveBeenCalledWith(state.client, "404");
-    expect(state.core.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
+    expect(state.core.channel.inbound.buildContext).toHaveReturnedWith(
       expect.objectContaining({
         ChatType: "channel",
         ChannelPrivacy: "unknown",
@@ -501,7 +498,7 @@ describe("monitorZulipProvider", () => {
         StreamId: "404",
       }),
     );
-    expect(state.core.channel.reply.dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
   });
 
   it("falls back to temp-file media storage with a sanitized filename when runtime saveMediaBuffer is unavailable", async () => {
@@ -519,10 +516,12 @@ describe("monitorZulipProvider", () => {
 
     await runMonitorOnce();
 
-    expect(state.core.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
+    expect(state.core.channel.inbound.buildContext).toHaveReturnedWith(
       expect.objectContaining({
-        MediaPath: expect.stringMatching(/^\/tmp\/zulip-upload-[^/]+\/evil_name\.pdf$/),
-        MediaType: "application/pdf",
+        media: [expect.objectContaining({
+          path: expect.stringMatching(/^\/tmp\/zulip-upload-[^/]+\/evil_name\.pdf$/),
+          contentType: "application/pdf",
+        })],
       }),
     );
   });
@@ -560,14 +559,13 @@ describe("monitorZulipProvider", () => {
       5 * 1024 * 1024,
     );
     expect(state.core.channel.media.saveMediaBuffer).toHaveBeenCalledTimes(3);
-    expect(state.core.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
+    expect(state.core.channel.inbound.buildContext).toHaveReturnedWith(
       expect.objectContaining({
-        MediaPath: "/managed/song.mp3",
-        MediaPaths: ["/managed/song.mp3", "/managed/image.png", "/managed/report.pdf"],
-        MediaUrl: "/managed/song.mp3",
-        MediaUrls: ["/managed/song.mp3", "/managed/image.png", "/managed/report.pdf"],
-        MediaType: "audio/mpeg",
-        MediaTypes: ["audio/mpeg", "image/png", "application/pdf"],
+        media: [
+          expect.objectContaining({ path: "/managed/song.mp3", contentType: "audio/mpeg" }),
+          expect.objectContaining({ path: "/managed/image.png", contentType: "image/png" }),
+          expect.objectContaining({ path: "/managed/report.pdf", contentType: "application/pdf" }),
+        ],
       }),
     );
   });
@@ -609,7 +607,7 @@ describe("monitorZulipProvider", () => {
 
     await runMonitorOnce();
 
-    expect(state.core.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
+    expect(state.core.channel.inbound.buildContext).toHaveReturnedWith(
       expect.objectContaining({
         To: "user:user8@zlp.pubnerd.app",
         OriginatingTo: "user:user8@zlp.pubnerd.app",
@@ -645,7 +643,7 @@ describe("monitorZulipProvider", () => {
 
     await runMonitorOnce();
 
-    expect(state.core.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
+    expect(state.core.channel.inbound.buildContext).toHaveReturnedWith(
       expect.objectContaining({
         To: "user:123",
         OriginatingTo: "user:123",
@@ -676,8 +674,8 @@ describe("monitorZulipProvider", () => {
 
     await runMonitorOnce();
 
-    expect(state.core.channel.reply.finalizeInboundContext).not.toHaveBeenCalled();
-    expect(state.core.channel.reply.dispatchReplyFromConfig).not.toHaveBeenCalled();
+    expect(state.core.channel.inbound.buildContext).not.toHaveBeenCalled();
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
   });
 
   it("processes stream messages inside configured topic filters with case and whitespace normalization", async () => {
@@ -695,8 +693,8 @@ describe("monitorZulipProvider", () => {
 
     await runMonitorOnce();
 
-    expect(state.core.channel.reply.finalizeInboundContext).toHaveBeenCalledTimes(1);
-    expect(state.core.channel.reply.dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+    expect(state.core.channel.inbound.buildContext).toHaveBeenCalledTimes(1);
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
   });
 
   it("drops stream messages outside a configured stream-scoped topic filter", async () => {
@@ -714,8 +712,8 @@ describe("monitorZulipProvider", () => {
 
     await runMonitorOnce();
 
-    expect(state.core.channel.reply.finalizeInboundContext).not.toHaveBeenCalled();
-    expect(state.core.channel.reply.dispatchReplyFromConfig).not.toHaveBeenCalled();
+    expect(state.core.channel.inbound.buildContext).not.toHaveBeenCalled();
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
   });
 
   it("treats empty and wildcard stream-scoped topic filters as unrestricted", async () => {
@@ -735,8 +733,8 @@ describe("monitorZulipProvider", () => {
 
     await runMonitorOnce();
 
-    expect(state.core.channel.reply.finalizeInboundContext).toHaveBeenCalledTimes(1);
-    expect(state.core.channel.reply.dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+    expect(state.core.channel.inbound.buildContext).toHaveBeenCalledTimes(1);
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
   });
 
   it("ignores duplicate inbound message ids on repeat processing", async () => {
@@ -756,8 +754,8 @@ describe("monitorZulipProvider", () => {
     ];
     await runMonitorOnce();
 
-    expect(state.core.channel.reply.finalizeInboundContext).toHaveBeenCalledTimes(1);
-    expect(state.core.channel.reply.dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+    expect(state.core.channel.inbound.buildContext).toHaveBeenCalledTimes(1);
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
   });
 
   it("records and completes durable inbound messages when plugin state is available", async () => {
@@ -783,7 +781,7 @@ describe("monitorZulipProvider", () => {
     expect(completedEntries?.[0]?.value).toMatchObject({
       metadata: { queueEventId: 2 },
     });
-    expect(state.core.channel.reply.finalizeInboundContext).toHaveBeenCalledTimes(1);
+    expect(state.core.channel.inbound.buildContext).toHaveBeenCalledTimes(1);
   });
 
   it("keeps durable journal store caps below the plugin state row limit", async () => {
@@ -825,8 +823,8 @@ describe("monitorZulipProvider", () => {
 
     await expect(journal.pending()).resolves.toEqual([]);
     expect(getZulipEventsWithRetryMock).toHaveBeenCalledTimes(1);
-    expect(state.core.channel.reply.finalizeInboundContext).toHaveBeenCalledTimes(1);
-    expect(state.core.channel.reply.dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+    expect(state.core.channel.inbound.buildContext).toHaveBeenCalledTimes(1);
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
   });
 
   it("retries same-process durable replay after a handler failure despite volatile dedupe", async () => {
@@ -864,8 +862,8 @@ describe("monitorZulipProvider", () => {
 
     await expect(journal.pending()).resolves.toEqual([]);
     expect(state.core.channel.session.updateLastRoute).toHaveBeenCalledTimes(2);
-    expect(state.core.channel.reply.dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
-    expect(state.core.channel.reply.finalizeInboundContext).toHaveBeenCalledTimes(2);
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+    expect(state.core.channel.inbound.buildContext).toHaveBeenCalledTimes(2);
   });
 
   it("re-registers the Zulip event queue after a BAD_EVENT_QUEUE_ID response and still processes the message", async () => {
@@ -884,7 +882,7 @@ describe("monitorZulipProvider", () => {
     await runMonitorOnce();
 
     expect(registerZulipQueueMock).toHaveBeenCalledTimes(2);
-    expect(state.core.channel.reply.finalizeInboundContext).toHaveBeenCalledTimes(1);
+    expect(state.core.channel.inbound.buildContext).toHaveBeenCalledTimes(1);
     expect(state.core.system.enqueueSystemEvent).not.toHaveBeenCalled();
   });
 });

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -919,33 +919,41 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       onIdle: typingCallbacks.onIdle,
       deliver: async (payload: ReplyPayload) => {
         const mediaUrls = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
+        const hasOutboundMetadata = Boolean(payload.presentation || payload.channelData);
         const rawText = core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode);
         const { text, topic: topicOverride } = extractZulipTopicDirective(rawText);
         const resolvedTopic = topicOverride ? topicOverride.slice(0, 60) : topic;
         if (mediaUrls.length === 0) {
           const chunkMode = core.channel.text.resolveChunkMode(cfg, "zulip", account.accountId);
           const chunks = core.channel.text.chunkMarkdownTextWithMode(text, textLimit, chunkMode);
+          let first = true;
           for (const chunk of chunks.length > 0 ? chunks : [text]) {
-            if (!chunk) {
+            if (!chunk && !(first && hasOutboundMetadata)) {
               continue;
             }
             await sendMessageZulip(to, chunk, {
               cfg,
               accountId: account.accountId,
               topic: resolvedTopic,
+              presentation: first ? payload.presentation : undefined,
+              channelData: first ? payload.channelData : undefined,
             });
+            first = false;
           }
         } else {
           let first = true;
           for (const mediaUrl of mediaUrls) {
-            const caption = first ? text : "";
-            first = false;
+            const isFirst = first;
+            const caption = isFirst ? text : "";
             await sendMessageZulip(to, caption, {
               cfg,
               accountId: account.accountId,
               mediaUrl,
               topic: resolvedTopic,
+              presentation: isFirst ? payload.presentation : undefined,
+              channelData: isFirst ? payload.channelData : undefined,
             });
+            first = false;
           }
         }
         opts.statusSink?.({ lastOutboundAt: Date.now() });

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -6,21 +6,13 @@ import type {
   ReplyPayload,
   RuntimeEnv,
 } from "../sdk.js";
-import {
-  createChannelPairingController,
-  type HistoryEntry,
-} from "../sdk.js";
-import { resolveControlCommandGate } from "openclaw/plugin-sdk/command-auth";
+import { createChannelPairingController } from "../sdk.js";
+import { resolveControlCommandGate } from "openclaw/plugin-sdk/command-auth-native";
 import { logTypingFailure } from "openclaw/plugin-sdk/channel-feedback";
 import { formatInboundEnvelope, logInboundDrop } from "openclaw/plugin-sdk/channel-inbound";
-import { readStoreAllowFromForDmPolicy, resolveDmGroupAccessWithLists } from "openclaw/plugin-sdk/channel-policy";
+import { mergeDmAllowFromSources, resolveGroupAllowFromSources } from "openclaw/plugin-sdk/allow-from";
+import { readChannelIngressStoreAllowFromForDmPolicy } from "openclaw/plugin-sdk/channel-ingress-runtime";
 import { createReplyPrefixOptions, createTypingCallbacks } from "openclaw/plugin-sdk/channel-outbound";
-import {
-  buildPendingHistoryContextFromMap,
-  clearHistoryEntriesIfEnabled,
-  DEFAULT_GROUP_HISTORY_LIMIT,
-  recordPendingHistoryEntryIfEnabled,
-} from "openclaw/plugin-sdk/reply-history";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { getZulipRuntime } from "../runtime.js";
 import { resolveZulipRuntimeAccount } from "./accounts.js";
@@ -417,7 +409,6 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
   const defaultTopic = account.config.defaultTopic?.trim() ?? FALLBACK_TOPIC;
   const oncharPrefixes = resolveOncharPrefixes(account.oncharPrefixes);
   const oncharEnabled = account.chatmode === "onchar";
-  const channelHistories = new Map<string, HistoryEntry[]>();
 
   const mediaMaxBytes =
     (account.config.mediaMaxMb || cfg.agents?.defaults?.mediaMaxMb || 5) * 1024 * 1024;
@@ -554,29 +545,22 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     const normalizedAllowFrom = normalizeAllowList(account.config.allowFrom ?? []);
     const normalizedGroupAllowFrom = normalizeAllowList(account.config.groupAllowFrom ?? []);
     const storeAllowFrom = normalizeAllowList(
-      await readStoreAllowFromForDmPolicy({
+      await readChannelIngressStoreAllowFromForDmPolicy({
         provider: "zulip",
         accountId: account.accountId,
         dmPolicy,
         readStore: pairing.readStoreForDmPolicy,
       }),
     );
-    const accessDecision = resolveDmGroupAccessWithLists({
-      isGroup: !isDM,
+    const effectiveAllowFrom = mergeDmAllowFromSources({
       dmPolicy,
-      groupPolicy,
+      allowFrom: normalizedAllowFrom,
+      storeAllowFrom,
+    });
+    const effectiveGroupAllowFrom = resolveGroupAllowFromSources({
       allowFrom: normalizedAllowFrom,
       groupAllowFrom: normalizedGroupAllowFrom,
-      storeAllowFrom,
-      isSenderAllowed: (allowFrom) =>
-        isSenderAllowed({
-          senderId: senderIdentity,
-          senderName,
-          allowFrom,
-        }),
     });
-    const effectiveAllowFrom = accessDecision.effectiveAllowFrom;
-    const effectiveGroupAllowFrom = accessDecision.effectiveGroupAllowFrom;
 
     const allowTextCommands = core.channel.commands.shouldHandleTextCommands({
       cfg,
@@ -769,7 +753,6 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         : undefined;
 
     const sessionKey = route.sessionKey ?? `zulip:${account.accountId}:${channelId}`;
-    const historyKey = kind === "dm" ? null : sessionKey;
 
     const timestamp = message.timestamp ? message.timestamp * 1000 : undefined;
     const textWithId = `${bodyText}\n[zulip message id: ${messageId}]`;
@@ -998,14 +981,6 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       } else {
         await addReactionSafe(reactionSuccess);
       }
-    }
-
-    if (historyKey) {
-      clearHistoryEntriesIfEnabled({
-        historyMap: channelHistories,
-        historyKey,
-        limit: DEFAULT_GROUP_HISTORY_LIMIT,
-      });
     }
 
     opts.statusSink?.({ lastInboundAt: Date.now() });

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -7,15 +7,14 @@ import type {
   RuntimeEnv,
 } from "../sdk.js";
 import {
-  createScopedPairingAccess,
+  createChannelPairingController,
   type HistoryEntry,
 } from "../sdk.js";
 import { resolveControlCommandGate } from "openclaw/plugin-sdk/command-auth";
 import { logTypingFailure } from "openclaw/plugin-sdk/channel-feedback";
-import { logInboundDrop } from "openclaw/plugin-sdk/channel-inbound";
+import { formatInboundEnvelope, logInboundDrop } from "openclaw/plugin-sdk/channel-inbound";
 import { readStoreAllowFromForDmPolicy, resolveDmGroupAccessWithLists } from "openclaw/plugin-sdk/channel-policy";
-import { createReplyPrefixOptions, createTypingCallbacks } from "openclaw/plugin-sdk/channel-runtime";
-import { resolveChannelMediaMaxBytes } from "openclaw/plugin-sdk/media-runtime";
+import { createReplyPrefixOptions, createTypingCallbacks } from "openclaw/plugin-sdk/channel-outbound";
 import {
   buildPendingHistoryContextFromMap,
   clearHistoryEntriesIfEnabled,
@@ -421,18 +420,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
   const channelHistories = new Map<string, HistoryEntry[]>();
 
   const mediaMaxBytes =
-    resolveChannelMediaMaxBytes({
-      cfg,
-      accountId: account.accountId,
-      resolveChannelLimitMb: ({ cfg, accountId }) =>
-        (
-          cfg.channels?.zulip as {
-            mediaMaxMb?: number;
-            accounts?: Record<string, { mediaMaxMb?: number }>;
-          }
-        )?.accounts?.[accountId]?.mediaMaxMb ??
-        (cfg.channels?.zulip as { mediaMaxMb?: number })?.mediaMaxMb,
-    }) ?? 5 * 1024 * 1024;
+    (account.config.mediaMaxMb || cfg.agents?.defaults?.mediaMaxMb || 5) * 1024 * 1024;
 
   const reactionConfig = account.config.reactions ?? {};
   const reactionsEnabled = reactionConfig.enabled !== false;
@@ -441,7 +429,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
   const reactionSuccess = normalizeZulipEmojiName(reactionConfig.onSuccess ?? "");
   const reactionError = normalizeZulipEmojiName(reactionConfig.onError ?? "warning");
 
-  const pairing = createScopedPairingAccess({
+  const pairing = createChannelPairingController({
     core,
     channel: "zulip",
     accountId: account.accountId,
@@ -785,7 +773,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
 
     const timestamp = message.timestamp ? message.timestamp * 1000 : undefined;
     const textWithId = `${bodyText}\n[zulip message id: ${messageId}]`;
-    const body = core.channel.reply.formatInboundEnvelope({
+    const body = formatInboundEnvelope({
       channel: "Zulip",
       from: fromLabel,
       timestamp,
@@ -796,45 +784,54 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
 
     const to =
       kind === "dm" ? `user:${dmTargetIdentity}` : `stream:${streamName || streamId}:${topic}`;
-    const ctxPayload = core.channel.reply.finalizeInboundContext({
-      Body: body,
-      RawBody: bodyText,
-      CommandBody: bodyText,
-      From: kind === "dm" ? `zulip:${senderIdentity}` : `zulip:channel:${channelId}`,
-      To: to,
-      SessionKey: sessionKey,
-      ParentSessionKey: parentSessionKey,
-      AccountId: route.accountId,
-      ChatType: chatType,
-      ChannelPrivacy: channelPrivacy,
-      IsPrivateChannel:
-        kind !== "dm" && channelPrivacy !== "unknown" ? channelPrivacy === "private" : undefined,
-      InviteOnly: streamMetadata?.inviteOnly,
-      IsWebPublic: streamMetadata?.isWebPublic,
-      HistoryPublicToSubscribers: streamMetadata?.historyPublicToSubscribers,
-      SubscriberCount: streamMetadata?.subscriberCount,
-      StreamId: kind !== "dm" ? streamId : undefined,
-      ConversationLabel: fromLabel,
-      GroupSubject: kind !== "dm" ? roomLabel : undefined,
-      GroupChannel: streamName ? `#${streamName}` : undefined,
-      SenderName: senderName,
-      SenderId: senderIdentity,
-      Provider: "zulip" as const,
-      Surface: "zulip" as const,
-      MessageSid: messageId,
-      ReplyToId: topic ? topic : undefined,
-      MessageThreadId: streamConversation?.threadId,
-      Timestamp: timestamp,
-      WasMentioned: kind !== "dm" ? effectiveWasMentioned : undefined,
-      CommandAuthorized: commandAuthorized,
-      OriginatingChannel: "zulip" as const,
-      OriginatingTo: to,
-      MediaPath: mediaPaths[0],
-      MediaPaths: mediaPaths.length > 0 ? mediaPaths : undefined,
-      MediaUrl: mediaUrls[0],
-      MediaUrls: mediaUrls.length > 0 ? mediaUrls : undefined,
-      MediaType: mediaTypes[0],
-      MediaTypes: mediaTypes.length > 0 ? mediaTypes : undefined,
+    const ctxPayload = core.channel.inbound.buildContext({
+      channel: "zulip",
+      accountId: route.accountId,
+      messageId,
+      timestamp,
+      from: kind === "dm" ? `zulip:${senderIdentity}` : `zulip:channel:${channelId}`,
+      sender: { name: senderName, id: senderIdentity },
+      conversation: {
+        kind: chatType,
+        id: isDM ? dmTargetIdentity : (streamConversation?.conversationId ?? channelId),
+        label: fromLabel,
+        threadId: streamConversation?.threadId,
+      },
+      route: {
+        agentId: route.agentId,
+        accountId: route.accountId,
+        routeSessionKey: sessionKey,
+        parentSessionKey,
+      },
+      reply: {
+        to,
+        replyToId: topic || undefined,
+        messageThreadId: streamConversation?.threadId,
+      },
+      message: { body, rawBody: bodyText, commandBody: bodyText },
+      access: {
+        commands: { authorized: commandAuthorized },
+        ...(kind !== "dm" ? {
+          mentions: { canDetectMention, wasMentioned: effectiveWasMentioned },
+        } : {}),
+      },
+      media: mediaPaths.map((mediaPath, index) => ({
+        path: mediaPath,
+        url: mediaUrls[index],
+        contentType: mediaTypes[index],
+      })),
+      extra: {
+        ChannelPrivacy: channelPrivacy,
+        IsPrivateChannel:
+          kind !== "dm" && channelPrivacy !== "unknown" ? channelPrivacy === "private" : undefined,
+        InviteOnly: streamMetadata?.inviteOnly,
+        IsWebPublic: streamMetadata?.isWebPublic,
+        HistoryPublicToSubscribers: streamMetadata?.historyPublicToSubscribers,
+        SubscriberCount: streamMetadata?.subscriberCount,
+        StreamId: kind !== "dm" ? streamId : undefined,
+        GroupSubject: kind !== "dm" ? roomLabel : undefined,
+        GroupChannel: streamName ? `#${streamName}` : undefined,
+      },
     });
 
     const sessionCfg = cfg.session;
@@ -932,58 +929,56 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       },
     });
 
-    const { dispatcher, replyOptions, markDispatchIdle } =
-      core.channel.reply.createReplyDispatcherWithTyping({
-        ...prefixOptions,
-        humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
-        onReplyStart: typingCallbacks.onReplyStart,
-        onIdle: typingCallbacks.onIdle,
-        deliver: async (payload: ReplyPayload) => {
-          const mediaUrls = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
-          const rawText = core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode);
-          const { text, topic: topicOverride } = extractZulipTopicDirective(rawText);
-          const resolvedTopic = topicOverride ? topicOverride.slice(0, 60) : topic;
-          if (mediaUrls.length === 0) {
-            const chunkMode = core.channel.text.resolveChunkMode(cfg, "zulip", account.accountId);
-            const chunks = core.channel.text.chunkMarkdownTextWithMode(text, textLimit, chunkMode);
-            for (const chunk of chunks.length > 0 ? chunks : [text]) {
-              if (!chunk) {
-                continue;
-              }
-              await sendMessageZulip(to, chunk, {
-                cfg,
-                accountId: account.accountId,
-                topic: resolvedTopic,
-              });
+    const dispatcherOptions = {
+      ...prefixOptions,
+      humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
+      onReplyStart: typingCallbacks.onReplyStart,
+      onIdle: typingCallbacks.onIdle,
+      deliver: async (payload: ReplyPayload) => {
+        const mediaUrls = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
+        const rawText = core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode);
+        const { text, topic: topicOverride } = extractZulipTopicDirective(rawText);
+        const resolvedTopic = topicOverride ? topicOverride.slice(0, 60) : topic;
+        if (mediaUrls.length === 0) {
+          const chunkMode = core.channel.text.resolveChunkMode(cfg, "zulip", account.accountId);
+          const chunks = core.channel.text.chunkMarkdownTextWithMode(text, textLimit, chunkMode);
+          for (const chunk of chunks.length > 0 ? chunks : [text]) {
+            if (!chunk) {
+              continue;
             }
-          } else {
-            let first = true;
-            for (const mediaUrl of mediaUrls) {
-              const caption = first ? text : "";
-              first = false;
-              await sendMessageZulip(to, caption, {
-                cfg,
-                accountId: account.accountId,
-                mediaUrl,
-                topic: resolvedTopic,
-              });
-            }
+            await sendMessageZulip(to, chunk, {
+              cfg,
+              accountId: account.accountId,
+              topic: resolvedTopic,
+            });
           }
-          opts.statusSink?.({ lastOutboundAt: Date.now() });
-        },
-        onError: (err: unknown) => {
-          runtime.error?.(`zulip reply failed: ${String(err)}`);
-        },
-      });
+        } else {
+          let first = true;
+          for (const mediaUrl of mediaUrls) {
+            const caption = first ? text : "";
+            first = false;
+            await sendMessageZulip(to, caption, {
+              cfg,
+              accountId: account.accountId,
+              mediaUrl,
+              topic: resolvedTopic,
+            });
+          }
+        }
+        opts.statusSink?.({ lastOutboundAt: Date.now() });
+      },
+      onError: (err: unknown) => {
+        runtime.error?.(`zulip reply failed: ${String(err)}`);
+      },
+    };
 
     let dispatchError: unknown;
     try {
-      await core.channel.reply.dispatchReplyFromConfig({
+      await core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
         ctx: ctxPayload,
         cfg,
-        dispatcher,
+        dispatcherOptions,
         replyOptions: {
-          ...replyOptions,
           disableBlockStreaming:
             typeof account.blockStreaming === "boolean" ? !account.blockStreaming : undefined,
           onModelSelected,
@@ -992,8 +987,6 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     } catch (err) {
       dispatchError = err;
       runtime.error?.(`zulip reply failed: ${String(err)}`);
-    } finally {
-      markDispatchIdle();
     }
 
     if (reactionsEnabled) {

--- a/src/zulip/send.test.ts
+++ b/src/zulip/send.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
-  interactiveToZulipWidgetContent,
+  presentationToZulipWidgetContent,
   normalizeLegacyZulipTarget,
   pollToZulipWidgetContent,
   resolveZulipWidgetContent,
@@ -8,17 +8,17 @@ import {
   sendPollZulip,
 } from "./send.js";
 
-describe("interactiveToZulipWidgetContent", () => {
+describe("presentationToZulipWidgetContent", () => {
   it("maps shared button payloads to Zulip zform widgets", () => {
     expect(
-      interactiveToZulipWidgetContent({
+      presentationToZulipWidgetContent({
         blocks: [
           { type: "text", text: "Approval Request" },
           {
             type: "buttons",
             buttons: [
-              { label: "Allow Once", value: "/approve req-1 allow-once", style: "success" },
-              { label: "Deny", value: "/approve req-1 deny", style: "danger" },
+              { label: "Allow Once", action: { type: "command", command: "/approve req-1 allow-once" }, style: "success" },
+              { label: "Deny", action: { type: "command", command: "/approve req-1 deny" }, style: "danger" },
             ],
           },
         ],
@@ -48,15 +48,15 @@ describe("interactiveToZulipWidgetContent", () => {
 
   it("skips URL-only or missing-value buttons", () => {
     expect(
-      interactiveToZulipWidgetContent({
+      presentationToZulipWidgetContent({
         blocks: [
           { type: "text", text: "Approval Request" },
           {
             type: "buttons",
             buttons: [
-              { label: "Docs", url: "https://example.test/docs" },
-              { label: "Blank", value: "   " },
-              { label: "Allow Once", value: "/approve req-1 allow-once" },
+              { label: "Docs", action: { type: "url", url: "https://example.test/docs" } },
+              { label: "Blank", action: { type: "callback", value: "   " } },
+              { label: "Allow Once", action: { type: "command", command: "/approve req-1 allow-once" } },
             ],
           },
         ],
@@ -78,8 +78,20 @@ describe("interactiveToZulipWidgetContent", () => {
     });
   });
 
+  it("preserves callback values and the presentation heading", () => {
+    expect(presentationToZulipWidgetContent({
+      title: "Pick a topic",
+      blocks: [{ type: "buttons", buttons: [
+        { label: "Support", action: { type: "callback", value: "topic:support" } },
+      ] }],
+    })).toMatchObject({ extra_data: {
+      heading: "Pick a topic",
+      choices: [{ reply: "topic:support" }],
+    } });
+  });
+
   it("returns undefined when there are no buttons", () => {
-    expect(interactiveToZulipWidgetContent({ blocks: [{ type: "text", text: "hi" }] })).toBeUndefined();
+    expect(presentationToZulipWidgetContent({ blocks: [{ type: "text", text: "hi" }] })).toBeUndefined();
   });
 });
 
@@ -151,7 +163,7 @@ const sendState = vi.hoisted(() => {
       },
       channel: {
         media: {
-          fetchRemoteMedia: vi.fn(),
+          readRemoteMediaBuffer: vi.fn(),
           saveMediaBuffer: vi.fn(),
         },
         text: {
@@ -188,8 +200,39 @@ vi.mock("./client.js", () => ({
   normalizeZulipBaseUrl: vi.fn((url?: string) => url ?? ""),
   sendZulipPrivateMessage: sendState.sendZulipPrivateMessage,
   sendZulipStreamMessage: sendState.sendZulipStreamMessage,
-  uploadZulipFile: vi.fn(),
+  uploadZulipFile: vi.fn(async () => ({ url: "/user_uploads/test/report.pdf" })),
 }));
+
+describe("sendMessageZulip media and presentation", () => {
+  it("uploads remote media through the bounded runtime buffer reader", async () => {
+    sendState.runtime.channel.media.readRemoteMediaBuffer.mockResolvedValueOnce({
+      buffer: Buffer.from("report"), contentType: "application/pdf",
+    });
+    sendState.runtime.channel.media.saveMediaBuffer.mockResolvedValueOnce({ path: "/managed/report.pdf" });
+    await sendMessageZulip("stream:general:reports", "Report", {
+      cfg: { agents: { defaults: { mediaMaxMb: 2 } } },
+      mediaUrl: "https://files.example.test/report.pdf",
+    });
+    expect(sendState.runtime.channel.media.readRemoteMediaBuffer).toHaveBeenCalledWith({
+      url: "https://files.example.test/report.pdf", maxBytes: 2 * 1024 * 1024,
+    });
+    expect(sendState.sendZulipStreamMessage).toHaveBeenLastCalledWith(expect.anything(),
+      expect.objectContaining({ content: "Report\n/user_uploads/test/report.pdf" }));
+  });
+
+  it("sends canonical command presentation controls to Zulip", async () => {
+    await sendMessageZulip("user:alice@example.test", "Approval", {
+      cfg: {},
+      presentation: { blocks: [{ type: "buttons", buttons: [
+        { label: "Deny", action: { type: "command", command: "/approve req-1 deny" } },
+      ] }] },
+    });
+    expect(sendState.sendZulipPrivateMessage).toHaveBeenLastCalledWith(expect.anything(),
+      expect.objectContaining({ widgetContent: expect.objectContaining({ extra_data: expect.objectContaining({
+        choices: [{ type: "multiple_choice", short_name: "Deny", long_name: "Deny", reply: "/approve req-1 deny" }],
+      }) }) }));
+  });
+});
 
 describe("sendMessageZulip target parsing hardening", () => {
   it("rejects malformed dm-like targets instead of silently auto-correcting", async () => {
@@ -250,15 +293,15 @@ describe("sendPollZulip", () => {
 });
 
 describe("resolveZulipWidgetContent", () => {
-  it("prefers shared interactive payloads when present", () => {
+  it("prefers shared presentation payloads when present", () => {
     expect(
       resolveZulipWidgetContent({
-        interactive: {
+        presentation: {
           blocks: [
             { type: "text", text: "Approval Request" },
             {
               type: "buttons",
-              buttons: [{ label: "Allow Once", value: "/approve req-1 allow-once" }],
+              buttons: [{ label: "Allow Once", action: { type: "command", command: "/approve req-1 allow-once" } }],
             },
           ],
         },
@@ -288,7 +331,7 @@ describe("resolveZulipWidgetContent", () => {
     });
   });
 
-  it("falls back to channelData.zulip.widgetContent when interactive is absent", () => {
+  it("falls back to channelData.zulip.widgetContent when presentation is absent", () => {
     expect(
       resolveZulipWidgetContent({
         channelData: {

--- a/src/zulip/send.ts
+++ b/src/zulip/send.ts
@@ -4,9 +4,10 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   loadOutboundMediaFromUrl,
+  resolveMessagePresentationActionValue,
   resolvePreferredOpenClawTmpDir,
 } from "../sdk.js";
-import type { InteractiveReply, OpenClawConfig } from "../sdk.js";
+import type { MessagePresentation, OpenClawConfig } from "../sdk.js";
 import { getZulipRuntime } from "../runtime.js";
 import { resolveZulipRuntimeAccount } from "./accounts.js";
 import {
@@ -17,7 +18,6 @@ import {
   uploadZulipFile,
 } from "./client.js";
 
-type InteractivePayload = InteractiveReply;
 type ZulipChannelData = {
   zulip?: {
     widgetContent?: unknown;
@@ -71,7 +71,7 @@ export type ZulipSendOpts = {
   mediaLocalRoots?: readonly string[];
   mediaReadFile?: (filePath: string) => Promise<Buffer>;
   topic?: string;
-  interactive?: InteractivePayload;
+  presentation?: MessagePresentation;
   channelData?: ZulipChannelData;
 };
 
@@ -88,17 +88,17 @@ const DEFAULT_TOPIC = "general";
 
 const getCore = () => getZulipRuntime();
 
-function interactiveToZulipWidgetContent(
-  interactive?: InteractivePayload,
+function presentationToZulipWidgetContent(
+  presentation?: MessagePresentation,
 ): ZulipWidgetContent | undefined {
   const choices: ZulipWidgetChoice[] = [];
-  for (const block of interactive?.blocks ?? []) {
+  for (const block of presentation?.blocks ?? []) {
     if (block.type !== "buttons") {
       continue;
     }
     for (const button of block.buttons ?? []) {
       const label = button.label?.trim();
-      const reply = button.value?.trim();
+      const reply = resolveMessagePresentationActionValue(button.action)?.trim();
       if (!label || !reply) {
         continue;
       }
@@ -114,7 +114,8 @@ function interactiveToZulipWidgetContent(
     return undefined;
   }
   const heading =
-    interactive?.blocks?.find((block) => block.type === "text")?.text?.trim() || "Choose an action";
+    presentation?.title?.trim() ||
+    presentation?.blocks.find((block) => block.type === "text")?.text?.trim() || "Choose an action";
   return {
     widget_type: "zform",
     extra_data: {
@@ -125,7 +126,7 @@ function interactiveToZulipWidgetContent(
   };
 }
 
-export { interactiveToZulipWidgetContent };
+export { presentationToZulipWidgetContent };
 
 export function pollToZulipWidgetContent(poll: PollInput): ZulipWidgetContent {
   const heading = poll.question.trim();
@@ -154,12 +155,12 @@ export function pollToZulipWidgetContent(poll: PollInput): ZulipWidgetContent {
 }
 
 export function resolveZulipWidgetContent(params: {
-  interactive?: InteractivePayload;
+  presentation?: MessagePresentation;
   channelData?: ZulipChannelData;
 }): unknown {
-  const interactiveWidget = interactiveToZulipWidgetContent(params.interactive);
-  if (interactiveWidget) {
-    return interactiveWidget;
+  const presentationWidget = presentationToZulipWidgetContent(params.presentation);
+  if (presentationWidget) {
+    return presentationWidget;
   }
   const explicitWidget = params.channelData?.zulip?.widgetContent;
   if (explicitWidget && typeof explicitWidget === "object" && !Array.isArray(explicitWidget)) {
@@ -379,7 +380,7 @@ export async function sendMessageZulip(
       mediaUrl = upload.url;
     } else if (isHttpUrl(mediaUrl) && !isZulipHosted) {
       const maxBytes = (opts.cfg.agents?.defaults?.mediaMaxMb ?? 5) * 1024 * 1024;
-      const fetched = await core.channel.media.fetchRemoteMedia({
+      const fetched = await core.channel.media.readRemoteMediaBuffer({
         url: mediaUrl,
         maxBytes,
       });
@@ -437,9 +438,9 @@ export async function sendMessageZulip(
     };
   })();
 
-  const interactiveWidget = interactiveToZulipWidgetContent(opts.interactive);
-  const widgetContent = interactiveWidget ?? resolveZulipWidgetContent({
-    interactive: undefined,
+  const presentationWidget = presentationToZulipWidgetContent(opts.presentation);
+  const widgetContent = presentationWidget ?? resolveZulipWidgetContent({
+    presentation: undefined,
     channelData: opts.channelData,
   });
 
@@ -447,8 +448,8 @@ export async function sendMessageZulip(
     throw new Error("Zulip message is empty");
   }
 
-  const widgetContentSource = interactiveWidget
-    ? "interactive"
+  const widgetContentSource = presentationWidget
+    ? "presentation"
     : opts.channelData?.zulip?.widgetContent
       ? "channelData"
       : "none";
@@ -456,7 +457,7 @@ export async function sendMessageZulip(
     ...preflightTargetSummary,
     accountId: account.accountId,
     hasMedia: Boolean(rawMediaUrl),
-    hasInteractive: Boolean(opts.interactive?.blocks?.length),
+    hasPresentation: Boolean(opts.presentation?.blocks?.length),
     channelDataKeys: Object.keys(opts.channelData ?? {}),
     hasExecApprovalChannelData: Boolean(opts.channelData?.execApproval),
     hasExplicitWidgetContent: Boolean(opts.channelData?.zulip?.widgetContent),
@@ -514,7 +515,7 @@ export async function sendMessageZulip(
 export async function sendPollZulip(
   to: string,
   poll: PollInput,
-  opts: Omit<ZulipSendOpts, "interactive" | "channelData">,
+  opts: Omit<ZulipSendOpts, "presentation" | "channelData">,
 ): Promise<ZulipSendResult> {
   return await sendMessageZulip(to, poll.question, {
     ...opts,


### PR DESCRIPTION
This migrates the Zulip plugin to the focused APIs available in published OpenClaw 2026.7.1-2. The old broad channel imports and low-level reply dispatcher make the plugin depend on compatibility surfaces scheduled for removal.

Message adapters and the existing durable receive journal now import from `channel-outbound`; channel contract types use `channel-contract`. Inbound messages use `runtime.channel.inbound.buildContext` with ordered media facts, and buffered reply dispatch owns dispatcher settlement and typing cleanup. Remote media reads use `readRemoteMediaBuffer`. Zulip widgets and the message action adapter consume `MessagePresentation` with typed command/callback actions, and setup owns its Zulip-specific input fields. The duplicated pairing wrapper is replaced by the SDK controller. Command authorization uses `command-auth-native` and the public ingress-store/list helpers, preserving paired users' authorization in open streams. An unwritten history map and its deprecated helpers are removed.

The schema crosses the SDK boundary as JSON Schema while retaining the plugin's Zod runtime validation, including the root and per-account open-DM allowlist refinement. This avoids incompatible bundled Zod declaration types in the published host SDK without casting away validation. The development dependency and regenerated pnpm lockfile pin OpenClaw 2026.7.1-2; the minimum host hint is raised to match.

This is a stable-SDK migration, not a claim of 2026.8 beta compatibility. The remaining boundaries are explicit:

- `createDurableInboundReceiveJournal` stays on the stable `channel-outbound` export and retains the existing keyed stores. The beta removes it and restricts `openChannelIngressQueue` and keyed state to bundled/trusted official plugins. A supported external queue API and an agreed migration for pending records are required. Namespaces, TTLs, pending records and deduplication tombstones are unchanged here.
- `channel.setup`, `runtime.channel.session.resolveStorePath`, and `runtime.channel.reply.resolveHumanDelayConfig` preserve the stable setup/session/delay behavior. The beta `defineChannelSetupContract` and higher-level inbound dispatch replacements are not available in the pinned stable SDK.
- `outbound-media.loadOutboundMediaFromUrl` remains a supported stable export but is private in the current SDK catalog. Its replacement must preserve host-provided file access roots and authorization capabilities; this PR does not bypass or copy that private policy.

Validation passed at commit `b4782c8c263a2d94e718193583013cfb5941b41a` on a fresh isolated AWS machine with no instance role, no Tailscale, no credential hydration, and a temporary home directory. Node 24.19.0 and pnpm 9.15.9 ran `pnpm install --frozen-lockfile --ignore-scripts`, `pnpm build`, and `pnpm test`: all 12 test files and 130 tests passed. Importing `dist/index.js` also succeeded and returned the Zulip plugin entry. Earlier runs exposed two fixture assumptions: the stable context builder still projects legacy output media fields, and a new command test reused a message ID already consumed by the module's deduplication cache. Assertions now check both canonical input and actual stable output; command fixtures use unique IDs.

Static TypeScript checking against the actual npm declarations and `git diff --check` pass. Independent Codex autoreviews reported no blocking findings. Tests exercise the real stable SDK inbound builder and command/list policy, presentation commands/callbacks, bounded remote media reads, schema refinements, durable replay and deduplication. Production TypeScript is reduced by 37 lines net; tests add 55 lines net. No live Zulip account was available; mocked transport tests do not establish live service compatibility. No package was published. This remains a draft until the unsupported beta API and durable-state migration boundaries above are resolved.
