### PR TITLE
ci: add release and OpenClaw compatibility checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Verify (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node:
+          - 22.19.0
+          - 24
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.23.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
+      - run: pnpm test
+      - name: Check committed changes for whitespace errors
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          if [[ "$BASE_SHA" =~ ^0+$ ]]; then
+            git diff-tree --check --no-commit-id --root -r "$HEAD_SHA"
+          else
+            git diff --check "$BASE_SHA...$HEAD_SHA"
+          fi
+      - name: Install and import the packed artifact
+        run: |
+          pack_file=$(npm pack --ignore-scripts --pack-destination "$RUNNER_TEMP" --silent)
+          openclaw_version=$(node -p "require('./node_modules/openclaw/package.json').version")
+          smoke_dir="$RUNNER_TEMP/package-smoke"
+          mkdir -p "$smoke_dir"
+          pnpm --dir "$smoke_dir" init
+          pnpm --dir "$smoke_dir" add "$RUNNER_TEMP/$pack_file" "openclaw@$openclaw_version" --config.minimumReleaseAge=1440
+          cd "$smoke_dir"
+          node --input-type=module --eval "await import('openclaw-channel-zulip')"

--- a/.github/workflows/openclaw-compatibility.yml
+++ b/.github/workflows/openclaw-compatibility.yml
@@ -1,0 +1,74 @@
+name: OpenClaw compatibility (advisory)
+
+on:
+  schedule:
+    - cron: '27 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: openclaw-compatibility-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compatibility:
+    name: Latest eligible OpenClaw (Node 24)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.23.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Select newest OpenClaw release at least 24 hours old
+        id: openclaw
+        run: |
+          node --input-type=module <<'NODE'
+          const response = await fetch("https://registry.npmjs.org/openclaw");
+          if (!response.ok) throw new Error(`npm registry returned ${response.status}`);
+
+          const registry = await response.json();
+          const cutoff = Date.now() - 24 * 60 * 60 * 1000;
+          const stableChannels = ["latest", "extended-stable"];
+          const version = stableChannels
+            .map((tag) => registry["dist-tags"]?.[tag])
+            .find((candidate) =>
+              typeof candidate === "string" && Date.parse(registry.time?.[candidate]) <= cutoff,
+            );
+          if (!version) throw new Error("No OpenClaw release is at least 24 hours old");
+          const { appendFile } = await import("node:fs/promises");
+          await appendFile(process.env.GITHUB_OUTPUT, `version=${version}\n`);
+          NODE
+      - name: Install against selected OpenClaw in a disposable lockfile
+        env:
+          OPENCLAW_VERSION: ${{ steps.openclaw.outputs.version }}
+        run: |
+          compat_dir="$RUNNER_TEMP/openclaw-compatibility"
+          mkdir -p "$compat_dir"
+          rsync -a --delete --exclude .git --exclude node_modules --exclude dist ./ "$compat_dir/"
+          COMPAT_DIR="$compat_dir" node --input-type=module <<'NODE'
+          import { readFile, writeFile } from "node:fs/promises";
+
+          const packagePath = `${process.env.COMPAT_DIR}/package.json`;
+          const packageJson = JSON.parse(await readFile(packagePath, "utf8"));
+          packageJson.devDependencies.openclaw = process.env.OPENCLAW_VERSION;
+          await writeFile(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`);
+          NODE
+          cd "$compat_dir"
+          pnpm install --no-frozen-lockfile --config.minimumReleaseAge=1440
+          pnpm run build
+          pnpm test
+          pack_file=$(npm pack --ignore-scripts --pack-destination "$RUNNER_TEMP" --silent)
+          smoke_dir="$RUNNER_TEMP/openclaw-package-smoke"
+          mkdir -p "$smoke_dir"
+          pnpm --dir "$smoke_dir" init
+          pnpm --dir "$smoke_dir" add "$RUNNER_TEMP/$pack_file" "openclaw@$OPENCLAW_VERSION" --config.minimumReleaseAge=1440
+          cd "$smoke_dir"
+          node --input-type=module --eval "await import('openclaw-channel-zulip')"

--- a/README.md
+++ b/README.md
@@ -216,6 +216,14 @@ openclaw gateway restart
 
 ---
 
+## Continuous integration
+
+Pull requests and pushes to `main` run the release-blocking **CI** workflow on Node 22.19 and Node 24. Each run installs from `pnpm-lock.yaml` with `--frozen-lockfile`, builds, runs the full test suite, checks whitespace errors with `git diff --check`, packs the release artifact, installs it with the locked OpenClaw host in a clean temporary project, and imports its public package entry point. The workflow has read-only repository permissions and does not receive repository or Zulip secrets.
+
+The scheduled **OpenClaw compatibility (advisory)** workflow is intentionally separate from release gating. Once a week it chooses the first eligible release from OpenClaw's `latest` and `extended-stable` npm channels that has been published for at least 24 hours, then installs and tests it in a temporary copy of the plugin. That temporary install and the packed-artifact smoke test enforce pnpm's 24-hour release-age rule and may update only disposable lockfiles; they never change or commit this repository's lockfile. A failure identifies compatibility work to investigate; it does not replace the locked CI evidence required for a release.
+
+---
+
 ## Plugin ID
 
 The plugin id is `zulip` (defined in `openclaw.plugin.json`). Use this id in `plugins.allow` and with `openclaw plugins` commands.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "type": "module",
   "author": "FtlC-ian",
   "license": "MIT",
+  "engines": {
+    "node": "^22.19.0 || ^24.0.0"
+  },
   "keywords": [
     "openclaw",
     "openclaw-plugin",


### PR DESCRIPTION
Closes #23.

## What changed

- Add release-blocking CI on Node 22.19 and Node 24.
- Run frozen install, build/typecheck, all tests, and diff checks.
- Pack the real release artifact, install it with the locked OpenClaw host in a clean temporary project, and import its public entry point.
- Add a weekly/manual advisory workflow against the first eligible release from OpenClaw's `latest` and `extended-stable` npm channels.
- Enforce a 24-hour minimum package age and keep compatibility lockfile changes disposable.
- Document release-blocking versus advisory checks and declare the supported Node range.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm test` (123 passing)
- `git diff --check`
- Ruby YAML parse for both workflows
- Live stable-channel selector canary
- Actual tarball install and package import in a clean temporary project

The advisory compatibility canary currently exposes a real OpenClaw/Zod compatibility break on newer OpenClaw, which is intentionally reported without blocking the locked release CI.

## Review

Reviewed independently across model families. The second review found and drove fixes for packed-artifact validation, the Node 22 lower bound, and release-channel-aware OpenClaw selection. The amended diff was re-reviewed clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI workflows, documentation, and Node engine metadata; no plugin runtime or security-sensitive application code is modified.
> 
> **Overview**
> Adds **release-blocking GitHub Actions CI** for pull requests and pushes to `main`, running on Node **22.19.0** and **24** with frozen `pnpm` install, build, full tests, `git diff --check` whitespace validation, and a **packed-artifact smoke test** that installs the tarball with the lockfile’s OpenClaw host and imports `openclaw-channel-zulip`.
> 
> Adds a separate **advisory** workflow (weekly schedule + manual dispatch) that picks the first eligible OpenClaw release from npm’s `latest` / `extended-stable` tags that is at least 24 hours old, then build/tests/pack-smokes against that version in a **temporary copy** with disposable lockfiles—without gating releases or changing this repo’s lockfile.
> 
> **README** documents release-blocking vs advisory checks; **`package.json`** declares supported Node via `engines`: `^22.19.0 || ^24.0.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 466fc3e0fe54b1d64a72e281aa231070df9eec21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->