### PR TITLE
fix: use supported session store and validation APIs

### DIFF
--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -49,7 +49,7 @@ const requireOpenAllowFrom = (params: {
     return;
   }
   params.ctx.addIssue({
-    code: z.ZodIssueCode.custom,
+    code: "custom",
     path: params.path,
     message: params.message,
   });

--- a/src/secret-contract.test.ts
+++ b/src/secret-contract.test.ts
@@ -3,6 +3,20 @@ import { ZulipConfigSchema } from "./config-schema.js";
 import { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from "./secret-contract.js";
 
 describe("Zulip secret contract", () => {
+  it.each([
+    { input: { dmPolicy: "open", allowFrom: [] }, path: ["allowFrom"] },
+    {
+      input: { accounts: { work: { dmPolicy: "open", allowFrom: [] } } },
+      path: ["accounts", "work", "allowFrom"],
+    },
+  ])("rejects open DM policy without a wildcard at $path", ({ input, path }) => {
+    const result = ZulipConfigSchema.safeParse(input);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues).toContainEqual(expect.objectContaining({ code: "custom", path }));
+    }
+  });
+
   it("schema accepts plain strings and structured SecretRefs", () => {
     expect(ZulipConfigSchema.safeParse({ apiKey: "plain" }).success).toBe(true);
     expect(

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -56,6 +56,11 @@ const state = vi.hoisted(() => {
     system: {
       enqueueSystemEvent: vi.fn(),
     },
+    agent: {
+      session: {
+        resolveStorePath: vi.fn((_store?: string, _options?: { agentId: string }) => "/tmp/openclaw-session-store.json"),
+      },
+    },
     channel: {
       media: {
         saveMediaBuffer: vi.fn(),
@@ -101,7 +106,6 @@ const state = vi.hoisted(() => {
         dispatchReplyFromConfig: vi.fn(async () => {}),
       },
       session: {
-        resolveStorePath: vi.fn(() => "/tmp/openclaw-session-store.json"),
         updateLastRoute: vi.fn(async () => {}),
       },
       pairing: {
@@ -569,6 +573,8 @@ describe("monitorZulipProvider", () => {
   });
 
   it("stores last-route delivery context for stream-topic messages", async () => {
+    state.core.config.session = { store: "/configured/{agentId}/sessions.json" };
+    state.core.agent.session.resolveStorePath.mockReturnValue("/resolved/debbie/session-store");
     state.pollResponses = [
       {
         result: "success",
@@ -578,8 +584,12 @@ describe("monitorZulipProvider", () => {
 
     await runMonitorOnce();
 
+    expect(state.core.agent.session.resolveStorePath).toHaveBeenCalledExactlyOnceWith(
+      "/configured/{agentId}/sessions.json",
+      { agentId: "debbie" },
+    );
     expect(state.core.channel.session.updateLastRoute).toHaveBeenCalledWith({
-      storePath: "/tmp/openclaw-session-store.json",
+      storePath: "/resolved/debbie/session-store",
       sessionKey: "agent:debbie:main",
       deliveryContext: {
         channel: "zulip",

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -838,7 +838,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     });
 
     const sessionCfg = cfg.session;
-    const storePath = core.channel.session.resolveStorePath(sessionCfg?.store, {
+      const storePath = core.agent.session.resolveStorePath(sessionCfg?.store, {
       agentId: route.agentId,
     });
     await core.channel.session.updateLastRoute({


### PR DESCRIPTION
The monitor still resolves session storage through the deprecated channel namespace, and schema refinements use Zod's deprecated issue-code enum. Call `runtime.agent.session.resolveStorePath` and use the literal `"custom"` issue code. Both replacements are already supported by the declared dependencies; no host minimum or lockfile changes are needed.

The monitor test supplies only the supported agent session resolver and checks that the configured store template, selected agent, resolved path, and delivery context stay connected. Root and account-level open-DM validation retain their issue codes and paths.

Independent follow-up to #21. This only addresses these two remaining deprecated calls; the broader SDK migration and other known compatibility gaps remain separate.

Validation at `55757bc`: a secretless Linux AWS runner with Node 24.19.0 installed the frozen lockfile with lifecycle scripts disabled. `pnpm build` and all 125 tests passed. Replacing only the production monitor with its pre-fix version made the strengthened route test fail because the deprecated channel resolver is unavailable; restoring the candidate passed all 26 focused tests. Codex review and whitespace checks also passed. No real Zulip account was used: transport APIs are mocked, while the published OpenClaw 2026.5.26 dependency supplies the SDK contract.
