### PR TITLE
feat(zulip): add thinking placeholder lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,16 @@ Add the plugin id to `plugins.allow` in `~/.openclaw/openclaw.json`:
         }
       },
 
+      // Optional edit-in-place progress feedback (disabled by default).
+      // Text-only replies replace this message. Media and interactive replies
+      // remove it before sending normally; silent or cancelled turns remove it.
+      // Failed turns keep the placeholder and replace it with errorText.
+      "thinkingPlaceholder": {
+        "enabled": false,
+        "text": "Thinking…",
+        "errorText": "I couldn't complete that response."
+      },
+
       // Model-controlled reaction prompt guidance: "off" | "minimal" | "extensive"
       // This does not enable automatic status/progress reactions.
       "agentReactionGuidance": "minimal",

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -94,6 +94,14 @@ const ZulipStreamOverridesSchema = z
     }
   });
 
+const ThinkingPlaceholderSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    text: z.string().min(1).optional(),
+    errorText: z.string().min(1).optional(),
+  })
+  .strict();
+
 const OptionalSecretInputSchema = buildOptionalSecretInputSchema();
 
 const MarkdownConfigSchema = z
@@ -166,6 +174,7 @@ const ZulipAccountSchemaBase = z
       })
       .strict()
       .optional(),
+    thinkingPlaceholder: ThinkingPlaceholderSchema.optional(),
     agentReactionGuidance: AgentReactionGuidanceSchema.optional(),
     textChunkLimit: z.number().int().positive().optional(),
     chunkMode: z.enum(["length", "newline"]).optional(),

--- a/src/secret-contract.test.ts
+++ b/src/secret-contract.test.ts
@@ -40,6 +40,27 @@ describe("Zulip secret contract", () => {
     expect(zulipChannelConfigSchema.runtime!.safeParse({ agentReactionGuidance: "ack" }).success).toBe(false);
   });
 
+  it("schema accepts account-scoped thinking placeholders and rejects empty text", () => {
+    expect(
+      zulipChannelConfigSchema.runtime!.safeParse({
+        accounts: {
+          work: {
+            thinkingPlaceholder: {
+              enabled: true,
+              text: "Thinking…",
+              errorText: "Turn failed.",
+            },
+          },
+        },
+      }).success,
+    ).toBe(true);
+    expect(
+      zulipChannelConfigSchema.runtime!.safeParse({
+        thinkingPlaceholder: { enabled: true, text: "" },
+      }).success,
+    ).toBe(false);
+  });
+
   it.each([
     { value: { dmPolicy: "open" }, path: ["allowFrom"] },
     { value: { accounts: { work: { dmPolicy: "open" } } }, path: ["accounts", "work", "allowFrom"] },

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,6 +101,14 @@ export type ZulipAccountConfig = {
     /** Dedicated indicator while spawned children are active. Empty string suppresses it. */
     subagent?: string;
   };
+  /** Optional edit-in-place progress message. Disabled unless enabled is true. */
+  thinkingPlaceholder?: {
+    enabled?: boolean;
+    /** Initial placeholder text. Default: "Thinking…". */
+    text?: string;
+    /** Text retained when the turn fails before delivering a reply. */
+    errorText?: string;
+  };
   /** Model prompt guidance for agent-controlled reactions. Does not enable automatic status reactions. Default: "minimal". */
   agentReactionGuidance?: ZulipAgentReactionGuidance;
   /** Outbound text chunk size (chars). Default: 4000. */

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -659,6 +659,59 @@ describe("monitorZulipProvider", () => {
     );
   });
 
+  it("awaits thinking placeholder deletion through the gateway-stop cleanup", async () => {
+    state.autoAbort = false;
+    state.account.config.thinkingPlaceholder = { enabled: true };
+    let dispatchStarted!: () => void;
+    const dispatched = new Promise<void>((resolve) => {
+      dispatchStarted = resolve;
+    });
+    let deletionStarted!: () => void;
+    const deleting = new Promise<void>((resolve) => {
+      deletionStarted = resolve;
+    });
+    let allowDeletion!: () => void;
+    const deletionAllowed = new Promise<void>((resolve) => {
+      allowDeletion = resolve;
+    });
+    state.deleteZulipMessage.mockImplementation(async () => {
+      deletionStarted();
+      await deletionAllowed;
+    });
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ replyOptions }) => {
+        dispatchStarted();
+        await new Promise<void>((resolve) => {
+          replyOptions.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+        });
+        return {};
+      },
+    );
+    state.pollResponses = [{
+      result: "success",
+      events: [{ id: 1, type: "message", message: makeChannelMessage(1099) }],
+    }];
+
+    const monitorPromise = runMonitorOnce();
+    await dispatched;
+    const { clearActiveZulipMonitorReactionLifecycles } = await import("./monitor.js");
+    let cleanupSettled = false;
+    const cleanup = clearActiveZulipMonitorReactionLifecycles().then(() => {
+      cleanupSettled = true;
+    });
+    await deleting;
+    await Promise.resolve();
+    expect(cleanupSettled).toBe(false);
+    allowDeletion();
+    await cleanup;
+
+    expect(state.deleteZulipMessage).toHaveBeenCalledWith(state.client, {
+      messageId: "outbound-1",
+    });
+    state.abortController?.abort();
+    await monitorPromise;
+  });
+
   it("does not add a terminal reaction when abort races subagent settlement", async () => {
     state.autoAbort = false;
     state.account.config.reactions = { enabled: true, clearOnFinish: false };
@@ -2047,6 +2100,90 @@ describe("monitorZulipProvider", () => {
       metadata: { queueEventId: 2 },
     });
     expect(state.core.channel.inbound.buildContext).toHaveBeenCalledTimes(1);
+  });
+
+  it("commits edited placeholder error feedback and does not replay it", async () => {
+    enableDurableInboundJournal();
+    state.account.config.thinkingPlaceholder = { enabled: true, errorText: "Turn failed." };
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockRejectedValueOnce(
+      new Error("synthetic model failure"),
+    );
+    const statusSink = vi.fn();
+    state.pollResponses = [{
+      result: "success",
+      events: [{ id: 6, type: "message", message: makeChannelMessage(2111) }],
+    }];
+
+    await runMonitorOnce(new AbortController(), undefined, { statusSink });
+
+    const pendingStore = Array.from(state.durableStores.entries()).find(([namespace]) =>
+      namespace.includes(".pending."),
+    )?.[1];
+    const completedStore = Array.from(state.durableStores.entries()).find(([namespace]) =>
+      namespace.includes(".completed."),
+    )?.[1];
+    await expect(pendingStore?.entries()).resolves.toEqual([]);
+    await expect(completedStore?.entries()).resolves.toHaveLength(1);
+    expect(state.editZulipMessage).toHaveBeenCalledExactlyOnceWith(state.client, {
+      messageId: "outbound-1",
+      content: "Turn failed.",
+    });
+    expect(statusSink).toHaveBeenCalledWith({ lastOutboundAt: expect.any(Number) });
+
+    await runMonitorOnce();
+
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+    expect(state.editZulipMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("commits fallback error feedback after placeholder cleanup and does not replay it", async () => {
+    enableDurableInboundJournal();
+    state.account.config.thinkingPlaceholder = { enabled: true, errorText: "Turn failed." };
+    state.sendMessageZulip
+      .mockResolvedValueOnce({ messageId: "placeholder-1", channelId: "debbie" })
+      .mockRejectedValueOnce(new Error("reply send failed"))
+      .mockResolvedValueOnce({ messageId: "error-1", channelId: "debbie" });
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions }) => {
+        try {
+          await dispatcherOptions.deliver({
+            presentation: {
+              blocks: [{ type: "buttons", buttons: [{ label: "Confirm", action: "confirm" }] }],
+            },
+          });
+        } catch (err) {
+          dispatcherOptions.onError(err);
+        }
+      },
+    );
+    const statusSink = vi.fn();
+    state.pollResponses = [{
+      result: "success",
+      events: [{ id: 7, type: "message", message: makeChannelMessage(2112) }],
+    }];
+
+    await runMonitorOnce(new AbortController(), undefined, { statusSink });
+
+    const pendingStore = Array.from(state.durableStores.entries()).find(([namespace]) =>
+      namespace.includes(".pending."),
+    )?.[1];
+    const completedStore = Array.from(state.durableStores.entries()).find(([namespace]) =>
+      namespace.includes(".completed."),
+    )?.[1];
+    await expect(pendingStore?.entries()).resolves.toEqual([]);
+    await expect(completedStore?.entries()).resolves.toHaveLength(1);
+    expect(state.sendMessageZulip).toHaveBeenNthCalledWith(
+      3,
+      "stream:debbie:zulip-plugin-pr",
+      "Turn failed.",
+      expect.objectContaining({ topic: "zulip-plugin-pr" }),
+    );
+    expect(statusSink).toHaveBeenCalledWith({ lastOutboundAt: expect.any(Number) });
+
+    await runMonitorOnce();
+
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+    expect(state.sendMessageZulip).toHaveBeenCalledTimes(3);
   });
 
   it.each([

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -573,6 +573,44 @@ describe("monitorZulipProvider", () => {
     );
   });
 
+  it("retries a transient placeholder deletion failure during ordinary abort", async () => {
+    state.autoAbort = false;
+    state.account.config.thinkingPlaceholder = { enabled: true };
+    state.deleteZulipMessage
+      .mockRejectedValueOnce(new Error("transient delete failure"))
+      .mockResolvedValueOnce(undefined);
+    let dispatchStarted!: () => void;
+    const dispatched = new Promise<void>((resolve) => {
+      dispatchStarted = resolve;
+    });
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ replyOptions }) => {
+        dispatchStarted();
+        await new Promise<void>((resolve) => {
+          replyOptions.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+        });
+        return {};
+      },
+    );
+    state.pollResponses = [{
+      result: "success",
+      events: [{ id: 1, type: "message", message: makeChannelMessage(1199) }],
+    }];
+
+    const monitorPromise = runMonitorOnce();
+    await dispatched;
+    state.abortController?.abort();
+    await monitorPromise;
+
+    expect(state.deleteZulipMessage).toHaveBeenCalledTimes(2);
+    expect(state.deleteZulipMessage).toHaveBeenNthCalledWith(1, state.client, {
+      messageId: "outbound-1",
+    });
+    expect(state.deleteZulipMessage).toHaveBeenNthCalledWith(2, state.client, {
+      messageId: "outbound-1",
+    });
+  });
+
   it("clears active reactions through the gateway-stop hook", async () => {
     state.autoAbort = false;
     state.account.config.reactions = { enabled: true, clearOnFinish: false };
@@ -659,7 +697,7 @@ describe("monitorZulipProvider", () => {
     );
   });
 
-  it("waits for pending placeholder creation and retrying deletion before gateway stop", async () => {
+  it("bounds persistent placeholder deletion failure during gateway stop", async () => {
     state.autoAbort = false;
     state.account.config.thinkingPlaceholder = { enabled: true };
     let creationStarted!: () => void;
@@ -675,20 +713,7 @@ describe("monitorZulipProvider", () => {
       await creationAllowed;
       return { messageId: "pending-placeholder", channelId: "debbie" };
     });
-    let retryDeletionStarted!: () => void;
-    const retryingDeletion = new Promise<void>((resolve) => {
-      retryDeletionStarted = resolve;
-    });
-    let allowRetryDeletion!: () => void;
-    const deletionAllowed = new Promise<void>((resolve) => {
-      allowRetryDeletion = resolve;
-    });
-    state.deleteZulipMessage
-      .mockRejectedValueOnce(new Error("transient delete failure"))
-      .mockImplementationOnce(async () => {
-        retryDeletionStarted();
-        await deletionAllowed;
-      });
+    state.deleteZulipMessage.mockRejectedValue(new Error("permission denied"));
     state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async () => {
       throw new Error("dispatch must not start during gateway shutdown");
     });
@@ -697,7 +722,12 @@ describe("monitorZulipProvider", () => {
       events: [{ id: 1, type: "message", message: makeChannelMessage(1099) }],
     }];
 
-    const monitorPromise = runMonitorOnce();
+    const runtimeError = vi.fn();
+    const monitorPromise = runMonitorOnce(new AbortController(), {
+      log: vi.fn(),
+      error: runtimeError,
+      exit: vi.fn(),
+    });
     await creating;
     const { clearActiveZulipMonitorReactionLifecycles } = await import("./monitor.js");
     let cleanupSettled = false;
@@ -710,19 +740,18 @@ describe("monitorZulipProvider", () => {
     expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
 
     allowCreation();
-    await retryingDeletion;
-    expect(state.deleteZulipMessage).toHaveBeenCalledTimes(2);
-    expect(cleanupSettled).toBe(false);
-    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
-    allowRetryDeletion();
-    await cleanup;
+    await expect(Promise.race([
+      cleanup.then(() => "settled"),
+      new Promise<string>((resolve) => setTimeout(() => resolve("timed-out"), 500)),
+    ])).resolves.toBe("settled");
 
+    expect(state.deleteZulipMessage).toHaveBeenCalledTimes(3);
     expect(state.deleteZulipMessage).toHaveBeenNthCalledWith(1, state.client, {
       messageId: "pending-placeholder",
     });
-    expect(state.deleteZulipMessage).toHaveBeenNthCalledWith(2, state.client, {
-      messageId: "pending-placeholder",
-    });
+    expect(runtimeError).toHaveBeenCalledWith(
+      "zulip: thinking placeholder cleanup failed after 3 attempts",
+    );
     expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
     state.abortController?.abort();
     await monitorPromise;

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -913,6 +913,13 @@ describe("monitorZulipProvider", () => {
     },
   ])("sends configured error text when a $name send fails after placeholder cleanup", async ({ payload, editFails, messageId }) => {
     state.account.config.thinkingPlaceholder = { enabled: true, errorText: "Turn failed." };
+    state.account.config.reactions = {
+      enabled: true,
+      clearOnFinish: false,
+      onStart: "",
+      onSuccess: "check",
+      onError: "warning",
+    };
     if (editFails) {
       state.editZulipMessage.mockRejectedValueOnce(new Error("edit denied"));
     }
@@ -921,7 +928,11 @@ describe("monitorZulipProvider", () => {
       .mockRejectedValueOnce(new Error("reply send failed"))
       .mockResolvedValueOnce({ messageId: "error-1", channelId: "debbie" });
     state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
-      await dispatcherOptions.deliver(payload);
+      try {
+        await dispatcherOptions.deliver(payload);
+      } catch (err) {
+        dispatcherOptions.onError(err);
+      }
     });
     state.pollResponses = [{ result: "success", events: [{ id: 1, type: "message", message: makeChannelMessage(messageId) }] }];
 
@@ -934,6 +945,14 @@ describe("monitorZulipProvider", () => {
       "stream:debbie:zulip-plugin-pr",
       "Turn failed.",
       expect.objectContaining({ topic: "zulip-plugin-pr" }),
+    );
+    expect(state.addZulipReaction).toHaveBeenCalledExactlyOnceWith(state.client, {
+      messageId: String(messageId),
+      emojiName: "warning",
+    });
+    expect(state.addZulipReaction).not.toHaveBeenCalledWith(
+      state.client,
+      expect.objectContaining({ emojiName: "check" }),
     );
   });
 

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -125,6 +125,9 @@ const state = vi.hoisted(() => {
     streamLookups: new Map<string, Record<string, unknown> | Error>(),
     downloadedUploads: [] as Array<{ buffer: Buffer; contentType: string; filename: string }>,
     extractedUploadUrls: [] as string[],
+    editZulipMessage: vi.fn(async () => {}),
+    deleteZulipMessage: vi.fn(async () => {}),
+    sendMessageZulip: vi.fn(async () => ({ messageId: "outbound-1", channelId: "debbie" })),
     client: { authHeader: "fake-auth" },
     addZulipReaction: vi.fn(async () => {}),
     removeZulipReaction: vi.fn(async () => {}),
@@ -196,6 +199,8 @@ vi.mock("./client.js", () => ({
   sendZulipTyping: vi.fn(async () => {}),
   addZulipReaction: state.addZulipReaction,
   removeZulipReaction: state.removeZulipReaction,
+  editZulipMessage: state.editZulipMessage,
+  deleteZulipMessage: state.deleteZulipMessage,
 }));
 
 vi.mock("./accounts.js", () => ({
@@ -203,7 +208,7 @@ vi.mock("./accounts.js", () => ({
 }));
 
 vi.mock("./send.js", () => ({
-  sendMessageZulip: vi.fn(async () => {}),
+  sendMessageZulip: state.sendMessageZulip,
 }));
 
 const downloadZulipUploadMock = vi.fn(async () => {
@@ -302,6 +307,7 @@ function makePrivateMessage(id: number, senderEmail = "user8@zlp.pubnerd.app") {
 async function runMonitorOnce(
   controller = new AbortController(),
   runtime?: RuntimeEnv,
+  options: { statusSink?: (patch: Record<string, unknown>) => void } = {},
 ) {
   const { monitorZulipProvider } = await import("./monitor.js");
   state.abortController = controller;
@@ -309,6 +315,7 @@ async function runMonitorOnce(
     config: state.core.config,
     runtime,
     abortSignal: state.abortController.signal,
+    statusSink: options.statusSink,
   });
 }
 
@@ -366,6 +373,10 @@ describe("monitorZulipProvider", () => {
     state.extractedUploadUrls = [];
     state.abortController = undefined;
     state.autoAbort = true;
+    state.editZulipMessage.mockReset();
+    state.deleteZulipMessage.mockReset();
+    state.sendMessageZulip.mockReset();
+    state.sendMessageZulip.mockResolvedValue({ messageId: "outbound-1", channelId: "debbie" });
     downloadZulipUploadMock.mockClear();
     extractZulipUploadUrlsMock.mockClear();
     registerZulipQueueMock.mockClear();
@@ -782,6 +793,119 @@ describe("monitorZulipProvider", () => {
       state.client,
       expect.objectContaining({ messageId: "1096", emojiName: "eyes" }),
     );
+  });
+
+  it("replaces a stream thinking placeholder with the first text chunk", async () => {
+    state.account.config.thinkingPlaceholder = { enabled: true, text: "Thinking…" };
+    state.core.channel.text.chunkMarkdownTextWithMode.mockReturnValue(["first chunk", "second chunk"]);
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "reply text" });
+    });
+    state.pollResponses = [{ result: "success", events: [{ id: 1, type: "message", message: makeChannelMessage(4001) }] }];
+
+    await runMonitorOnce();
+
+    expect(state.sendMessageZulip).toHaveBeenNthCalledWith(1, "stream:debbie:zulip-plugin-pr", "Thinking…", expect.objectContaining({ topic: "zulip-plugin-pr" }));
+    expect(state.editZulipMessage).toHaveBeenCalledWith(state.client, { messageId: "outbound-1", content: "first chunk" });
+    expect(state.sendMessageZulip).toHaveBeenNthCalledWith(2, "stream:debbie:zulip-plugin-pr", "second chunk", expect.any(Object));
+    expect(state.deleteZulipMessage).not.toHaveBeenCalled();
+  });
+
+  it("removes a DM thinking placeholder after a silent turn", async () => {
+    state.account.config.thinkingPlaceholder = { enabled: true };
+    const statusSink = vi.fn();
+    state.pollResponses = [{ result: "success", events: [{ id: 1, type: "message", message: makePrivateMessage(4002) }] }];
+
+    await runMonitorOnce(new AbortController(), undefined, { statusSink });
+
+    expect(state.sendMessageZulip).toHaveBeenCalledWith("user:user8@zlp.pubnerd.app", "Thinking…", expect.any(Object));
+    expect(state.deleteZulipMessage).toHaveBeenCalledWith(state.client, { messageId: "outbound-1" });
+    expect(state.editZulipMessage).not.toHaveBeenCalled();
+    expect(statusSink).not.toHaveBeenCalledWith(expect.objectContaining({ lastOutboundAt: expect.any(Number) }));
+  });
+
+  it("removes the placeholder before a presentation-only reply", async () => {
+    state.account.config.thinkingPlaceholder = { enabled: true };
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({
+        presentation: { blocks: [{ type: "buttons", buttons: [{ label: "Confirm", action: "confirm" }] }] },
+      });
+    });
+    state.pollResponses = [{ result: "success", events: [{ id: 1, type: "message", message: makeChannelMessage(4003) }] }];
+
+    await runMonitorOnce();
+
+    expect(state.deleteZulipMessage).toHaveBeenCalledWith(state.client, { messageId: "outbound-1" });
+    expect(state.sendMessageZulip).toHaveBeenNthCalledWith(2, "stream:debbie:zulip-plugin-pr", "", expect.objectContaining({ presentation: expect.any(Object) }));
+  });
+
+  it("removes the placeholder before a media-only reply", async () => {
+    state.account.config.thinkingPlaceholder = { enabled: true };
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ mediaUrl: "https://example.com/result.png" });
+    });
+    state.pollResponses = [{ result: "success", events: [{ id: 1, type: "message", message: makePrivateMessage(4006) }] }];
+
+    await runMonitorOnce();
+
+    expect(state.deleteZulipMessage).toHaveBeenCalledWith(state.client, { messageId: "outbound-1" });
+    expect(state.sendMessageZulip).toHaveBeenNthCalledWith(2, "user:user8@zlp.pubnerd.app", "", expect.objectContaining({ mediaUrl: "https://example.com/result.png" }));
+  });
+
+  it("converts the placeholder to an error when dispatch fails before delivery", async () => {
+    state.account.config.thinkingPlaceholder = { enabled: true, errorText: "Turn failed." };
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockRejectedValue(new Error("model failed"));
+    state.pollResponses = [{ result: "success", events: [{ id: 1, type: "message", message: makeChannelMessage(4004) }] }];
+
+    await runMonitorOnce();
+
+    expect(state.editZulipMessage).toHaveBeenCalledWith(state.client, { messageId: "outbound-1", content: "Turn failed." });
+    expect(state.deleteZulipMessage).not.toHaveBeenCalled();
+  });
+
+  it("removes the placeholder when the turn is cancelled", async () => {
+    state.account.config.thinkingPlaceholder = { enabled: true };
+    const cancelled = new Error("cancelled");
+    cancelled.name = "AbortError";
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockRejectedValue(cancelled);
+    state.pollResponses = [{ result: "success", events: [{ id: 1, type: "message", message: makeChannelMessage(4007) }] }];
+
+    await runMonitorOnce();
+
+    expect(state.deleteZulipMessage).toHaveBeenCalledWith(state.client, { messageId: "outbound-1" });
+    expect(state.editZulipMessage).not.toHaveBeenCalled();
+  });
+
+  it("continues normally when placeholder creation fails", async () => {
+    state.account.config.thinkingPlaceholder = { enabled: true };
+    state.sendMessageZulip
+      .mockRejectedValueOnce(new Error("placeholder rejected"))
+      .mockResolvedValueOnce({ messageId: "reply-1", channelId: "debbie" });
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "actual reply" });
+    });
+    state.pollResponses = [{ result: "success", events: [{ id: 1, type: "message", message: makeChannelMessage(4008) }] }];
+
+    await runMonitorOnce();
+
+    expect(state.sendMessageZulip).toHaveBeenCalledTimes(2);
+    expect(state.sendMessageZulip).toHaveBeenNthCalledWith(2, "stream:debbie:zulip-plugin-pr", "actual reply", expect.any(Object));
+    expect(state.editZulipMessage).not.toHaveBeenCalled();
+    expect(state.deleteZulipMessage).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a normal send when replacing the placeholder fails", async () => {
+    state.account.config.thinkingPlaceholder = { enabled: true };
+    state.editZulipMessage.mockRejectedValueOnce(new Error("edit denied"));
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "actual reply" });
+    });
+    state.pollResponses = [{ result: "success", events: [{ id: 1, type: "message", message: makeChannelMessage(4005) }] }];
+
+    await runMonitorOnce();
+
+    expect(state.deleteZulipMessage).toHaveBeenCalledWith(state.client, { messageId: "outbound-1" });
+    expect(state.sendMessageZulip).toHaveBeenNthCalledWith(2, "stream:debbie:zulip-plugin-pr", "actual reply", expect.any(Object));
   });
 
   it("forwards presentation and channel data only with the first text chunk", async () => {

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -127,6 +127,8 @@ const state = vi.hoisted(() => {
     extractedUploadUrls: [] as string[],
     editZulipMessage: vi.fn(async () => {}),
     deleteZulipMessage: vi.fn(async () => {}),
+    addZulipReaction: vi.fn(async () => {}),
+    removeZulipReaction: vi.fn(async () => {}),
     sendMessageZulip: vi.fn(async () => ({ messageId: "outbound-1", channelId: "debbie" })),
     client: { authHeader: "fake-auth" },
     addZulipReaction: vi.fn(async () => {}),
@@ -375,6 +377,8 @@ describe("monitorZulipProvider", () => {
     state.autoAbort = true;
     state.editZulipMessage.mockReset();
     state.deleteZulipMessage.mockReset();
+    state.addZulipReaction.mockReset();
+    state.removeZulipReaction.mockReset();
     state.sendMessageZulip.mockReset();
     state.sendMessageZulip.mockResolvedValue({ messageId: "outbound-1", channelId: "debbie" });
     downloadZulipUploadMock.mockClear();
@@ -824,6 +828,23 @@ describe("monitorZulipProvider", () => {
     expect(statusSink).not.toHaveBeenCalledWith(expect.objectContaining({ lastOutboundAt: expect.any(Number) }));
   });
 
+  it("adds the configured success reaction after a silent turn", async () => {
+    state.account.config.reactions = {
+      enabled: true,
+      clearOnFinish: false,
+      onStart: "",
+      onSuccess: "check",
+    };
+    state.pollResponses = [{ result: "success", events: [{ id: 1, type: "message", message: makeChannelMessage(4010) }] }];
+
+    await runMonitorOnce();
+
+    expect(state.addZulipReaction).toHaveBeenCalledExactlyOnceWith(state.client, {
+      messageId: "4010",
+      emojiName: "check",
+    });
+  });
+
   it("removes the placeholder before a presentation-only reply", async () => {
     state.account.config.thinkingPlaceholder = { enabled: true };
     state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
@@ -861,6 +882,59 @@ describe("monitorZulipProvider", () => {
 
     expect(state.editZulipMessage).toHaveBeenCalledWith(state.client, { messageId: "outbound-1", content: "Turn failed." });
     expect(state.deleteZulipMessage).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "media",
+      payload: { mediaUrl: "https://example.com/result.png" },
+      editFails: false,
+      messageId: 4011,
+    },
+    {
+      name: "presentation-only",
+      payload: {
+        presentation: { blocks: [{ type: "buttons", buttons: [{ label: "Confirm", action: "confirm" }] }] },
+      },
+      editFails: false,
+      messageId: 4012,
+    },
+    {
+      name: "topic-change",
+      payload: { text: "[[zulip_topic: another-topic]] actual reply" },
+      editFails: false,
+      messageId: 4013,
+    },
+    {
+      name: "text replacement fallback",
+      payload: { text: "actual reply" },
+      editFails: true,
+      messageId: 4014,
+    },
+  ])("sends configured error text when a $name send fails after placeholder cleanup", async ({ payload, editFails, messageId }) => {
+    state.account.config.thinkingPlaceholder = { enabled: true, errorText: "Turn failed." };
+    if (editFails) {
+      state.editZulipMessage.mockRejectedValueOnce(new Error("edit denied"));
+    }
+    state.sendMessageZulip
+      .mockResolvedValueOnce({ messageId: "placeholder-1", channelId: "debbie" })
+      .mockRejectedValueOnce(new Error("reply send failed"))
+      .mockResolvedValueOnce({ messageId: "error-1", channelId: "debbie" });
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver(payload);
+    });
+    state.pollResponses = [{ result: "success", events: [{ id: 1, type: "message", message: makeChannelMessage(messageId) }] }];
+
+    await runMonitorOnce();
+
+    expect(state.deleteZulipMessage).toHaveBeenCalledWith(state.client, { messageId: "placeholder-1" });
+    expect(state.sendMessageZulip).toHaveBeenCalledTimes(3);
+    expect(state.sendMessageZulip).toHaveBeenNthCalledWith(
+      3,
+      "stream:debbie:zulip-plugin-pr",
+      "Turn failed.",
+      expect.objectContaining({ topic: "zulip-plugin-pr" }),
+    );
   });
 
   it("removes the placeholder when the turn is cancelled", async () => {

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -131,8 +131,6 @@ const state = vi.hoisted(() => {
     removeZulipReaction: vi.fn(async () => {}),
     sendMessageZulip: vi.fn(async () => ({ messageId: "outbound-1", channelId: "debbie" })),
     client: { authHeader: "fake-auth" },
-    addZulipReaction: vi.fn(async () => {}),
-    removeZulipReaction: vi.fn(async () => {}),
     botUser: {
       id: 999,
       email: "debbie-bot@zlp.pubnerd.app",
@@ -953,6 +951,72 @@ describe("monitorZulipProvider", () => {
     expect(state.addZulipReaction).not.toHaveBeenCalledWith(
       state.client,
       expect.objectContaining({ emojiName: "check" }),
+    );
+  });
+
+  it.each([
+    {
+      name: "text chunk",
+      payload: { text: "reply text", channelData: { test: true } },
+      chunks: ["first chunk", "second chunk"],
+      expectedFirstReply: "first chunk",
+      expectedFirstReplyOptions: { channelData: { test: true } },
+      messageId: 4015,
+    },
+    {
+      name: "media item",
+      payload: {
+        text: "caption",
+        mediaUrls: ["https://example.com/first.png", "https://example.com/second.png"],
+      },
+      chunks: undefined,
+      expectedFirstReply: "caption",
+      expectedFirstReplyOptions: { mediaUrl: "https://example.com/first.png" },
+      messageId: 4016,
+    },
+  ])("does not append error text after partial $name delivery", async ({
+    payload,
+    chunks,
+    expectedFirstReply,
+    expectedFirstReplyOptions,
+    messageId,
+  }) => {
+    state.account.config.thinkingPlaceholder = { enabled: true, errorText: "Turn failed." };
+    if (chunks) {
+      state.core.channel.text.chunkMarkdownTextWithMode.mockReturnValue(chunks);
+    }
+    state.sendMessageZulip
+      .mockResolvedValueOnce({ messageId: "placeholder-1", channelId: "debbie" })
+      .mockResolvedValueOnce({ messageId: "reply-1", channelId: "debbie" })
+      .mockRejectedValueOnce(new Error("later reply send failed"));
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      try {
+        await dispatcherOptions.deliver(payload);
+      } catch (err) {
+        dispatcherOptions.onError(err);
+      }
+    });
+    state.pollResponses = [{
+      result: "success",
+      events: [{ id: 1, type: "message", message: makeChannelMessage(messageId) }],
+    }];
+
+    await runMonitorOnce();
+
+    expect(state.deleteZulipMessage).toHaveBeenCalledWith(state.client, {
+      messageId: "placeholder-1",
+    });
+    expect(state.sendMessageZulip).toHaveBeenNthCalledWith(
+      2,
+      "stream:debbie:zulip-plugin-pr",
+      expectedFirstReply,
+      expect.objectContaining(expectedFirstReplyOptions),
+    );
+    expect(state.sendMessageZulip).toHaveBeenCalledTimes(3);
+    expect(state.sendMessageZulip).not.toHaveBeenCalledWith(
+      "stream:debbie:zulip-plugin-pr",
+      "Turn failed.",
+      expect.any(Object),
     );
   });
 

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -659,55 +659,71 @@ describe("monitorZulipProvider", () => {
     );
   });
 
-  it("awaits thinking placeholder deletion through the gateway-stop cleanup", async () => {
+  it("waits for pending placeholder creation and retrying deletion before gateway stop", async () => {
     state.autoAbort = false;
     state.account.config.thinkingPlaceholder = { enabled: true };
-    let dispatchStarted!: () => void;
-    const dispatched = new Promise<void>((resolve) => {
-      dispatchStarted = resolve;
+    let creationStarted!: () => void;
+    const creating = new Promise<void>((resolve) => {
+      creationStarted = resolve;
     });
-    let deletionStarted!: () => void;
-    const deleting = new Promise<void>((resolve) => {
-      deletionStarted = resolve;
+    let allowCreation!: () => void;
+    const creationAllowed = new Promise<void>((resolve) => {
+      allowCreation = resolve;
     });
-    let allowDeletion!: () => void;
+    state.sendMessageZulip.mockImplementationOnce(async () => {
+      creationStarted();
+      await creationAllowed;
+      return { messageId: "pending-placeholder", channelId: "debbie" };
+    });
+    let retryDeletionStarted!: () => void;
+    const retryingDeletion = new Promise<void>((resolve) => {
+      retryDeletionStarted = resolve;
+    });
+    let allowRetryDeletion!: () => void;
     const deletionAllowed = new Promise<void>((resolve) => {
-      allowDeletion = resolve;
+      allowRetryDeletion = resolve;
     });
-    state.deleteZulipMessage.mockImplementation(async () => {
-      deletionStarted();
-      await deletionAllowed;
+    state.deleteZulipMessage
+      .mockRejectedValueOnce(new Error("transient delete failure"))
+      .mockImplementationOnce(async () => {
+        retryDeletionStarted();
+        await deletionAllowed;
+      });
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async () => {
+      throw new Error("dispatch must not start during gateway shutdown");
     });
-    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
-      async ({ replyOptions }) => {
-        dispatchStarted();
-        await new Promise<void>((resolve) => {
-          replyOptions.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
-        });
-        return {};
-      },
-    );
     state.pollResponses = [{
       result: "success",
       events: [{ id: 1, type: "message", message: makeChannelMessage(1099) }],
     }];
 
     const monitorPromise = runMonitorOnce();
-    await dispatched;
+    await creating;
     const { clearActiveZulipMonitorReactionLifecycles } = await import("./monitor.js");
     let cleanupSettled = false;
     const cleanup = clearActiveZulipMonitorReactionLifecycles().then(() => {
       cleanupSettled = true;
     });
-    await deleting;
     await Promise.resolve();
     expect(cleanupSettled).toBe(false);
-    allowDeletion();
+    expect(state.deleteZulipMessage).not.toHaveBeenCalled();
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+
+    allowCreation();
+    await retryingDeletion;
+    expect(state.deleteZulipMessage).toHaveBeenCalledTimes(2);
+    expect(cleanupSettled).toBe(false);
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    allowRetryDeletion();
     await cleanup;
 
-    expect(state.deleteZulipMessage).toHaveBeenCalledWith(state.client, {
-      messageId: "outbound-1",
+    expect(state.deleteZulipMessage).toHaveBeenNthCalledWith(1, state.client, {
+      messageId: "pending-placeholder",
     });
+    expect(state.deleteZulipMessage).toHaveBeenNthCalledWith(2, state.client, {
+      messageId: "pending-placeholder",
+    });
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
     state.abortController?.abort();
     await monitorPromise;
   });

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -1174,18 +1174,24 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
 
     let replyDeliveryCommitted = false;
     let placeholderMessageId: string | undefined;
+    let placeholderRemovedForDelivery = false;
     let deliveredReply = false;
 
-    const deletePlaceholder = async () => {
+    const deletePlaceholder = async (forDelivery = false): Promise<boolean> => {
       const placeholderId = placeholderMessageId;
       if (!placeholderId) {
-        return;
+        return false;
       }
       try {
         await deleteZulipMessage(client, { messageId: placeholderId });
         placeholderMessageId = undefined;
+        if (forDelivery) {
+          placeholderRemovedForDelivery = true;
+        }
+        return true;
       } catch (err) {
         logVerboseMessage(`zulip: failed to delete thinking placeholder: ${String(err)}`);
+        return false;
       }
     };
 
@@ -1205,7 +1211,6 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         return true;
       } catch (err) {
         logVerboseMessage(`zulip: failed to replace thinking placeholder: ${String(err)}`);
-        await deletePlaceholder();
         return false;
       }
     };
@@ -1262,7 +1267,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
               continue;
             }
             if (first) {
-              await deletePlaceholder();
+              await deletePlaceholder(true);
             }
             await sendMessageZulip(to, chunk, {
               cfg,
@@ -1277,7 +1282,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
             first = false;
           }
         } else {
-          await deletePlaceholder();
+          await deletePlaceholder(true);
           let first = true;
           for (const mediaUrl of mediaUrls) {
             const isFirst = first;
@@ -1377,6 +1382,26 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         await deletePlaceholder();
       } else if (!(await replacePlaceholder(thinkingPlaceholderErrorText))) {
         await deletePlaceholder();
+      }
+    } else if (
+      dispatchError &&
+      !(dispatchError instanceof Error && dispatchError.name === "AbortError") &&
+      placeholderRemovedForDelivery
+    ) {
+      try {
+        await sendMessageZulip(to, thinkingPlaceholderErrorText, {
+          cfg,
+          accountId: account.accountId,
+          topic,
+        });
+        core.channel.activity.record({
+          channel: "zulip",
+          accountId: account.accountId,
+          direction: "outbound",
+        });
+        opts.statusSink?.({ lastOutboundAt: Date.now() });
+      } catch (err) {
+        logVerboseMessage(`zulip: failed to send thinking placeholder error: ${String(err)}`);
       }
     }
     if (terminalError) {

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -1064,6 +1064,56 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         logVerboseMessage(`zulip: failed to remove reaction ${reaction.emojiName}: ${String(err)}`);
       }
     };
+    let replyDeliveryCommitted = false;
+    let placeholderMessageId: string | undefined;
+    let placeholderCreationPromise: Promise<void> | undefined;
+    let placeholderRemovedForDelivery = false;
+    let deliveredReply = false;
+
+    const deletePlaceholder = async (forDelivery = false): Promise<boolean> => {
+      const placeholderId = placeholderMessageId;
+      if (!placeholderId) {
+        return false;
+      }
+      placeholderMessageId = undefined;
+      try {
+        await deleteZulipMessage(client, { messageId: placeholderId });
+        if (forDelivery) {
+          placeholderRemovedForDelivery = true;
+        }
+        return true;
+      } catch (err) {
+        placeholderMessageId ??= placeholderId;
+        logVerboseMessage(`zulip: failed to delete thinking placeholder: ${String(err)}`);
+        return false;
+      }
+    };
+
+    const replacePlaceholder = async (content: string): Promise<boolean> => {
+      const placeholderId = placeholderMessageId;
+      if (!placeholderId) {
+        return false;
+      }
+      placeholderMessageId = undefined;
+      try {
+        await editZulipMessage(client, { messageId: placeholderId, content });
+        core.channel.activity.record({
+          channel: "zulip",
+          accountId: account.accountId,
+          direction: "outbound",
+        });
+        return true;
+      } catch (err) {
+        placeholderMessageId ??= placeholderId;
+        logVerboseMessage(`zulip: failed to replace thinking placeholder: ${String(err)}`);
+        return false;
+      }
+    };
+
+    const cleanupPlaceholderLifecycle = async (): Promise<void> => {
+      await placeholderCreationPromise;
+      await deletePlaceholder();
+    };
     if (opts.abortSignal?.aborted || monitorReactionShutdownStarted) {
       return ABORTED_INBOUND_MESSAGE;
     }
@@ -1106,7 +1156,11 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
           terminalCleanupTimer = undefined;
         }
         activeReactionCleanups.delete(cancelReactionLifecycle);
-        await Promise.allSettled([statusReactions.clear(), subagentContext.cancel()]);
+        await Promise.allSettled([
+          statusReactions.clear(),
+          subagentContext.cancel(),
+          cleanupPlaceholderLifecycle(),
+        ]);
       })();
       return reactionLifecycleCleanup;
     };
@@ -1172,63 +1226,31 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       },
     });
 
-    let replyDeliveryCommitted = false;
-    let placeholderMessageId: string | undefined;
-    let placeholderRemovedForDelivery = false;
-    let deliveredReply = false;
-
-    const deletePlaceholder = async (forDelivery = false): Promise<boolean> => {
-      const placeholderId = placeholderMessageId;
-      if (!placeholderId) {
-        return false;
-      }
-      try {
-        await deleteZulipMessage(client, { messageId: placeholderId });
-        placeholderMessageId = undefined;
-        if (forDelivery) {
-          placeholderRemovedForDelivery = true;
+    if (
+      thinkingPlaceholderEnabled &&
+      !reactionLifecycleCancelled &&
+      !monitorReactionShutdownStarted &&
+      !opts.abortSignal?.aborted
+    ) {
+      placeholderCreationPromise = (async () => {
+        try {
+          const placeholder = await sendMessageZulip(to, thinkingPlaceholderText, {
+            cfg,
+            accountId: account.accountId,
+            topic,
+          });
+          if (placeholder.messageId !== "unknown") {
+            placeholderMessageId = placeholder.messageId;
+          } else {
+            logVerboseMessage("zulip: thinking placeholder send returned no message id");
+          }
+        } catch (err) {
+          logVerboseMessage(`zulip: failed to create thinking placeholder: ${String(err)}`);
         }
-        return true;
-      } catch (err) {
-        logVerboseMessage(`zulip: failed to delete thinking placeholder: ${String(err)}`);
-        return false;
-      }
-    };
-
-    const replacePlaceholder = async (content: string): Promise<boolean> => {
-      const placeholderId = placeholderMessageId;
-      if (!placeholderId) {
-        return false;
-      }
-      try {
-        await editZulipMessage(client, { messageId: placeholderId, content });
-        placeholderMessageId = undefined;
-        core.channel.activity.record({
-          channel: "zulip",
-          accountId: account.accountId,
-          direction: "outbound",
-        });
-        return true;
-      } catch (err) {
-        logVerboseMessage(`zulip: failed to replace thinking placeholder: ${String(err)}`);
-        return false;
-      }
-    };
-
-    if (thinkingPlaceholderEnabled) {
-      try {
-        const placeholder = await sendMessageZulip(to, thinkingPlaceholderText, {
-          cfg,
-          accountId: account.accountId,
-          topic,
-        });
-        if (placeholder.messageId !== "unknown") {
-          placeholderMessageId = placeholder.messageId;
-        } else {
-          logVerboseMessage("zulip: thinking placeholder send returned no message id");
-        }
-      } catch (err) {
-        logVerboseMessage(`zulip: failed to create thinking placeholder: ${String(err)}`);
+      })();
+      await placeholderCreationPromise;
+      if (reactionLifecycleCancelled || monitorReactionShutdownStarted || opts.abortSignal?.aborted) {
+        await deletePlaceholder();
       }
     }
     let deliveryError: unknown;
@@ -1386,13 +1408,18 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     }
     const finalDeliveryFailed = (dispatchResult?.failedCounts?.final ?? 0) > 0;
     const terminalError = Boolean(dispatchError) || finalDeliveryFailed;
-    const retryableNoDelivery = terminalError && !replyDeliveryCommitted;
     if (placeholderMessageId) {
       const cancelled = dispatchError instanceof Error && dispatchError.name === "AbortError";
       if (!terminalError || cancelled || deliveredReply) {
         await deletePlaceholder();
-      } else if (!(await replacePlaceholder(thinkingPlaceholderErrorText))) {
-        await deletePlaceholder();
+      } else {
+        const errorFeedbackCommitted = await replacePlaceholder(thinkingPlaceholderErrorText);
+        if (errorFeedbackCommitted) {
+          replyDeliveryCommitted = true;
+          opts.statusSink?.({ lastOutboundAt: Date.now() });
+        } else {
+          await deletePlaceholder();
+        }
       }
     } else if (
       dispatchError &&
@@ -1411,11 +1438,13 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
           accountId: account.accountId,
           direction: "outbound",
         });
+        replyDeliveryCommitted = true;
         opts.statusSink?.({ lastOutboundAt: Date.now() });
       } catch (err) {
         logVerboseMessage(`zulip: failed to send thinking placeholder error: ${String(err)}`);
       }
     }
+    const retryableNoDelivery = terminalError && !replyDeliveryCommitted;
     if (terminalError) {
       await statusReactions.setError();
     } else {

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -1067,52 +1067,99 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     let replyDeliveryCommitted = false;
     let placeholderMessageId: string | undefined;
     let placeholderCreationPromise: Promise<void> | undefined;
+    let placeholderDeletionPromise: Promise<boolean> | undefined;
+    let placeholderEditPromise: Promise<boolean> | undefined;
     let placeholderRemovedForDelivery = false;
     let deliveredReply = false;
 
     const deletePlaceholder = async (forDelivery = false): Promise<boolean> => {
+      await placeholderEditPromise;
+      const activeDeletion = placeholderDeletionPromise;
+      if (activeDeletion) {
+        const deleted = await activeDeletion;
+        if (deleted && forDelivery) {
+          placeholderRemovedForDelivery = true;
+        }
+        return deleted;
+      }
       const placeholderId = placeholderMessageId;
       if (!placeholderId) {
         return false;
       }
-      placeholderMessageId = undefined;
-      try {
-        await deleteZulipMessage(client, { messageId: placeholderId });
-        if (forDelivery) {
-          placeholderRemovedForDelivery = true;
+      const deletion = (async () => {
+        try {
+          await deleteZulipMessage(client, { messageId: placeholderId });
+          if (placeholderMessageId === placeholderId) {
+            placeholderMessageId = undefined;
+          }
+          return true;
+        } catch (err) {
+          logVerboseMessage(`zulip: failed to delete thinking placeholder: ${String(err)}`);
+          return false;
         }
-        return true;
-      } catch (err) {
-        placeholderMessageId ??= placeholderId;
-        logVerboseMessage(`zulip: failed to delete thinking placeholder: ${String(err)}`);
-        return false;
+      })();
+      placeholderDeletionPromise = deletion;
+      const deleted = await deletion;
+      if (placeholderDeletionPromise === deletion) {
+        placeholderDeletionPromise = undefined;
       }
+      if (deleted && forDelivery) {
+        placeholderRemovedForDelivery = true;
+      }
+      return deleted;
     };
 
     const replacePlaceholder = async (content: string): Promise<boolean> => {
+      const activeDeletion = placeholderDeletionPromise;
+      if (activeDeletion) {
+        await activeDeletion;
+        return false;
+      }
+      const activeEdit = placeholderEditPromise;
+      if (activeEdit) {
+        return await activeEdit;
+      }
       const placeholderId = placeholderMessageId;
       if (!placeholderId) {
         return false;
       }
-      placeholderMessageId = undefined;
-      try {
-        await editZulipMessage(client, { messageId: placeholderId, content });
-        core.channel.activity.record({
-          channel: "zulip",
-          accountId: account.accountId,
-          direction: "outbound",
-        });
-        return true;
-      } catch (err) {
-        placeholderMessageId ??= placeholderId;
-        logVerboseMessage(`zulip: failed to replace thinking placeholder: ${String(err)}`);
-        return false;
+      const edit = (async () => {
+        try {
+          await editZulipMessage(client, { messageId: placeholderId, content });
+          if (placeholderMessageId === placeholderId) {
+            placeholderMessageId = undefined;
+          }
+          core.channel.activity.record({
+            channel: "zulip",
+            accountId: account.accountId,
+            direction: "outbound",
+          });
+          return true;
+        } catch (err) {
+          logVerboseMessage(`zulip: failed to replace thinking placeholder: ${String(err)}`);
+          return false;
+        }
+      })();
+      placeholderEditPromise = edit;
+      const edited = await edit;
+      if (placeholderEditPromise === edit) {
+        placeholderEditPromise = undefined;
       }
+      return edited;
     };
 
     const cleanupPlaceholderLifecycle = async (): Promise<void> => {
       await placeholderCreationPromise;
-      await deletePlaceholder();
+      await placeholderEditPromise;
+      while (placeholderMessageId) {
+        if (await deletePlaceholder()) {
+          return;
+        }
+        if (!monitorReactionShutdownStarted) {
+          return;
+        }
+        await delay(100);
+      }
     };
     if (opts.abortSignal?.aborted || monitorReactionShutdownStarted) {
       return ABORTED_INBOUND_MESSAGE;
@@ -1250,7 +1297,9 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       })();
       await placeholderCreationPromise;
       if (reactionLifecycleCancelled || monitorReactionShutdownStarted || opts.abortSignal?.aborted) {
-        await deletePlaceholder();
+        await cancelReactionLifecycle();
+        opts.statusSink?.({ lastInboundAt: Date.now() });
+        return ABORTED_INBOUND_MESSAGE;
       }
     }
     let deliveryError: unknown;

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -1263,6 +1263,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
               resolvedTopic === topic &&
               (await replacePlaceholder(chunk));
             if (replacedPlaceholder) {
+              replyDeliveryCommitted = true;
               deliveredReply = true;
               deliveredThisPayload = true;
               first = false;
@@ -1387,7 +1388,8 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     const terminalError = Boolean(dispatchError) || finalDeliveryFailed;
     const retryableNoDelivery = terminalError && !replyDeliveryCommitted;
     if (placeholderMessageId) {
-      if (!terminalError || deliveredReply) {
+      const cancelled = dispatchError instanceof Error && dispatchError.name === "AbortError";
+      if (!terminalError || cancelled || deliveredReply) {
         await deletePlaceholder();
       } else if (!(await replacePlaceholder(thinkingPlaceholderErrorText))) {
         await deletePlaceholder();
@@ -1395,7 +1397,8 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     } else if (
       dispatchError &&
       !(dispatchError instanceof Error && dispatchError.name === "AbortError") &&
-      placeholderRemovedForDelivery
+      placeholderRemovedForDelivery &&
+      !deliveredReply
     ) {
       try {
         await sendMessageZulip(to, thinkingPlaceholderErrorText, {

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -33,6 +33,8 @@ import {
   sendZulipTyping,
   addZulipReaction,
   removeZulipReaction,
+  editZulipMessage,
+  deleteZulipMessage,
   type ZulipMessage,
   type ZulipStream,
   type ZulipSubscription,
@@ -486,6 +488,11 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     );
     return reactionCleanupChain;
   };
+  const thinkingPlaceholderConfig = account.config.thinkingPlaceholder;
+  const thinkingPlaceholderEnabled = thinkingPlaceholderConfig?.enabled === true;
+  const thinkingPlaceholderText = thinkingPlaceholderConfig?.text?.trim() || "Thinking…";
+  const thinkingPlaceholderErrorText =
+    thinkingPlaceholderConfig?.errorText?.trim() || "I couldn't complete that response.";
 
   const pairing = createChannelPairingController({
     core,
@@ -1166,6 +1173,59 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     });
 
     let replyDeliveryCommitted = false;
+    let placeholderMessageId: string | undefined;
+    let deliveredReply = false;
+
+    const deletePlaceholder = async () => {
+      const placeholderId = placeholderMessageId;
+      if (!placeholderId) {
+        return;
+      }
+      try {
+        await deleteZulipMessage(client, { messageId: placeholderId });
+        placeholderMessageId = undefined;
+      } catch (err) {
+        logVerboseMessage(`zulip: failed to delete thinking placeholder: ${String(err)}`);
+      }
+    };
+
+    const replacePlaceholder = async (content: string): Promise<boolean> => {
+      const placeholderId = placeholderMessageId;
+      if (!placeholderId) {
+        return false;
+      }
+      try {
+        await editZulipMessage(client, { messageId: placeholderId, content });
+        placeholderMessageId = undefined;
+        core.channel.activity.record({
+          channel: "zulip",
+          accountId: account.accountId,
+          direction: "outbound",
+        });
+        return true;
+      } catch (err) {
+        logVerboseMessage(`zulip: failed to replace thinking placeholder: ${String(err)}`);
+        await deletePlaceholder();
+        return false;
+      }
+    };
+
+    if (thinkingPlaceholderEnabled) {
+      try {
+        const placeholder = await sendMessageZulip(to, thinkingPlaceholderText, {
+          cfg,
+          accountId: account.accountId,
+          topic,
+        });
+        if (placeholder.messageId !== "unknown") {
+          placeholderMessageId = placeholder.messageId;
+        } else {
+          logVerboseMessage("zulip: thinking placeholder send returned no message id");
+        }
+      } catch (err) {
+        logVerboseMessage(`zulip: failed to create thinking placeholder: ${String(err)}`);
+      }
+    }
     const dispatcherOptions = {
       ...prefixOptions,
       humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
@@ -1175,6 +1235,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       },
       onIdle: typingCallbacks.onIdle,
       deliver: async (payload: ReplyPayload) => {
+        let deliveredThisPayload = false;
         const mediaUrls = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
         const hasOutboundMetadata = Boolean(payload.presentation || payload.channelData);
         const rawText = core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode);
@@ -1188,6 +1249,21 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
             if (!chunk && !(first && hasOutboundMetadata)) {
               continue;
             }
+            const replacedPlaceholder =
+              first &&
+              chunk &&
+              !hasOutboundMetadata &&
+              resolvedTopic === topic &&
+              (await replacePlaceholder(chunk));
+            if (replacedPlaceholder) {
+              deliveredReply = true;
+              deliveredThisPayload = true;
+              first = false;
+              continue;
+            }
+            if (first) {
+              await deletePlaceholder();
+            }
             await sendMessageZulip(to, chunk, {
               cfg,
               accountId: account.accountId,
@@ -1196,9 +1272,12 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
               channelData: first ? payload.channelData : undefined,
             });
             replyDeliveryCommitted = true;
+            deliveredReply = true;
+            deliveredThisPayload = true;
             first = false;
           }
         } else {
+          await deletePlaceholder();
           let first = true;
           for (const mediaUrl of mediaUrls) {
             const isFirst = first;
@@ -1212,10 +1291,14 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
               channelData: isFirst ? payload.channelData : undefined,
             });
             replyDeliveryCommitted = true;
+            deliveredReply = true;
+            deliveredThisPayload = true;
             first = false;
           }
         }
-        opts.statusSink?.({ lastOutboundAt: Date.now() });
+        if (deliveredThisPayload) {
+          opts.statusSink?.({ lastOutboundAt: Date.now() });
+        }
       },
       onError: (err: unknown) => {
         runtime.error?.(`zulip reply failed: ${String(err)}`);
@@ -1273,6 +1356,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       replyDeliveryCommitted ? undefined : ABORTED_INBOUND_MESSAGE;
 
     if (reactionLifecycleCancelled || opts.abortSignal?.aborted) {
+      await deletePlaceholder();
       await cancelReactionLifecycle();
       opts.statusSink?.({ lastInboundAt: Date.now() });
       return abortOutcome();
@@ -1280,6 +1364,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
 
     await subagentContext.finish();
     if (reactionLifecycleCancelled || opts.abortSignal?.aborted) {
+      await deletePlaceholder();
       await cancelReactionLifecycle();
       opts.statusSink?.({ lastInboundAt: Date.now() });
       return abortOutcome();
@@ -1287,12 +1372,20 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     const finalDeliveryFailed = (dispatchResult?.failedCounts?.final ?? 0) > 0;
     const terminalError = Boolean(dispatchError) || finalDeliveryFailed;
     const retryableNoDelivery = terminalError && !replyDeliveryCommitted;
+    if (placeholderMessageId) {
+      if (!terminalError || deliveredReply) {
+        await deletePlaceholder();
+      } else if (!(await replacePlaceholder(thinkingPlaceholderErrorText))) {
+        await deletePlaceholder();
+      }
+    }
     if (terminalError) {
       await statusReactions.setError();
     } else {
       await statusReactions.setDone();
     }
     if (reactionLifecycleCancelled || opts.abortSignal?.aborted) {
+      await deletePlaceholder();
       await cancelReactionLifecycle();
       opts.statusSink?.({ lastInboundAt: Date.now() });
       return abortOutcome();

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -1231,6 +1231,8 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         logVerboseMessage(`zulip: failed to create thinking placeholder: ${String(err)}`);
       }
     }
+    let deliveryError: unknown;
+    let hasDeliveryError = false;
     const dispatcherOptions = {
       ...prefixOptions,
       humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
@@ -1306,6 +1308,10 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         }
       },
       onError: (err: unknown) => {
+        if (!hasDeliveryError) {
+          deliveryError = err;
+          hasDeliveryError = true;
+        }
         runtime.error?.(`zulip reply failed: ${String(err)}`);
       },
     };
@@ -1350,6 +1356,9 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     } catch (err) {
       dispatchError = err;
       runtime.error?.(`zulip reply failed: ${String(err)}`);
+    }
+    if (dispatchError === undefined && hasDeliveryError) {
+      dispatchError = deliveryError;
     }
 
     const successfulReplyCount =

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -81,6 +81,8 @@ export type MonitorZulipOpts = {
 const RECENT_MESSAGE_TTL_MS = 5 * 60_000;
 const RECENT_MESSAGE_MAX = 2000;
 const DEFAULT_ONCHAR_PREFIXES = [">", "!"];
+const PLACEHOLDER_DELETE_MAX_ATTEMPTS = 3;
+const PLACEHOLDER_DELETE_RETRY_MS = 50;
 /** Empty string = Zulip's "general chat" (no topic). */
 const FALLBACK_TOPIC = "";
 
@@ -1151,14 +1153,22 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     const cleanupPlaceholderLifecycle = async (): Promise<void> => {
       await placeholderCreationPromise;
       await placeholderEditPromise;
-      while (placeholderMessageId) {
+      for (
+        let attempt = 1;
+        placeholderMessageId && attempt <= PLACEHOLDER_DELETE_MAX_ATTEMPTS;
+        attempt += 1
+      ) {
         if (await deletePlaceholder()) {
           return;
         }
-        if (!monitorReactionShutdownStarted) {
-          return;
+        if (attempt < PLACEHOLDER_DELETE_MAX_ATTEMPTS) {
+          await delay(PLACEHOLDER_DELETE_RETRY_MS);
         }
-        await delay(100);
+      }
+      if (placeholderMessageId) {
+        runtime.error?.(
+          `zulip: thinking placeholder cleanup failed after ${PLACEHOLDER_DELETE_MAX_ATTEMPTS} attempts`,
+        );
       }
     };
     if (opts.abortSignal?.aborted || monitorReactionShutdownStarted) {
@@ -1190,7 +1200,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     let statusLifecycleSettled = false;
     let subagentLifecycleSettled = false;
     const releaseReactionCleanupIfSettled = () => {
-      if (statusLifecycleSettled && subagentLifecycleSettled) {
+      if (statusLifecycleSettled && subagentLifecycleSettled && !placeholderMessageId) {
         activeReactionCleanups.delete(cancelReactionLifecycle);
       }
     };


### PR DESCRIPTION
Closes #22.

Adds an opt-in edit-in-place Thinking placeholder lifecycle for accepted Zulip turns. Text replies replace the placeholder, while media/presentation-only and silent/cancelled turns clean it up. Failures convert it to configurable error text, with defensive fallbacks when create/edit/delete operations fail.

Verification:

- `pnpm build`
- `pnpm test` (162 tests)
- `git diff --check origin/main...HEAD`
- Independent cross-family review: approved with no blocking findings

Live Zulip smoke testing will be coordinated separately before enabling or releasing the feature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core outbound reply flow in `monitor.ts` (send/edit/delete ordering, delivery commit, and durable inbound completion), so regressions could affect visible replies or retry behavior even though the feature is off by default.
> 
> **Overview**
> Adds an **opt-in** `thinkingPlaceholder` account setting (`enabled`, `text`, `errorText`) so the Zulip monitor can post a short “thinking” message and update it in place while a turn runs.
> 
> When enabled, the monitor sends the placeholder before dispatch, then **edits** it to the first plain-text chunk (further chunks are new messages). **Media**, **presentation-only**, and **topic-override** replies **delete** the placeholder first; **silent** and **cancelled** turns delete it without counting as outbound delivery. **Failures** before any reply either edit the placeholder to `errorText` or, after cleanup, send that text as a fallback—without duplicating errors after partial delivery.
> 
> Placeholder teardown is wired into reaction lifecycle cleanup (abort, gateway stop) with **retried deletes** and bounded failure logging. Config schema/types and README document the feature; monitor tests cover the main paths and durable-journal completion for error feedback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1270dc5e5cc52dec3c774394036d25e224f004eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->