### PR TITLE
feat(actions): require destructive confirmation

### DIFF
--- a/src/actions.test.ts
+++ b/src/actions.test.ts
@@ -1,6 +1,10 @@
 import type { OpenClawConfig } from "./sdk.js";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
 import { splitStreamTarget, zulipMessageActions } from "./actions.js";
+
+type CoreAction = Parameters<NonNullable<typeof zulipMessageActions.handleAction>>[0]["action"];
+type AnyAction = CoreAction | "user-deactivate" | "org-settings-edit";
+type FetchMock = Mock<typeof fetch>;
 
 function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -20,7 +24,7 @@ const cfg: OpenClawConfig = {
 
 async function runReactAction(
   params: Record<string, unknown>,
-  options?: { dryRun?: boolean; fetchImpl?: typeof fetch },
+  options?: { dryRun?: boolean; fetchImpl?: FetchMock },
 ) {
   const fetchImpl =
     options?.fetchImpl ??
@@ -38,6 +42,232 @@ async function runReactAction(
 
 afterEach(() => {
   vi.unstubAllGlobals();
+});
+
+async function runAction(
+  action: AnyAction,
+  params: Record<string, unknown>,
+  options?: { dryRun?: boolean; fetchImpl?: FetchMock },
+) {
+  const fetchImpl =
+    options?.fetchImpl ??
+    vi.fn<typeof fetch>().mockResolvedValue(jsonResponse({ result: "success", msg: "" }));
+  vi.stubGlobal("fetch", fetchImpl);
+  const result = await zulipMessageActions.handleAction?.({
+    channel: "zulip",
+    action: action as CoreAction,
+    cfg,
+    params,
+    dryRun: options?.dryRun,
+  });
+  return { result: result as { details?: unknown } | undefined, fetchImpl };
+}
+
+async function expectRejectedWithoutFetch(
+  action: AnyAction,
+  params: Record<string, unknown>,
+): Promise<void> {
+  const fetchImpl = vi.fn<typeof fetch>();
+  await expect(runAction(action, params, { fetchImpl })).rejects.toThrow("confirm: true");
+  expect(fetchImpl).not.toHaveBeenCalled();
+}
+
+describe("destructive action confirmation", () => {
+  it("rejects delete without confirm", async () => {
+    await expectRejectedWithoutFetch("delete", { messageId: "123" });
+  });
+
+  it("rejects channel-delete without confirm", async () => {
+    await expectRejectedWithoutFetch("channel-delete", { streamId: "general" });
+  });
+
+  it("rejects user-deactivate without confirm", async () => {
+    await expectRejectedWithoutFetch("user-deactivate", { userId: "42" });
+  });
+
+  it("rejects org-settings-edit without confirm", async () => {
+    await expectRejectedWithoutFetch("org-settings-edit", { settings: { name: "X" } });
+  });
+
+  it("rejects delete when confirm is false", async () => {
+    await expectRejectedWithoutFetch("delete", { messageId: "123", confirm: false });
+  });
+
+  it("rejects delete when confirm is a string", async () => {
+    await expectRejectedWithoutFetch("delete", { messageId: "123", confirm: "yes" });
+  });
+
+  it("scopes the confirmation schema to advertised destructive actions", () => {
+    expect(zulipMessageActions.describeMessageTool({ cfg })).toMatchObject({
+      schema: {
+        actions: ["channel-delete", "delete"],
+        properties: { confirm: { type: "boolean" } },
+      },
+    });
+  });
+
+  it.each([
+    ["delete", { messageId: "123", confirm: true }],
+    ["channel-delete", { streamId: "general", confirm: true }],
+  ] as const)("does not send Zulip requests for %s dry runs", async (action, params) => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    const { result } = await runAction(action, params, { dryRun: true, fetchImpl });
+    expect(result?.details).toMatchObject({ ok: true, dryRun: true, action });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["user-deactivate", { userId: "42", confirm: true }],
+    ["org-settings-edit", { settings: { name: "X" }, confirm: true }],
+  ] as const)("does not send Zulip requests for hidden %s dry runs", async (action, params) => {
+    const adminCfg: OpenClawConfig = {
+      channels: {
+        zulip: {
+          apiKey: "secret",
+          email: "bot@example.test",
+          url: "https://zulip.example.test",
+          enableAdminActions: true,
+        },
+      },
+    };
+    const fetchImpl = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", fetchImpl);
+    const result = await zulipMessageActions.handleAction?.({
+      channel: "zulip",
+      action: action as CoreAction,
+      cfg: adminCfg,
+      params,
+      dryRun: true,
+    });
+    expect(result?.details).toMatchObject({ ok: true, dryRun: true, action });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("succeeds delete when confirm is true and all other gates pass", async () => {
+    const { result, fetchImpl } = await runAction("delete", {
+      messageId: "123",
+      confirm: true,
+    });
+    expect(result?.details).toMatchObject({ ok: true, deleted: "123" });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0] ?? [];
+    expect(String(url)).toContain("/messages/123");
+    expect(init?.method).toBe("DELETE");
+  });
+
+  it("succeeds channel-delete when confirm is true and all other gates pass", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockImplementation(async (input: Parameters<typeof fetch>[0]) => {
+        const url = String(input);
+        if (url.includes("/streams")) {
+          return jsonResponse({
+            result: "success",
+            streams: [{ stream_id: 7, name: "general" }],
+          });
+        }
+        return jsonResponse({ result: "success" });
+      });
+    const { result } = await runAction(
+      "channel-delete",
+      { streamId: "general", confirm: true },
+      { fetchImpl },
+    );
+    expect(result?.details).toMatchObject({ ok: true, streamId: "7" });
+  });
+
+  it("cannot bypass admin check via confirmation on user-deactivate", async () => {
+    const adminCfg: OpenClawConfig = {
+      channels: {
+        zulip: {
+          apiKey: "secret",
+          email: "bot@example.test",
+          url: "https://zulip.example.test",
+          enableAdminActions: true,
+        },
+      },
+    };
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({
+        result: "success",
+        user: { user_id: 1, is_admin: false },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchImpl);
+    await expect(
+      zulipMessageActions.handleAction?.({
+        channel: "zulip",
+        action: "user-deactivate" as CoreAction,
+        cfg: adminCfg,
+        params: { userId: "42", confirm: true },
+      }),
+    ).rejects.toThrow("admin privileges");
+  });
+
+  it("cannot bypass enableAdminActions via confirmation on org-settings-edit", async () => {
+    const lockedCfg: OpenClawConfig = {
+      channels: {
+        zulip: {
+          apiKey: "secret",
+          email: "bot@example.test",
+          url: "https://zulip.example.test",
+          enableAdminActions: false,
+        },
+      },
+    };
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({ result: "success", user: { user_id: 1, is_admin: true } }),
+    );
+    vi.stubGlobal("fetch", fetchImpl);
+    await expect(
+      zulipMessageActions.handleAction?.({
+        channel: "zulip",
+        action: "org-settings-edit" as CoreAction,
+        cfg: lockedCfg,
+        params: { settings: { name: "X" }, confirm: true },
+      }),
+    ).rejects.toThrow("enableAdminActions");
+  });
+
+  it("cannot bypass enableAdminActions via confirmation on user-deactivate", async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", fetchImpl);
+    await expect(
+      zulipMessageActions.handleAction?.({
+        channel: "zulip",
+        action: "user-deactivate" as CoreAction,
+        cfg,
+        params: { userId: "42", confirm: true },
+      }),
+    ).rejects.toThrow("enableAdminActions");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("cannot bypass Zulip admin check via confirmation on org-settings-edit", async () => {
+    const adminCfg: OpenClawConfig = {
+      channels: {
+        zulip: {
+          apiKey: "secret",
+          email: "bot@example.test",
+          url: "https://zulip.example.test",
+          enableAdminActions: true,
+        },
+      },
+    };
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({ result: "success", user: { user_id: 1, is_admin: false } }),
+    );
+    vi.stubGlobal("fetch", fetchImpl);
+    await expect(
+      zulipMessageActions.handleAction?.({
+        channel: "zulip",
+        action: "org-settings-edit" as CoreAction,
+        cfg: adminCfg,
+        params: { settings: { name: "X" }, confirm: true },
+      }),
+    ).rejects.toThrow("admin privileges");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("splitStreamTarget", () => {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -190,6 +190,12 @@ function requireAdminActionsEnabled(account: ReturnType<typeof resolveZulipAccou
   }
 }
 
+function requireDestructiveConfirmation(params: Record<string, unknown>): void {
+  if (params.confirm !== true) {
+    throw new Error("This destructive action requires confirm: true.");
+  }
+}
+
 async function requireZulipAdmin(client: ReturnType<typeof createZulipClient>): Promise<void> {
   const me = await fetchZulipMemberInfo(client, "me");
   if (!me.is_admin) {
@@ -552,7 +558,21 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
     // actions.add("user-reactivate" as ChannelMessageActionName);
     // actions.add("org-settings" as ChannelMessageActionName);
     // actions.add("org-settings-edit" as ChannelMessageActionName);
-    return { actions: Array.from(actions), capabilities: ["presentation"] };
+    const destructiveActions: ChannelMessageActionName[] = [
+      "channel-delete",
+      "delete",
+    ];
+    return {
+      actions: Array.from(actions),
+      capabilities: ["presentation"],
+      schema: {
+        properties: {
+          confirm: { type: "boolean", description: "Set to true to confirm destructive actions." },
+        },
+        actions: destructiveActions,
+        visibility: "current-channel",
+      },
+    };
   },
   supportsAction: ({ action }) => action !== "poll",
   extractToolSend: ({ args }) => {
@@ -722,7 +742,11 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
     }
 
     if (action === "channel-delete") {
+      requireDestructiveConfirmation(params);
       const streamIdOrName = readStreamId(params);
+      if (dryRun) {
+        return jsonResult({ ok: true, dryRun: true, action, streamId: streamIdOrName });
+      }
       // Resolve stream name to ID if necessary
       const streamId = await resolveZulipStreamId(client, streamIdOrName);
       await deleteZulipStream(client, streamId);
@@ -746,9 +770,13 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
     }
 
     if ((action as string) === "user-deactivate") {
+      requireDestructiveConfirmation(params);
       requireAdminActionsEnabled(account);
-      await requireZulipAdmin(client);
       const userId = readUserIdParam(params);
+      if (dryRun) {
+        return jsonResult({ ok: true, dryRun: true, action: "user-deactivate", userId });
+      }
+      await requireZulipAdmin(client);
       await deactivateZulipUser(client, userId);
       return jsonResult({ ok: true, userId, deactivated: true });
     }
@@ -767,9 +795,18 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
     }
 
     if ((action as string) === "org-settings-edit") {
+      requireDestructiveConfirmation(params);
       requireAdminActionsEnabled(account);
-      await requireZulipAdmin(client);
       const updates = readRealmUpdateParams(params);
+      if (dryRun) {
+        return jsonResult({
+          ok: true,
+          dryRun: true,
+          action: "org-settings-edit",
+          updated: Object.keys(updates),
+        });
+      }
+      await requireZulipAdmin(client);
       await updateZulipRealm(client, updates);
       return jsonResult({ ok: true, updated: Object.keys(updates) });
     }
@@ -902,7 +939,11 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
     }
 
     if (action === "delete") {
+      requireDestructiveConfirmation(params);
       const messageId = readMessageId(params);
+      if (dryRun) {
+        return jsonResult({ ok: true, dryRun: true, action, messageId });
+      }
       await deleteZulipMessage(client, { messageId });
       return jsonResult({ ok: true, deleted: messageId });
     }


### PR DESCRIPTION
Closes #25.

## What changed

- Require literal `confirm: true` before message deletion, channel deletion, user deactivation, or organization-setting mutation.
- Preserve `enableAdminActions` and live Zulip-administrator authorization for protected admin operations.
- Make destructive dry-runs return before any Zulip request.
- Advertise the confirmation schema only for destructive actions supported by the current public SDK action union.
- Add regression coverage for missing, false, and string confirmations, zero-request rejection, dry-run safety, successful confirmed operations, discovery schema output, and both authorization gates on both hidden admin mutations.

## Verification

- Direct test-file TypeScript check with the project's ES2023 library configuration
- Full suite: 140 passing
- Targeted actions suite: 27 passing
- `pnpm build`
- `git diff --check`

## Review

Hawk performed repeated security/correctness review passes. Findings around destructive dry-run execution, zero-request proof, hidden-action schema casts, complementary admin-gate coverage, and test portability were fixed and re-reviewed. Final verdict: approved with no remaining findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a safety gate on destructive and org-mutating operations but changes when admin API calls run (dry-run and confirmation ordering); mistakes could block legitimate automation or still allow harm if callers always pass confirm.
> 
> **Overview**
> Destructive Zulip message actions now require **`confirm: true`** (strict boolean) before they run. That gate applies to **`delete`**, **`channel-delete`**, and the hidden admin paths **`user-deactivate`** and **`org-settings-edit`**.
> 
> **`describeMessageTool`** advertises a boolean **`confirm`** parameter only for the publicly listed destructive actions **`delete`** and **`channel-delete`**. For those actions and the admin mutations, **`dryRun`** returns a success payload **without** calling Zulip; admin flows still enforce **`enableAdminActions`** and live Zulip admin checks **after** confirmation and cannot be skipped by setting **`confirm`**.
> 
> Regression tests cover missing/invalid confirmation, zero-network rejection, dry-run safety, successful confirmed deletes, schema discovery, and admin/config gates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 250bad5ec07cf6255d6f0fda8c96a0f6b0db23d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->