### PR TITLE
feat: add truthful Zulip lifecycle reactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2026.5.26
 
 ### Features
+- **Truthful lifecycle reactions**: Replace coarse start/success/error hooks with SDK-backed queued, thinking, tool-category, compaction, stall, done, and error states, plus exact-run subagent activity tracking that safely handles concurrent children and overlapping requester turns.
 - **Outbound route hook**: Add native Zulip outbound session routing for DMs and stream topics, preserving raw Zulip topics over sanitized session ids.
 - **Durable inbound receive journal**: Add optional keyed-state journaling with bounded pending/completed stores and replay-before-poll behavior when trusted plugin state is available.
 - **Message reactions**: Add `message(action="react")` support for Zulip add/remove reactions, dry-run handling, current-message defaults, idempotent add/remove behavior, and common emoji normalization.

--- a/README.md
+++ b/README.md
@@ -137,10 +137,22 @@ Add the plugin id to `plugins.allow` in `~/.openclaw/openclaw.json`:
       // Group policy: "open" | "allowlist" | "disabled"
       "groupPolicy": "open",
 
-      // Optional reaction hooks (defaults no longer add start/success emoji spam)
+      // Truthful lifecycle reactions on the inbound message. The defaults show
+      // queued, thinking, tool category, compaction, stalls, done/error, and
+      // a separate robot while one or more spawned children are active.
       "reactions": {
-        "enabled": false,
-        "onError": "warning"
+        "enabled": true,
+        "clearOnFinish": true,
+        "subagent": "robot_face",
+        "timing": {
+          "stallSoftMs": 10000,
+          "stallHardMs": 30000
+        },
+        "emojis": {
+          "thinking": "brain",
+          "coding": "computer",
+          "web": "globe_with_meridians"
+        }
       },
 
       // Model-controlled reaction prompt guidance: "off" | "minimal" | "extensive"
@@ -172,6 +184,24 @@ Then restart the Gateway:
 ```sh
 openclaw gateway restart
 ```
+
+### Lifecycle reactions
+
+When `channels.zulip.reactions.enabled` is not `false`, the plugin uses OpenClaw's
+public status-reaction controller. Reactions reflect actual queued, reasoning,
+tool-category, compaction, stall, done, and error events; native Zulip typing
+continues independently and no placeholder message is posted. `clearOnFinish`
+defaults to `true`, so the terminal reaction is removed after its configured
+hold. Set it to `false` to retain the final done/error reaction.
+
+The dedicated `subagent` reaction is driven only by `subagent_spawned` and
+`subagent_ended` hooks. It remains while at least one child run bound to that
+exact inbound turn is active, including concurrent children and children that
+outlive the requester's reply. The default is `robot_face`. Built-in lifecycle
+Unicode values and named Zulip emoji are supported. Account-level
+`reactions.emojis` and `reactions.timing` override global
+`messages.statusReactions` values. The legacy `onStart`, `onSuccess`, and
+`onError` keys remain accepted as queued, done, and error aliases.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,11 @@ Unicode values and named Zulip emoji are supported. Account-level
 `messages.statusReactions` values. The legacy `onStart`, `onSuccess`, and
 `onError` keys remain accepted as queued, done, and error aliases.
 
+This subagent indicator covers children launched through OpenClaw's
+`sessions_spawn` lifecycle, which emits the public hooks above. Codex-native
+collaboration tasks do not currently expose that lifecycle through OpenClaw's
+public plugin hooks, so they cannot truthfully drive this indicator.
+
 ---
 
 ## How to get a Zulip API key

--- a/README.md
+++ b/README.md
@@ -198,10 +198,14 @@ The dedicated `subagent` reaction is driven only by `subagent_spawned` and
 `subagent_ended` hooks. It remains while at least one child run bound to that
 exact inbound turn is active, including concurrent children and children that
 outlive the requester's reply. The default is `robot_face`. Built-in lifecycle
-Unicode values and named Zulip emoji are supported. Account-level
+Unicode values (`👀`, `🧠`, `🛠️`, `💻`, `🌐`, `🛫`, `🏗️`, `💁`, `✅`, `❌`,
+`⏳`, `⚠️`, `🗜️`, and `🤖`) and named Zulip emoji are supported; arbitrary
+Unicode is rejected because Zulip requires exact reaction metadata. An empty
+string suppresses that state. Account-level
 `reactions.emojis` and `reactions.timing` override global
 `messages.statusReactions` values. The legacy `onStart`, `onSuccess`, and
-`onError` keys remain accepted as queued, done, and error aliases.
+`onError` keys remain accepted as queued, done, and error aliases, and an
+explicit empty legacy value suppresses its state.
 
 This subagent indicator covers children launched through OpenClaw's
 `sessions_spawn` lifecycle, which emits the public hooks above. Codex-native

--- a/index.ts
+++ b/index.ts
@@ -2,6 +2,7 @@ import { defineChannelPluginEntry } from "openclaw/plugin-sdk/core";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import { zulipPlugin } from "./src/channel.js";
 import { setZulipRuntime } from "./src/runtime.js";
+import { registerZulipSubagentReactionHooks } from "./src/zulip/subagent-reactions.js";
 import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 
@@ -45,8 +46,9 @@ const entry: {
   setRuntime(runtime) {
     setZulipRuntime(runtime);
   },
-  registerFull(_api) {
+  registerFull(api) {
     loadZulipEnv();
+    registerZulipSubagentReactionHooks(api);
   },
 });
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -32,7 +32,7 @@
             "anyOf": [
               {
                 "type": "string",
-                "pattern": "^(?:[A-Za-z0-9][A-Za-z0-9_+-]*|:[A-Za-z0-9][A-Za-z0-9_+-]*:)$"
+                "pattern": "^(?:(?:[A-Za-z0-9][A-Za-z0-9_+-]*|[+-][A-Za-z0-9][A-Za-z0-9_+-]*)|:(?:[A-Za-z0-9][A-Za-z0-9_+-]*|[+-][A-Za-z0-9][A-Za-z0-9_+-]*):)$"
               },
               {
                 "type": "string",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -28,23 +28,35 @@
           "secretInput": {
             "anyOf": [{ "type": "string" }, { "$ref": "#/$defs/secretRef" }]
           },
+          "zulipReactionEmoji": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?:[A-Za-z0-9][A-Za-z0-9_+-]*|:[A-Za-z0-9][A-Za-z0-9_+-]*:)$"
+              },
+              {
+                "type": "string",
+                "enum": ["", "👀", "🧠", "🛠", "🛠️", "💻", "🌐", "🛫", "🏗", "🏗️", "💁", "✅", "❌", "⏳", "⚠", "⚠️", "🗜", "🗜️", "🤖"]
+              }
+            ]
+          },
           "statusReactionEmojis": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-              "queued": { "type": "string" },
-              "thinking": { "type": "string" },
-              "tool": { "type": "string" },
-              "coding": { "type": "string" },
-              "web": { "type": "string" },
-              "deploy": { "type": "string" },
-              "build": { "type": "string" },
-              "concierge": { "type": "string" },
-              "done": { "type": "string" },
-              "error": { "type": "string" },
-              "stallSoft": { "type": "string" },
-              "stallHard": { "type": "string" },
-              "compacting": { "type": "string" }
+              "queued": { "$ref": "#/$defs/zulipReactionEmoji" },
+              "thinking": { "$ref": "#/$defs/zulipReactionEmoji" },
+              "tool": { "$ref": "#/$defs/zulipReactionEmoji" },
+              "coding": { "$ref": "#/$defs/zulipReactionEmoji" },
+              "web": { "$ref": "#/$defs/zulipReactionEmoji" },
+              "deploy": { "$ref": "#/$defs/zulipReactionEmoji" },
+              "build": { "$ref": "#/$defs/zulipReactionEmoji" },
+              "concierge": { "$ref": "#/$defs/zulipReactionEmoji" },
+              "done": { "$ref": "#/$defs/zulipReactionEmoji" },
+              "error": { "$ref": "#/$defs/zulipReactionEmoji" },
+              "stallSoft": { "$ref": "#/$defs/zulipReactionEmoji" },
+              "stallHard": { "$ref": "#/$defs/zulipReactionEmoji" },
+              "compacting": { "$ref": "#/$defs/zulipReactionEmoji" }
             }
           },
           "statusReactionTiming": {
@@ -100,12 +112,12 @@
                 "properties": {
                   "enabled": { "type": "boolean" },
                   "clearOnFinish": { "type": "boolean" },
-                  "onStart": { "type": "string" },
-                  "onSuccess": { "type": "string" },
-                  "onError": { "type": "string" },
+                  "onStart": { "$ref": "#/$defs/zulipReactionEmoji" },
+                  "onSuccess": { "$ref": "#/$defs/zulipReactionEmoji" },
+                  "onError": { "$ref": "#/$defs/zulipReactionEmoji" },
                   "emojis": { "$ref": "#/$defs/statusReactionEmojis" },
                   "timing": { "$ref": "#/$defs/statusReactionTiming" },
-                  "subagent": { "type": "string" }
+                  "subagent": { "$ref": "#/$defs/zulipReactionEmoji" }
                 }
               },
               "agentReactionGuidance": { "type": "string", "enum": ["off", "minimal", "extensive"] },
@@ -166,12 +178,12 @@
             "properties": {
               "enabled": { "type": "boolean" },
               "clearOnFinish": { "type": "boolean" },
-              "onStart": { "type": "string" },
-              "onSuccess": { "type": "string" },
-              "onError": { "type": "string" },
+              "onStart": { "$ref": "#/$defs/zulipReactionEmoji" },
+              "onSuccess": { "$ref": "#/$defs/zulipReactionEmoji" },
+              "onError": { "$ref": "#/$defs/zulipReactionEmoji" },
               "emojis": { "$ref": "#/$defs/statusReactionEmojis" },
               "timing": { "$ref": "#/$defs/statusReactionTiming" },
-              "subagent": { "type": "string" }
+              "subagent": { "$ref": "#/$defs/zulipReactionEmoji" }
             }
           },
           "agentReactionGuidance": { "type": "string", "enum": ["off", "minimal", "extensive"] },

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -28,6 +28,36 @@
           "secretInput": {
             "anyOf": [{ "type": "string" }, { "$ref": "#/$defs/secretRef" }]
           },
+          "statusReactionEmojis": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "queued": { "type": "string" },
+              "thinking": { "type": "string" },
+              "tool": { "type": "string" },
+              "coding": { "type": "string" },
+              "web": { "type": "string" },
+              "deploy": { "type": "string" },
+              "build": { "type": "string" },
+              "concierge": { "type": "string" },
+              "done": { "type": "string" },
+              "error": { "type": "string" },
+              "stallSoft": { "type": "string" },
+              "stallHard": { "type": "string" },
+              "compacting": { "type": "string" }
+            }
+          },
+          "statusReactionTiming": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "debounceMs": { "type": "integer", "minimum": 0 },
+              "stallSoftMs": { "type": "integer", "minimum": 0 },
+              "stallHardMs": { "type": "integer", "minimum": 0 },
+              "doneHoldMs": { "type": "integer", "minimum": 0 },
+              "errorHoldMs": { "type": "integer", "minimum": 0 }
+            }
+          },
           "zulipAccount": {
             "type": "object",
             "additionalProperties": true,
@@ -72,7 +102,10 @@
                   "clearOnFinish": { "type": "boolean" },
                   "onStart": { "type": "string" },
                   "onSuccess": { "type": "string" },
-                  "onError": { "type": "string" }
+                  "onError": { "type": "string" },
+                  "emojis": { "$ref": "#/$defs/statusReactionEmojis" },
+                  "timing": { "$ref": "#/$defs/statusReactionTiming" },
+                  "subagent": { "type": "string" }
                 }
               },
               "agentReactionGuidance": { "type": "string", "enum": ["off", "minimal", "extensive"] },
@@ -135,7 +168,10 @@
               "clearOnFinish": { "type": "boolean" },
               "onStart": { "type": "string" },
               "onSuccess": { "type": "string" },
-              "onError": { "type": "string" }
+              "onError": { "type": "string" },
+              "emojis": { "$ref": "#/$defs/statusReactionEmojis" },
+              "timing": { "$ref": "#/$defs/statusReactionTiming" },
+              "subagent": { "type": "string" }
             }
           },
           "agentReactionGuidance": { "type": "string", "enum": ["off", "minimal", "extensive"] },
@@ -198,7 +234,11 @@
           "label": "Require @mention in Streams"
         },
         "reactions.enabled": {
-          "label": "Reaction Indicators"
+          "label": "Lifecycle Reaction Indicators"
+        },
+        "reactions.subagent": {
+          "label": "Active Subagent Reaction",
+          "placeholder": "robot_face"
         },
         "agentReactionGuidance": {
           "label": "Agent Reaction Guidance",
@@ -246,7 +286,11 @@
       "label": "Require @mention in Streams"
     },
     "reactions.enabled": {
-      "label": "Reaction Indicators"
+      "label": "Lifecycle Reaction Indicators"
+    },
+    "reactions.subagent": {
+      "label": "Active Subagent Reaction",
+      "placeholder": "robot_face"
     },
     "agentReactionGuidance": {
       "label": "Agent Reaction Guidance",

--- a/src/config-schema.test.ts
+++ b/src/config-schema.test.ts
@@ -16,6 +16,33 @@ describe("Zulip lifecycle reaction config", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts named emoji, built-in Unicode mappings, and explicit suppression", () => {
+    const result = zulipChannelConfigSchema.runtime.safeParse({
+      reactions: {
+        onStart: "",
+        onSuccess: "✅",
+        onError: ":warning:",
+        emojis: { thinking: "🧠", done: "" },
+        subagent: "🤖",
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects arbitrary Unicode reaction values", () => {
+    expect(
+      zulipChannelConfigSchema.runtime.safeParse({
+        reactions: { emojis: { thinking: "🦄" } },
+      }).success,
+    ).toBe(false);
+    expect(
+      zulipChannelConfigSchema.runtime.safeParse({
+        reactions: { subagent: "🦄" },
+      }).success,
+    ).toBe(false);
+  });
+
   it("rejects unknown lifecycle reaction keys", () => {
     const result = zulipChannelConfigSchema.runtime.safeParse({
       reactions: { frozenPlaceholder: true },

--- a/src/config-schema.test.ts
+++ b/src/config-schema.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import { describe, expect, it } from "vitest";
 import { zulipChannelConfigSchema } from "./config-schema.js";
 
@@ -28,6 +29,60 @@ describe("Zulip lifecycle reaction config", () => {
     });
 
     expect(result.success).toBe(true);
+  });
+
+  it.each(["+1", "-1", ":+1:", ":-1:"])(
+    "accepts leading-sign named emoji %s",
+    (emoji) => {
+      expect(
+        zulipChannelConfigSchema.runtime.safeParse({
+          reactions: { onStart: emoji, emojis: { thinking: emoji }, subagent: emoji },
+        }).success,
+      ).toBe(true);
+    },
+  );
+
+  it.each(["+", "-", ":+:", ":-:", ":+1", "+1:", "white space"])(
+    "rejects invalid named emoji %s",
+    (emoji) => {
+      expect(
+        zulipChannelConfigSchema.runtime.safeParse({
+          reactions: { onStart: emoji },
+        }).success,
+      ).toBe(false);
+    },
+  );
+
+  it("keeps manifest named-emoji validation aligned with runtime validation", () => {
+    const manifest = JSON.parse(
+      fs.readFileSync(new URL("../openclaw.plugin.json", import.meta.url), "utf8"),
+    ) as {
+      channelConfigs: {
+        zulip: {
+          schema: {
+            $defs: {
+              zulipReactionEmoji: {
+                anyOf: Array<{ pattern?: string; enum?: string[] }>;
+              };
+            };
+          };
+        };
+      };
+    };
+    const variants = manifest.channelConfigs.zulip.schema.$defs.zulipReactionEmoji.anyOf;
+    const accepts = (value: string) =>
+      variants.some(
+        (variant) =>
+          variant.enum?.includes(value) ||
+          (variant.pattern !== undefined && new RegExp(variant.pattern).test(value)),
+      );
+
+    for (const value of ["+1", "-1", ":+1:", ":-1:"]) {
+      expect(accepts(value)).toBe(true);
+    }
+    for (const value of ["+", "-", ":+:", ":-:", ":+1", "+1:", "white space", "🦄"]) {
+      expect(accepts(value)).toBe(false);
+    }
   });
 
   it("rejects arbitrary Unicode reaction values", () => {

--- a/src/config-schema.test.ts
+++ b/src/config-schema.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { zulipChannelConfigSchema } from "./config-schema.js";
+
+describe("Zulip lifecycle reaction config", () => {
+  it("accepts lifecycle emoji, timing, and subagent overrides", () => {
+    const result = zulipChannelConfigSchema.runtime.safeParse({
+      reactions: {
+        enabled: true,
+        clearOnFinish: true,
+        emojis: { thinking: "brain", coding: "computer" },
+        timing: { debounceMs: 25, stallSoftMs: 10_000, stallHardMs: 30_000 },
+        subagent: "robot_face",
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects unknown lifecycle reaction keys", () => {
+    const result = zulipChannelConfigSchema.runtime.safeParse({
+      reactions: { frozenPlaceholder: true },
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { buildJsonChannelConfigSchema } from "openclaw/plugin-sdk/channel-config-schema";
 import { buildOptionalSecretInputSchema } from "openclaw/plugin-sdk/secret-input";
+import { isSupportedZulipReactionValue } from "./zulip/status-reactions.js";
 
 // Inlined from openclaw/plugin-sdk to avoid module resolution issues
 // when installed via npm to ~/.openclaw/extensions/. These are stable
@@ -21,21 +22,24 @@ const BlockStreamingCoalesceSchema = z
 
 const MarkdownTableModeSchema = z.enum(["native", "codeblock", "disabled"]);
 const AgentReactionGuidanceSchema = z.enum(["off", "minimal", "extensive"]);
+const ZulipReactionEmojiSchema = z.string().refine(isSupportedZulipReactionValue, {
+  message: "Use a named Zulip emoji, an explicitly supported built-in Unicode value, or empty string",
+});
 const StatusReactionEmojisSchema = z
   .object({
-    queued: z.string().optional(),
-    thinking: z.string().optional(),
-    tool: z.string().optional(),
-    coding: z.string().optional(),
-    web: z.string().optional(),
-    deploy: z.string().optional(),
-    build: z.string().optional(),
-    concierge: z.string().optional(),
-    done: z.string().optional(),
-    error: z.string().optional(),
-    stallSoft: z.string().optional(),
-    stallHard: z.string().optional(),
-    compacting: z.string().optional(),
+    queued: ZulipReactionEmojiSchema.optional(),
+    thinking: ZulipReactionEmojiSchema.optional(),
+    tool: ZulipReactionEmojiSchema.optional(),
+    coding: ZulipReactionEmojiSchema.optional(),
+    web: ZulipReactionEmojiSchema.optional(),
+    deploy: ZulipReactionEmojiSchema.optional(),
+    build: ZulipReactionEmojiSchema.optional(),
+    concierge: ZulipReactionEmojiSchema.optional(),
+    done: ZulipReactionEmojiSchema.optional(),
+    error: ZulipReactionEmojiSchema.optional(),
+    stallSoft: ZulipReactionEmojiSchema.optional(),
+    stallHard: ZulipReactionEmojiSchema.optional(),
+    compacting: ZulipReactionEmojiSchema.optional(),
   })
   .strict();
 const StatusReactionTimingSchema = z
@@ -110,12 +114,12 @@ const ZulipAccountSchemaBase = z
       .object({
         enabled: z.boolean().optional(),
         clearOnFinish: z.boolean().optional(),
-        onStart: z.string().optional(),
-        onSuccess: z.string().optional(),
-        onError: z.string().optional(),
+        onStart: ZulipReactionEmojiSchema.optional(),
+        onSuccess: ZulipReactionEmojiSchema.optional(),
+        onError: ZulipReactionEmojiSchema.optional(),
         emojis: StatusReactionEmojisSchema.optional(),
         timing: StatusReactionTimingSchema.optional(),
-        subagent: z.string().optional(),
+        subagent: ZulipReactionEmojiSchema.optional(),
       })
       .strict()
       .optional(),

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -21,6 +21,32 @@ const BlockStreamingCoalesceSchema = z
 
 const MarkdownTableModeSchema = z.enum(["native", "codeblock", "disabled"]);
 const AgentReactionGuidanceSchema = z.enum(["off", "minimal", "extensive"]);
+const StatusReactionEmojisSchema = z
+  .object({
+    queued: z.string().optional(),
+    thinking: z.string().optional(),
+    tool: z.string().optional(),
+    coding: z.string().optional(),
+    web: z.string().optional(),
+    deploy: z.string().optional(),
+    build: z.string().optional(),
+    concierge: z.string().optional(),
+    done: z.string().optional(),
+    error: z.string().optional(),
+    stallSoft: z.string().optional(),
+    stallHard: z.string().optional(),
+    compacting: z.string().optional(),
+  })
+  .strict();
+const StatusReactionTimingSchema = z
+  .object({
+    debounceMs: z.number().int().nonnegative().optional(),
+    stallSoftMs: z.number().int().nonnegative().optional(),
+    stallHardMs: z.number().int().nonnegative().optional(),
+    doneHoldMs: z.number().int().nonnegative().optional(),
+    errorHoldMs: z.number().int().nonnegative().optional(),
+  })
+  .strict();
 
 const OptionalSecretInputSchema = buildOptionalSecretInputSchema();
 
@@ -87,7 +113,11 @@ const ZulipAccountSchemaBase = z
         onStart: z.string().optional(),
         onSuccess: z.string().optional(),
         onError: z.string().optional(),
+        emojis: StatusReactionEmojisSchema.optional(),
+        timing: StatusReactionTimingSchema.optional(),
+        subagent: z.string().optional(),
       })
+      .strict()
       .optional(),
     agentReactionGuidance: AgentReactionGuidanceSchema.optional(),
     textChunkLimit: z.number().int().positive().optional(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,9 @@
 import type { ChannelSetupInput, DmPolicy, GroupPolicy } from "./sdk.js";
 import type { SecretInput } from "openclaw/plugin-sdk/secret-input";
+import type {
+  StatusReactionEmojis,
+  StatusReactionTiming,
+} from "openclaw/plugin-sdk/channel-feedback";
 
 export type ZulipSetupInput = ChannelSetupInput & {
   apiKey?: string;
@@ -67,13 +71,22 @@ export type ZulipAccountConfig = {
   groupPolicy?: GroupPolicy;
   /** Inbound media max size (MB). Default: 5. */
   mediaMaxMb?: number;
-  /** Optional reaction hooks. Defaults no longer add start/success reactions. */
+  /** Automatic lifecycle reactions on the inbound Zulip message. */
   reactions?: {
     enabled?: boolean;
     clearOnFinish?: boolean;
+    /** Legacy queued-state override. */
     onStart?: string;
+    /** Legacy done-state override. */
     onSuccess?: string;
+    /** Legacy error-state override. */
     onError?: string;
+    /** Lifecycle emoji overrides. Named Zulip emoji or Unicode are accepted. */
+    emojis?: StatusReactionEmojis;
+    /** Debounce, stall, and terminal timing overrides. */
+    timing?: StatusReactionTiming;
+    /** Dedicated indicator while one or more spawned children are active. */
+    subagent?: string;
   };
   /** Model prompt guidance for agent-controlled reactions. Does not enable automatic status reactions. Default: "minimal". */
   agentReactionGuidance?: ZulipAgentReactionGuidance;

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,17 +75,17 @@ export type ZulipAccountConfig = {
   reactions?: {
     enabled?: boolean;
     clearOnFinish?: boolean;
-    /** Legacy queued-state override. */
+    /** Legacy queued-state override. Empty string suppresses the state. */
     onStart?: string;
-    /** Legacy done-state override. */
+    /** Legacy done-state override. Empty string suppresses the state. */
     onSuccess?: string;
-    /** Legacy error-state override. */
+    /** Legacy error-state override. Empty string suppresses the state. */
     onError?: string;
-    /** Lifecycle emoji overrides. Named Zulip emoji or Unicode are accepted. */
+    /** Lifecycle overrides. Accepts named Zulip emoji, empty string, or supported built-in Unicode values. */
     emojis?: StatusReactionEmojis;
     /** Debounce, stall, and terminal timing overrides. */
     timing?: StatusReactionTiming;
-    /** Dedicated indicator while one or more spawned children are active. */
+    /** Dedicated indicator while spawned children are active. Empty string suppresses it. */
     subagent?: string;
   };
   /** Model prompt guidance for agent-controlled reactions. Does not enable automatic status reactions. Default: "minimal". */

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -454,6 +454,9 @@ describe("monitorZulipProvider", () => {
 
     await runMonitorOnce();
 
+    expect(
+      state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher,
+    ).toHaveBeenCalledTimes(1);
     expect(state.addZulipReaction).toHaveBeenCalledWith(
       state.client,
       expect.objectContaining({ messageId: "1097", emojiName: "cross_mark" }),
@@ -474,6 +477,9 @@ describe("monitorZulipProvider", () => {
 
     await runMonitorOnce();
 
+    expect(
+      state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher,
+    ).toHaveBeenCalledTimes(1);
     expect(state.addZulipReaction).toHaveBeenCalledWith(
       state.client,
       expect.objectContaining({ messageId: "1095", emojiName: "cross_mark" }),
@@ -1192,6 +1198,114 @@ describe("monitorZulipProvider", () => {
       metadata: { queueEventId: 2 },
     });
     expect(state.core.channel.inbound.buildContext).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { failureMode: "dispatcher rejection", messageId: 2108 },
+    { failureMode: "failed final result", messageId: 2109 },
+  ])(
+    "keeps durable inbound retryable after $failureMode with no visible delivery",
+    async ({ failureMode, messageId }) => {
+      enableDurableInboundJournal();
+      state.account.config.reactions = { enabled: true, clearOnFinish: false };
+      let dispatchAttempts = 0;
+      if (failureMode === "dispatcher rejection") {
+        state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementationOnce(
+          async () => {
+            dispatchAttempts += 1;
+            throw new Error("synthetic durable dispatch failure");
+          },
+        );
+      } else {
+        state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementationOnce(
+          async () => {
+            dispatchAttempts += 1;
+            return {
+              counts: { tool: 0, block: 0, final: 0 },
+              failedCounts: { tool: 0, block: 0, final: 1 },
+            };
+          },
+        );
+      }
+      state.pollResponses = [
+        {
+          result: "success",
+          events: [{ id: 4, type: "message", message: makeChannelMessage(messageId) }],
+        },
+      ];
+
+      await runMonitorOnce();
+
+      const pendingStore = Array.from(state.durableStores.entries()).find(([namespace]) =>
+        namespace.includes(".pending."),
+      )?.[1];
+      const completedStore = Array.from(state.durableStores.entries()).find(([namespace]) =>
+        namespace.includes(".completed."),
+      )?.[1];
+      await expect(pendingStore?.entries()).resolves.toHaveLength(1);
+      await expect(completedStore?.entries()).resolves.toEqual([]);
+      expect(state.addZulipReaction).toHaveBeenCalledWith(
+        state.client,
+        expect.objectContaining({ messageId: String(messageId), emojiName: "cross_mark" }),
+      );
+      expect(
+        state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher,
+      ).toHaveBeenCalledTimes(1);
+      expect(dispatchAttempts).toBe(1);
+
+      state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher
+        .mockReset()
+        .mockImplementation(async () => {
+          dispatchAttempts += 1;
+          return { counts: { tool: 0, block: 0, final: 1 } };
+        });
+      await runMonitorOnce();
+
+      await expect(pendingStore?.entries()).resolves.toEqual([]);
+      await expect(completedStore?.entries()).resolves.toHaveLength(1);
+      expect(
+        state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher,
+      ).toHaveBeenCalledTimes(1);
+      expect(dispatchAttempts).toBe(2);
+    },
+  );
+
+  it("completes durable inbound after a visible partial reply even when final delivery fails", async () => {
+    enableDurableInboundJournal();
+    state.account.config.reactions = { enabled: true, clearOnFinish: false };
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions }) => {
+        await dispatcherOptions.deliver({ text: "visible partial reply" });
+        return {
+          counts: { tool: 0, block: 1, final: 0 },
+          failedCounts: { tool: 0, block: 0, final: 1 },
+        };
+      },
+    );
+    state.pollResponses = [
+      {
+        result: "success",
+        events: [{ id: 5, type: "message", message: makeChannelMessage(2110) }],
+      },
+    ];
+
+    await runMonitorOnce();
+
+    const pendingStore = Array.from(state.durableStores.entries()).find(([namespace]) =>
+      namespace.includes(".pending."),
+    )?.[1];
+    const completedStore = Array.from(state.durableStores.entries()).find(([namespace]) =>
+      namespace.includes(".completed."),
+    )?.[1];
+    await expect(pendingStore?.entries()).resolves.toEqual([]);
+    await expect(completedStore?.entries()).resolves.toHaveLength(1);
+    expect(state.addZulipReaction).toHaveBeenCalledWith(
+      state.client,
+      expect.objectContaining({ messageId: "2110", emojiName: "cross_mark" }),
+    );
+    expect(
+      state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher,
+    ).toHaveBeenCalledTimes(1);
   });
 
   it("keeps durable journal store caps below the plugin state row limit", async () => {

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -290,9 +290,9 @@ function makePrivateMessage(id: number, senderEmail = "user8@zlp.pubnerd.app") {
   };
 }
 
-async function runMonitorOnce() {
+async function runMonitorOnce(controller = new AbortController()) {
   const { monitorZulipProvider } = await import("./monitor.js");
-  state.abortController = new AbortController();
+  state.abortController = controller;
   await monitorZulipProvider({
     config: state.core.config,
     abortSignal: state.abortController.signal,
@@ -593,15 +593,20 @@ describe("monitorZulipProvider", () => {
     getZulipEventsWithRetryMock.mockRejectedValueOnce(
       Object.assign(new Error("synthetic rate limit"), { retryAfterMs: 120_000 }),
     );
+    const controller = new AbortController();
+    const originalAddEventListener = controller.signal.addEventListener.bind(controller.signal);
+    let abortListenerRegistrations = 0;
+    vi.spyOn(controller.signal, "addEventListener").mockImplementation(
+      (type, listener, options) => {
+        abortListenerRegistrations += 1;
+        if (abortListenerRegistrations === 2) {
+          controller.abort();
+        }
+        originalAddEventListener(type, listener, options);
+      },
+    );
 
-    const monitorPromise = runMonitorOnce();
-    for (let attempt = 0; attempt < 100; attempt += 1) {
-      if (getZulipEventsWithRetryMock.mock.calls.length > 0) {
-        break;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 1));
-    }
-    state.abortController?.abort();
+    const monitorPromise = runMonitorOnce(controller);
 
     await expect(
       Promise.race([
@@ -1217,6 +1222,69 @@ describe("monitorZulipProvider", () => {
     expect(getZulipEventsWithRetryMock).toHaveBeenCalledTimes(1);
     expect(state.core.channel.inbound.buildContext).toHaveBeenCalledTimes(1);
     expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts an active durable replay without starting the next pending record", async () => {
+    enableDurableInboundJournal();
+    state.autoAbort = false;
+    state.account.config.reactions = { enabled: true };
+    const {
+      createZulipDurableInboundMessageId,
+      createZulipDurableInboundReceiveJournal,
+      serializeZulipDurableInboundMessage,
+    } = await import("./durable-receive.js");
+    const firstMessage = makeChannelMessage(2105);
+    const secondMessage = makeChannelMessage(2106);
+    const journal = createZulipDurableInboundReceiveJournal(state.account.accountId);
+    for (const message of [firstMessage, secondMessage]) {
+      await journal.accept(
+        createZulipDurableInboundMessageId({
+          accountId: state.account.accountId,
+          messageId: String(message.id),
+        }),
+        {
+          message: serializeZulipDurableInboundMessage(message),
+          receivedAt: Date.now(),
+        },
+      );
+    }
+    let dispatchStarted!: () => void;
+    const activeReplayStarted = new Promise<void>((resolve) => {
+      dispatchStarted = resolve;
+    });
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ replyOptions }) => {
+        dispatchStarted();
+        if (!replyOptions.abortSignal?.aborted) {
+          await new Promise<void>((resolve) => {
+            replyOptions.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+          });
+        }
+        return {};
+      },
+    );
+
+    const monitorPromise = runMonitorOnce();
+    await activeReplayStarted;
+    state.abortController?.abort();
+    await expect(
+      Promise.race([
+        monitorPromise.then(() => "stopped"),
+        new Promise<string>((resolve) => setTimeout(() => resolve("timed-out"), 250)),
+      ]),
+    ).resolves.toBe("stopped");
+
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+    expect(state.core.channel.inbound.buildContext).toHaveBeenCalledTimes(1);
+    expect(state.addZulipReaction).not.toHaveBeenCalledWith(
+      state.client,
+      expect.objectContaining({ messageId: String(secondMessage.id) }),
+    );
+    expect(state.removeZulipReaction).toHaveBeenCalledWith(
+      state.client,
+      expect.objectContaining({ messageId: String(firstMessage.id), emojiName: "eyes" }),
+    );
+    await expect(journal.pending()).resolves.toHaveLength(2);
   });
 
   it("retries same-process durable replay after a handler failure despite volatile dedupe", async () => {

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -114,6 +114,7 @@ const state = vi.hoisted(() => {
   return {
     createMemoryKeyedStore,
     abortController: undefined as AbortController | undefined,
+    autoAbort: true,
     durableStores: new Map<string, ReturnType<typeof createMemoryKeyedStore>>(),
     pollResponses: [] as Array<Record<string, unknown>>,
     pairingAllowFrom: [] as string[],
@@ -155,8 +156,9 @@ vi.mock("../runtime.js", () => ({
 const registerZulipQueueMock = vi.fn(async () => ({ queueId: "queue-1", lastEventId: 0 }));
 const getZulipEventsWithRetryMock = vi.fn(async () => {
   const next = state.pollResponses.shift() ?? { result: "success", events: [] };
-  if (state.abortController && state.pollResponses.length === 0) {
-    state.abortController.abort();
+  if (state.autoAbort && state.abortController && state.pollResponses.length === 0) {
+    const controller = state.abortController;
+    setTimeout(() => controller.abort(), 0);
   }
   return next;
 });
@@ -338,6 +340,7 @@ describe("monitorZulipProvider", () => {
     state.downloadedUploads = [];
     state.extractedUploadUrls = [];
     state.abortController = undefined;
+    state.autoAbort = true;
     downloadZulipUploadMock.mockClear();
     extractZulipUploadUrlsMock.mockClear();
     registerZulipQueueMock.mockClear();
@@ -367,13 +370,14 @@ describe("monitorZulipProvider", () => {
   });
 
   it("reports real model, tool, compaction, and terminal lifecycle states", async () => {
+    state.autoAbort = false;
     state.account.config.reactions = {
       enabled: true,
       timing: {
         debounceMs: 0,
         stallSoftMs: 60_000,
         stallHardMs: 120_000,
-        doneHoldMs: 0,
+        doneHoldMs: 500,
       },
     };
     state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
@@ -397,7 +401,15 @@ describe("monitorZulipProvider", () => {
       },
     ];
 
-    await runMonitorOnce();
+    const monitorPromise = runMonitorOnce();
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      if (state.addZulipReaction.mock.calls.some((call) => call[1].emojiName === "check")) {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 2));
+    }
+    state.abortController?.abort();
+    await monitorPromise;
 
     const addedNames = state.addZulipReaction.mock.calls.map((call) => call[1].emojiName);
     expect(addedNames).toEqual(expect.arrayContaining([
@@ -434,6 +446,79 @@ describe("monitorZulipProvider", () => {
     expect(state.addZulipReaction).toHaveBeenCalledWith(
       state.client,
       expect.objectContaining({ messageId: "1097", emojiName: "cross_mark" }),
+    );
+  });
+
+  it("uses the terminal error state when final delivery resolves as failed", async () => {
+    state.account.config.reactions = { enabled: true, clearOnFinish: false };
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
+      failedCounts: { final: 1 },
+    });
+    state.pollResponses = [
+      {
+        result: "success",
+        events: [{ id: 1, type: "message", message: makeChannelMessage(1095) }],
+      },
+    ];
+
+    await runMonitorOnce();
+
+    expect(state.addZulipReaction).toHaveBeenCalledWith(
+      state.client,
+      expect.objectContaining({ messageId: "1095", emojiName: "cross_mark" }),
+    );
+    expect(state.addZulipReaction).not.toHaveBeenCalledWith(
+      state.client,
+      expect.objectContaining({ messageId: "1095", emojiName: "check" }),
+    );
+  });
+
+  it("aborts active replies and clears reactions when the monitor stops", async () => {
+    state.autoAbort = false;
+    state.account.config.reactions = {
+      enabled: true,
+      timing: { doneHoldMs: 500 },
+    };
+    let dispatched!: () => void;
+    const dispatchStarted = new Promise<void>((resolve) => {
+      dispatched = resolve;
+    });
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        expect(replyOptions.abortSignal).toBe(state.abortController?.signal);
+        await dispatcherOptions.onReplyStart?.();
+        await replyOptions.onToolStart?.({ name: "exec", phase: "start" });
+        await replyOptions.onCompactionStart?.();
+        dispatched();
+        await new Promise<void>((resolve) => {
+          replyOptions.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+        });
+        return {};
+      },
+    );
+    state.pollResponses = [
+      {
+        result: "success",
+        events: [{ id: 1, type: "message", message: makeChannelMessage(1094) }],
+      },
+    ];
+
+    const monitorPromise = runMonitorOnce();
+    await dispatchStarted;
+    state.abortController?.abort();
+    await monitorPromise;
+
+    expect(state.removeZulipReaction).toHaveBeenCalledWith(
+      state.client,
+      expect.objectContaining({ messageId: "1094", emojiName: "eyes" }),
+    );
+    expect(state.addZulipReaction).not.toHaveBeenCalledWith(
+      state.client,
+      expect.objectContaining({ messageId: "1094", emojiName: "check" }),
+    );
+    expect(state.addZulipReaction).not.toHaveBeenCalledWith(
+      state.client,
+      expect.objectContaining({ messageId: "1094", emojiName: "cross_mark" }),
     );
   });
 

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -348,8 +348,8 @@ describe("monitorZulipProvider", () => {
     deleteZulipQueueMock.mockClear();
     fetchZulipSubscriptionsMock.mockClear();
     fetchZulipStreamMock.mockClear();
-    state.addZulipReaction.mockClear();
-    state.removeZulipReaction.mockClear();
+    state.addZulipReaction.mockReset().mockResolvedValue(undefined);
+    state.removeZulipReaction.mockReset().mockResolvedValue(undefined);
   });
 
   it("wires typing idle cleanup into the reply dispatcher", async () => {
@@ -369,7 +369,7 @@ describe("monitorZulipProvider", () => {
     expect(dispatcherCall?.onIdle).toBe(typingCallbacks?.onIdle);
   });
 
-  it("reports real model, tool, compaction, and terminal lifecycle states", async () => {
+  it("reports real lifecycle states and cancels an existing terminal hold on stop", async () => {
     state.autoAbort = false;
     state.account.config.reactions = {
       enabled: true,
@@ -377,7 +377,7 @@ describe("monitorZulipProvider", () => {
         debounceMs: 0,
         stallSoftMs: 60_000,
         stallHardMs: 120_000,
-        doneHoldMs: 500,
+        doneHoldMs: 40,
       },
     };
     state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
@@ -427,6 +427,12 @@ describe("monitorZulipProvider", () => {
       state.client,
       expect.objectContaining({ messageId: "1098", emojiName: "check" }),
     );
+    const reactionCallCount =
+      state.addZulipReaction.mock.calls.length + state.removeZulipReaction.mock.calls.length;
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(
+      state.addZulipReaction.mock.calls.length + state.removeZulipReaction.mock.calls.length,
+    ).toBe(reactionCallCount);
   });
 
   it("uses the terminal error state when reply dispatch throws", async () => {
@@ -520,6 +526,112 @@ describe("monitorZulipProvider", () => {
       state.client,
       expect.objectContaining({ messageId: "1094", emojiName: "cross_mark" }),
     );
+  });
+
+  it("does not add a terminal reaction when abort races subagent settlement", async () => {
+    state.autoAbort = false;
+    state.account.config.reactions = { enabled: true, clearOnFinish: false };
+    let subagentHideStarted!: () => void;
+    const hideStarted = new Promise<void>((resolve) => {
+      subagentHideStarted = resolve;
+    });
+    let releaseSubagentHide!: () => void;
+    const allowHide = new Promise<void>((resolve) => {
+      releaseSubagentHide = resolve;
+    });
+    state.removeZulipReaction.mockImplementation(async (_client, reaction) => {
+      if (reaction.emojiName === "robot_face") {
+        subagentHideStarted();
+        await allowHide;
+      }
+    });
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ ctx }) => {
+        const { handleZulipSubagentEnded, handleZulipSubagentSpawned } =
+          await import("./subagent-reactions.js");
+        const requesterSessionKey = String(ctx.SessionKey);
+        await handleZulipSubagentSpawned(
+          {
+            runId: "finish-race-run",
+            childSessionKey: "finish-race-child",
+            requester: { channel: "zulip" },
+          },
+          { requesterSessionKey },
+        );
+        void handleZulipSubagentEnded(
+          { runId: "finish-race-run", targetSessionKey: "finish-race-child" },
+          { childSessionKey: "finish-race-child" },
+        );
+        return {};
+      },
+    );
+    state.pollResponses = [
+      {
+        result: "success",
+        events: [{ id: 1, type: "message", message: makeChannelMessage(1093) }],
+      },
+    ];
+
+    const monitorPromise = runMonitorOnce();
+    await hideStarted;
+    state.abortController?.abort();
+    releaseSubagentHide();
+    await monitorPromise;
+
+    expect(state.addZulipReaction).not.toHaveBeenCalledWith(
+      state.client,
+      expect.objectContaining({ messageId: "1093", emojiName: "check" }),
+    );
+    expect(state.addZulipReaction).not.toHaveBeenCalledWith(
+      state.client,
+      expect.objectContaining({ messageId: "1093", emojiName: "cross_mark" }),
+    );
+  });
+
+  it("stops promptly when aborted during retry backoff", async () => {
+    state.autoAbort = false;
+    getZulipEventsWithRetryMock.mockRejectedValueOnce(
+      Object.assign(new Error("synthetic rate limit"), { retryAfterMs: 120_000 }),
+    );
+
+    const monitorPromise = runMonitorOnce();
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      if (getZulipEventsWithRetryMock.mock.calls.length > 0) {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+    state.abortController?.abort();
+
+    await expect(
+      Promise.race([
+        monitorPromise.then(() => "stopped"),
+        new Promise<string>((resolve) => setTimeout(() => resolve("timed-out"), 250)),
+      ]),
+    ).resolves.toBe("stopped");
+  });
+
+  it("does not start the next event when aborted during batch pacing", async () => {
+    state.autoAbort = false;
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async () => {
+        state.abortController?.abort();
+        return {};
+      },
+    );
+    state.pollResponses = [
+      {
+        result: "success",
+        events: [
+          { id: 1, type: "message", message: makeChannelMessage(1092) },
+          { id: 2, type: "message", message: makeChannelMessage(1091) },
+        ],
+      },
+    ];
+
+    await runMonitorOnce();
+
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
   });
 
   it("continues reply dispatch when the Zulip reaction API fails", async () => {

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
+import type { RuntimeEnv } from "../sdk.js";
 
 const state = vi.hoisted(() => {
   const createMemoryKeyedStore = <T>(maxEntries = Number.MAX_SAFE_INTEGER) => {
@@ -290,11 +291,15 @@ function makePrivateMessage(id: number, senderEmail = "user8@zlp.pubnerd.app") {
   };
 }
 
-async function runMonitorOnce(controller = new AbortController()) {
+async function runMonitorOnce(
+  controller = new AbortController(),
+  runtime?: RuntimeEnv,
+) {
   const { monitorZulipProvider } = await import("./monitor.js");
   state.abortController = controller;
   await monitorZulipProvider({
     config: state.core.config,
+    runtime,
     abortSignal: state.abortController.signal,
   });
 }
@@ -639,9 +644,10 @@ describe("monitorZulipProvider", () => {
     expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
   });
 
-  it("continues reply dispatch when the Zulip reaction API fails", async () => {
+  it("reports status adapter failures and continues reply dispatch", async () => {
     state.account.config.reactions = { enabled: true };
     state.addZulipReaction.mockRejectedValueOnce(new Error("reaction unavailable"));
+    const runtimeError = vi.fn();
     state.pollResponses = [
       {
         result: "success",
@@ -649,9 +655,16 @@ describe("monitorZulipProvider", () => {
       },
     ];
 
-    await runMonitorOnce();
+    await runMonitorOnce(new AbortController(), {
+      log: vi.fn(),
+      error: runtimeError,
+      exit: vi.fn(),
+    });
 
     expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+    expect(runtimeError).toHaveBeenCalledWith(
+      expect.stringContaining("zulip: status reaction update failed: Error: reaction unavailable"),
+    );
     expect(state.addZulipReaction).toHaveBeenCalledWith(
       state.client,
       expect.objectContaining({ messageId: "1096", emojiName: "eyes" }),
@@ -1260,7 +1273,10 @@ describe("monitorZulipProvider", () => {
             replyOptions.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
           });
         }
-        return {};
+        return {
+          counts: { tool: 0, block: 0, final: 0 },
+          failedCounts: { tool: 0, block: 0, final: 1 },
+        };
       },
     );
 
@@ -1285,6 +1301,84 @@ describe("monitorZulipProvider", () => {
       expect.objectContaining({ messageId: String(firstMessage.id), emojiName: "eyes" }),
     );
     await expect(journal.pending()).resolves.toHaveLength(2);
+  });
+
+  it("completes a durable reply when abort races post-delivery subagent settlement", async () => {
+    enableDurableInboundJournal();
+    state.autoAbort = false;
+    state.account.config.reactions = { enabled: true, clearOnFinish: false };
+    const {
+      createZulipDurableInboundMessageId,
+      createZulipDurableInboundReceiveJournal,
+      serializeZulipDurableInboundMessage,
+    } = await import("./durable-receive.js");
+    const message = makeChannelMessage(2107);
+    const journal = createZulipDurableInboundReceiveJournal(state.account.accountId);
+    await journal.accept(
+      createZulipDurableInboundMessageId({
+        accountId: state.account.accountId,
+        messageId: String(message.id),
+      }),
+      {
+        message: serializeZulipDurableInboundMessage(message),
+        receivedAt: Date.now(),
+      },
+    );
+    let subagentHideStarted!: () => void;
+    const hideStarted = new Promise<void>((resolve) => {
+      subagentHideStarted = resolve;
+    });
+    let releaseSubagentHide!: () => void;
+    const allowHide = new Promise<void>((resolve) => {
+      releaseSubagentHide = resolve;
+    });
+    state.removeZulipReaction.mockImplementation(async (_client, reaction) => {
+      if (reaction.emojiName === "robot_face") {
+        subagentHideStarted();
+        await allowHide;
+      }
+    });
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ ctx, dispatcherOptions }) => {
+        await dispatcherOptions.deliver({ text: "committed reply" });
+        const { handleZulipSubagentEnded, handleZulipSubagentSpawned } =
+          await import("./subagent-reactions.js");
+        const requesterSessionKey = String(ctx.SessionKey);
+        await handleZulipSubagentSpawned(
+          {
+            runId: "durable-finish-race-run",
+            childSessionKey: "durable-finish-race-child",
+            requester: { channel: "zulip" },
+          },
+          { requesterSessionKey },
+        );
+        void handleZulipSubagentEnded(
+          {
+            runId: "durable-finish-race-run",
+            targetSessionKey: "durable-finish-race-child",
+          },
+          { childSessionKey: "durable-finish-race-child" },
+        );
+        return { counts: { tool: 0, block: 0, final: 1 } };
+      },
+    );
+
+    const monitorPromise = runMonitorOnce();
+    await hideStarted;
+    state.abortController?.abort();
+    releaseSubagentHide();
+    await monitorPromise;
+
+    await expect(journal.pending()).resolves.toEqual([]);
+    const completedStore = Array.from(state.durableStores.entries()).find(([namespace]) =>
+      namespace.includes(".completed."),
+    )?.[1];
+    await expect(completedStore?.entries()).resolves.toHaveLength(1);
+
+    state.removeZulipReaction.mockResolvedValue(undefined);
+    state.autoAbort = true;
+    await runMonitorOnce();
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
   });
 
   it("retries same-process durable replay after a handler failure despite volatile dedupe", async () => {

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -122,6 +122,8 @@ const state = vi.hoisted(() => {
     downloadedUploads: [] as Array<{ buffer: Buffer; contentType: string; filename: string }>,
     extractedUploadUrls: [] as string[],
     client: { authHeader: "fake-auth" },
+    addZulipReaction: vi.fn(async () => {}),
+    removeZulipReaction: vi.fn(async () => {}),
     botUser: {
       id: 999,
       email: "debbie-bot@zlp.pubnerd.app",
@@ -181,8 +183,8 @@ vi.mock("./client.js", () => ({
   getZulipEventsWithRetry: getZulipEventsWithRetryMock,
   deleteZulipQueue: deleteZulipQueueMock,
   sendZulipTyping: vi.fn(async () => {}),
-  addZulipReaction: vi.fn(async () => {}),
-  removeZulipReaction: vi.fn(async () => {}),
+  addZulipReaction: state.addZulipReaction,
+  removeZulipReaction: state.removeZulipReaction,
 }));
 
 vi.mock("./accounts.js", () => ({
@@ -242,7 +244,8 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => ({
   logInboundDrop: vi.fn(),
 }));
 
-vi.mock("openclaw/plugin-sdk/channel-feedback", () => ({
+vi.mock("openclaw/plugin-sdk/channel-feedback", async (importOriginal) => ({
+  ...await importOriginal<typeof import("openclaw/plugin-sdk/channel-feedback")>(),
   logTypingFailure: vi.fn(),
 }));
 
@@ -342,6 +345,8 @@ describe("monitorZulipProvider", () => {
     deleteZulipQueueMock.mockClear();
     fetchZulipSubscriptionsMock.mockClear();
     fetchZulipStreamMock.mockClear();
+    state.addZulipReaction.mockClear();
+    state.removeZulipReaction.mockClear();
   });
 
   it("wires typing idle cleanup into the reply dispatcher", async () => {
@@ -356,8 +361,99 @@ describe("monitorZulipProvider", () => {
 
     const dispatcherCall = state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0]?.[0]?.dispatcherOptions;
     const typingCallbacks = typingCallbacksMock.mock.results[0]?.value;
-    expect(dispatcherCall?.onReplyStart).toBe(typingCallbacks?.onReplyStart);
+    await dispatcherCall?.onReplyStart?.();
+    expect(typingCallbacks?.onReplyStart).toHaveBeenCalledTimes(1);
     expect(dispatcherCall?.onIdle).toBe(typingCallbacks?.onIdle);
+  });
+
+  it("reports real model, tool, compaction, and terminal lifecycle states", async () => {
+    state.account.config.reactions = {
+      enabled: true,
+      timing: {
+        debounceMs: 0,
+        stallSoftMs: 60_000,
+        stallHardMs: 120_000,
+        doneHoldMs: 0,
+      },
+    };
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await dispatcherOptions.onReplyStart?.();
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        await replyOptions.onToolStart?.({ name: "exec", phase: "start" });
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        await replyOptions.onToolStart?.({ name: "exec", phase: "end" });
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        await replyOptions.onCompactionStart?.();
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        await replyOptions.onCompactionEnd?.();
+        await new Promise((resolve) => setTimeout(resolve, 1));
+      },
+    );
+    state.pollResponses = [
+      {
+        result: "success",
+        events: [{ id: 1, type: "message", message: makeChannelMessage(1098) }],
+      },
+    ];
+
+    await runMonitorOnce();
+
+    const addedNames = state.addZulipReaction.mock.calls.map((call) => call[1].emojiName);
+    expect(addedNames).toEqual(expect.arrayContaining([
+      "eyes",
+      "brain",
+      "computer",
+      "compression",
+      "check",
+    ]));
+    expect(state.removeZulipReaction).toHaveBeenCalledWith(
+      state.client,
+      expect.objectContaining({ messageId: "1098", emojiName: "eyes" }),
+    );
+    expect(state.removeZulipReaction).toHaveBeenCalledWith(
+      state.client,
+      expect.objectContaining({ messageId: "1098", emojiName: "check" }),
+    );
+  });
+
+  it("uses the terminal error state when reply dispatch throws", async () => {
+    state.account.config.reactions = { enabled: true };
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockRejectedValue(
+      new Error("synthetic dispatch failure"),
+    );
+    state.pollResponses = [
+      {
+        result: "success",
+        events: [{ id: 1, type: "message", message: makeChannelMessage(1097) }],
+      },
+    ];
+
+    await runMonitorOnce();
+
+    expect(state.addZulipReaction).toHaveBeenCalledWith(
+      state.client,
+      expect.objectContaining({ messageId: "1097", emojiName: "cross_mark" }),
+    );
+  });
+
+  it("continues reply dispatch when the Zulip reaction API fails", async () => {
+    state.account.config.reactions = { enabled: true };
+    state.addZulipReaction.mockRejectedValueOnce(new Error("reaction unavailable"));
+    state.pollResponses = [
+      {
+        result: "success",
+        events: [{ id: 1, type: "message", message: makeChannelMessage(1096) }],
+      },
+    ];
+
+    await runMonitorOnce();
+
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+    expect(state.addZulipReaction).toHaveBeenCalledWith(
+      state.client,
+      expect.objectContaining({ messageId: "1096", emojiName: "eyes" }),
+    );
   });
 
   it("forwards presentation and channel data only with the first text chunk", async () => {

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -897,6 +897,24 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         logVerboseMessage(`zulip: failed to add reaction ${reaction.emojiName}: ${String(err)}`);
       }
     };
+    const addStatusReaction = async (reaction: {
+      emojiName: string;
+      emojiCode?: string;
+      reactionType?: string;
+    }) => {
+      if (statusReactionConfig.enabled && reaction.emojiName) {
+        await addZulipReaction(client, { messageId, ...reaction });
+      }
+    };
+    const removeStatusReaction = async (reaction: {
+      emojiName: string;
+      emojiCode?: string;
+      reactionType?: string;
+    }) => {
+      if (statusReactionConfig.enabled && reaction.emojiName) {
+        await removeZulipReaction(client, { messageId, ...reaction });
+      }
+    };
     const removeReactionSafe = async (reaction: {
       emojiName: string;
       emojiCode?: string;
@@ -917,14 +935,14 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     const statusReactions = createStatusReactionController({
       enabled: statusReactionConfig.enabled,
       adapter: createZulipStatusReactionAdapter({
-        add: addReactionSafe,
-        remove: removeReactionSafe,
+        add: addStatusReaction,
+        remove: removeStatusReaction,
       }),
       initialEmoji: statusReactionConfig.emojis.queued,
       emojis: statusReactionConfig.emojis,
       timing: statusReactionConfig.timing,
       onError: (err) => {
-        logVerboseMessage(`zulip: status reaction update failed: ${String(err)}`);
+        runtime.error?.(`zulip: status reaction update failed: ${String(err)}`);
       },
     });
     statusReactions.setQueued();
@@ -1019,6 +1037,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       },
     });
 
+    let replyDeliveryCommitted = false;
     const dispatcherOptions = {
       ...prefixOptions,
       humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
@@ -1048,6 +1067,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
               presentation: first ? payload.presentation : undefined,
               channelData: first ? payload.channelData : undefined,
             });
+            replyDeliveryCommitted = true;
             first = false;
           }
         } else {
@@ -1063,6 +1083,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
               presentation: isFirst ? payload.presentation : undefined,
               channelData: isFirst ? payload.channelData : undefined,
             });
+            replyDeliveryCommitted = true;
             first = false;
           }
         }
@@ -1074,7 +1095,12 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     };
 
     let dispatchError: unknown;
-    let dispatchResult: { failedCounts?: Partial<Record<string, number>> } | undefined;
+    let dispatchResult:
+      | {
+          counts?: Partial<Record<"tool" | "block" | "final", number>>;
+          failedCounts?: Partial<Record<"tool" | "block" | "final", number>>;
+        }
+      | undefined;
     try {
       dispatchResult = await subagentContext.run(() =>
         core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
@@ -1110,17 +1136,23 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       runtime.error?.(`zulip reply failed: ${String(err)}`);
     }
 
+    const successfulReplyCount =
+      (dispatchResult?.counts?.block ?? 0) + (dispatchResult?.counts?.final ?? 0);
+    replyDeliveryCommitted ||= successfulReplyCount > 0;
+    const abortOutcome = () =>
+      replyDeliveryCommitted ? undefined : ABORTED_INBOUND_MESSAGE;
+
     if (reactionLifecycleCancelled || opts.abortSignal?.aborted) {
       await cancelReactionLifecycle();
       opts.statusSink?.({ lastInboundAt: Date.now() });
-      return ABORTED_INBOUND_MESSAGE;
+      return abortOutcome();
     }
 
     await subagentContext.finish();
     if (reactionLifecycleCancelled || opts.abortSignal?.aborted) {
       await cancelReactionLifecycle();
       opts.statusSink?.({ lastInboundAt: Date.now() });
-      return ABORTED_INBOUND_MESSAGE;
+      return abortOutcome();
     }
     const finalDeliveryFailed = (dispatchResult?.failedCounts?.final ?? 0) > 0;
     const terminalError = Boolean(dispatchError) || finalDeliveryFailed;
@@ -1132,7 +1164,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     if (reactionLifecycleCancelled || opts.abortSignal?.aborted) {
       await cancelReactionLifecycle();
       opts.statusSink?.({ lastInboundAt: Date.now() });
-      return ABORTED_INBOUND_MESSAGE;
+      return abortOutcome();
     }
     if (account.config.reactions?.clearOnFinish !== false) {
       const terminalHoldMs = terminalError

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -427,6 +427,8 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     accountConfig: account.config,
     globalStatusReactions: cfg.messages?.statusReactions,
   });
+  const activeMessageTasks = new Set<Promise<void>>();
+  const activeReactionCleanups = new Set<() => Promise<void>>();
 
   const pairing = createChannelPairingController({
     core,
@@ -893,6 +895,32 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       show: () => addReactionSafe(subagentReaction),
       hide: () => removeReactionSafe(subagentReaction),
     });
+    let terminalCleanupTimer: ReturnType<typeof setTimeout> | undefined;
+    let reactionLifecycleCancelled = false;
+    let statusLifecycleSettled = false;
+    let subagentLifecycleSettled = false;
+    const releaseReactionCleanupIfSettled = () => {
+      if (statusLifecycleSettled && subagentLifecycleSettled) {
+        activeReactionCleanups.delete(cancelReactionLifecycle);
+      }
+    };
+    const cancelReactionLifecycle = async () => {
+      if (reactionLifecycleCancelled) {
+        return;
+      }
+      reactionLifecycleCancelled = true;
+      if (terminalCleanupTimer) {
+        clearTimeout(terminalCleanupTimer);
+        terminalCleanupTimer = undefined;
+      }
+      activeReactionCleanups.delete(cancelReactionLifecycle);
+      await Promise.allSettled([statusReactions.clear(), subagentContext.cancel()]);
+    };
+    activeReactionCleanups.add(cancelReactionLifecycle);
+    void subagentContext.closed.then(() => {
+      subagentLifecycleSettled = true;
+      releaseReactionCleanupIfSettled();
+    });
 
     const textLimit = core.channel.text.resolveTextChunkLimit(cfg, "zulip", account.accountId, {
       fallbackLimit: account.textChunkLimit ?? 4000,
@@ -1000,8 +1028,9 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     };
 
     let dispatchError: unknown;
+    let dispatchResult: { failedCounts?: Partial<Record<string, number>> } | undefined;
     try {
-      await subagentContext.run(() =>
+      dispatchResult = await subagentContext.run(() =>
         core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
           ctx: ctxPayload,
           cfg,
@@ -1009,6 +1038,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
           replyOptions: {
             disableBlockStreaming:
               typeof account.blockStreaming === "boolean" ? !account.blockStreaming : undefined,
+            abortSignal: opts.abortSignal,
             onModelSelected,
             allowToolLifecycleWhenProgressHidden: statusReactionConfig.enabled ? true : undefined,
             onToolStart: async (payload) => {
@@ -1034,20 +1064,38 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       runtime.error?.(`zulip reply failed: ${String(err)}`);
     }
 
+    if (reactionLifecycleCancelled || opts.abortSignal?.aborted) {
+      await cancelReactionLifecycle();
+      opts.statusSink?.({ lastInboundAt: Date.now() });
+      return;
+    }
+
     await subagentContext.finish();
-    if (dispatchError) {
+    const finalDeliveryFailed = (dispatchResult?.failedCounts?.final ?? 0) > 0;
+    const terminalError = Boolean(dispatchError) || finalDeliveryFailed;
+    if (terminalError) {
       await statusReactions.setError();
     } else {
       await statusReactions.setDone();
     }
     if (account.config.reactions?.clearOnFinish !== false) {
-      const terminalHoldMs = dispatchError
+      const terminalHoldMs = terminalError
         ? (statusReactionConfig.timing?.errorHoldMs ?? DEFAULT_TIMING.errorHoldMs)
         : (statusReactionConfig.timing?.doneHoldMs ?? DEFAULT_TIMING.doneHoldMs);
-      const cleanupTimer = setTimeout(() => {
-        void statusReactions.clear();
+      terminalCleanupTimer = setTimeout(() => {
+        terminalCleanupTimer = undefined;
+        if (reactionLifecycleCancelled) {
+          return;
+        }
+        void statusReactions.clear().finally(() => {
+          statusLifecycleSettled = true;
+          releaseReactionCleanupIfSettled();
+        });
       }, terminalHoldMs);
-      cleanupTimer.unref?.();
+      terminalCleanupTimer.unref?.();
+    } else {
+      statusLifecycleSettled = true;
+      releaseReactionCleanupIfSettled();
     }
 
     opts.statusSink?.({ lastInboundAt: Date.now() });
@@ -1231,8 +1279,12 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
 
         if (event.type === "message" && event.message) {
           // Start processing without awaiting (fire-and-forget with error handling)
-          processMessage(event.message, validEventId).catch((err) => {
+          const messageTask = processMessage(event.message, validEventId).catch((err) => {
             runtime.error?.(`zulip: message processing failed: ${String(err)}`);
+          });
+          activeMessageTasks.add(messageTask);
+          void messageTask.finally(() => {
+            activeMessageTasks.delete(messageTask);
           });
           // Small delay between starting each message for natural pacing
           await delay(200);
@@ -1273,6 +1325,11 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       await delay(waitMs);
     }
   }
+
+  const pendingReactionCleanups = Array.from(activeReactionCleanups, (cleanup) => cleanup());
+  await Promise.allSettled(pendingReactionCleanups);
+  await Promise.allSettled(Array.from(activeMessageTasks));
+  await Promise.allSettled(Array.from(activeReactionCleanups, (cleanup) => cleanup()));
 
   // Cleanup
   await deleteZulipQueue(client, queueId);

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -8,7 +8,11 @@ import type {
 } from "../sdk.js";
 import { createChannelPairingController } from "../sdk.js";
 import { resolveControlCommandGate } from "openclaw/plugin-sdk/command-auth-native";
-import { logTypingFailure } from "openclaw/plugin-sdk/channel-feedback";
+import {
+  createStatusReactionController,
+  DEFAULT_TIMING,
+  logTypingFailure,
+} from "openclaw/plugin-sdk/channel-feedback";
 import { formatInboundEnvelope, logInboundDrop } from "openclaw/plugin-sdk/channel-inbound";
 import { mergeDmAllowFromSources, resolveGroupAllowFromSources } from "openclaw/plugin-sdk/allow-from";
 import { readChannelIngressStoreAllowFromForDmPolicy } from "openclaw/plugin-sdk/channel-ingress-runtime";
@@ -46,7 +50,13 @@ import {
 } from "./durable-receive.js";
 import { buildZulipStreamConversation } from "../session-conversation.js";
 import { sendMessageZulip } from "./send.js";
-import { downloadZulipUpload, extractZulipUploadUrls, normalizeZulipEmojiName, sanitizeUploadFilename } from "./uploads.js";
+import { downloadZulipUpload, extractZulipUploadUrls, sanitizeUploadFilename } from "./uploads.js";
+import {
+  createZulipStatusReactionAdapter,
+  resolveZulipReactionSpec,
+  resolveZulipStatusReactionConfig,
+} from "./status-reactions.js";
+import { registerZulipSubagentReactionContext } from "./subagent-reactions.js";
 
 export type MonitorZulipOpts = {
   apiKey?: string;
@@ -413,12 +423,10 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
   const mediaMaxBytes =
     (account.config.mediaMaxMb || cfg.agents?.defaults?.mediaMaxMb || 5) * 1024 * 1024;
 
-  const reactionConfig = account.config.reactions ?? {};
-  const reactionsEnabled = reactionConfig.enabled !== false;
-  const reactionClearOnFinish = reactionConfig.clearOnFinish !== false;
-  const reactionStart = normalizeZulipEmojiName(reactionConfig.onStart ?? "");
-  const reactionSuccess = normalizeZulipEmojiName(reactionConfig.onSuccess ?? "");
-  const reactionError = normalizeZulipEmojiName(reactionConfig.onError ?? "warning");
+  const statusReactionConfig = resolveZulipStatusReactionConfig({
+    accountConfig: account.config,
+    globalStatusReactions: cfg.messages?.statusReactions,
+  });
 
   const pairing = createChannelPairingController({
     core,
@@ -836,30 +844,55 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       `zulip inbound: from=${ctxPayload.From} len=${bodyText.length} preview="${previewLine}"`,
     );
 
-    const addReactionSafe = async (emojiName: string) => {
-      if (!reactionsEnabled || !emojiName) {
+    const addReactionSafe = async (reaction: {
+      emojiName: string;
+      emojiCode?: string;
+      reactionType?: string;
+    }) => {
+      if (!statusReactionConfig.enabled || !reaction.emojiName) {
         return;
       }
       try {
-        await addZulipReaction(client, { messageId, emojiName });
+        await addZulipReaction(client, { messageId, ...reaction });
       } catch (err) {
-        logVerboseMessage(`zulip: failed to add reaction ${emojiName}: ${String(err)}`);
+        logVerboseMessage(`zulip: failed to add reaction ${reaction.emojiName}: ${String(err)}`);
       }
     };
-    const removeReactionSafe = async (emojiName: string) => {
-      if (!reactionsEnabled || !emojiName) {
+    const removeReactionSafe = async (reaction: {
+      emojiName: string;
+      emojiCode?: string;
+      reactionType?: string;
+    }) => {
+      if (!statusReactionConfig.enabled || !reaction.emojiName) {
         return;
       }
       try {
-        await removeZulipReaction(client, { messageId, emojiName });
+        await removeZulipReaction(client, { messageId, ...reaction });
       } catch (err) {
-        logVerboseMessage(`zulip: failed to remove reaction ${emojiName}: ${String(err)}`);
+        logVerboseMessage(`zulip: failed to remove reaction ${reaction.emojiName}: ${String(err)}`);
       }
     };
+    const statusReactions = createStatusReactionController({
+      enabled: statusReactionConfig.enabled,
+      adapter: createZulipStatusReactionAdapter({
+        add: addReactionSafe,
+        remove: removeReactionSafe,
+      }),
+      initialEmoji: statusReactionConfig.emojis.queued,
+      emojis: statusReactionConfig.emojis,
+      timing: statusReactionConfig.timing,
+      onError: (err) => {
+        logVerboseMessage(`zulip: status reaction update failed: ${String(err)}`);
+      },
+    });
+    statusReactions.setQueued();
 
-    if (reactionsEnabled) {
-      await addReactionSafe(reactionStart);
-    }
+    const subagentReaction = resolveZulipReactionSpec(statusReactionConfig.subagent);
+    const subagentContext = registerZulipSubagentReactionContext({
+      requesterSessionKey: String(ctxPayload.SessionKey ?? sessionKey),
+      show: () => addReactionSafe(subagentReaction),
+      hide: () => removeReactionSafe(subagentReaction),
+    });
 
     const textLimit = core.channel.text.resolveTextChunkLimit(cfg, "zulip", account.accountId, {
       fallbackLimit: account.textChunkLimit ?? 4000,
@@ -915,7 +948,10 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     const dispatcherOptions = {
       ...prefixOptions,
       humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
-      onReplyStart: typingCallbacks.onReplyStart,
+      onReplyStart: async () => {
+        await typingCallbacks.onReplyStart();
+        await statusReactions.setThinking();
+      },
       onIdle: typingCallbacks.onIdle,
       deliver: async (payload: ReplyPayload) => {
         const mediaUrls = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
@@ -965,30 +1001,53 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
 
     let dispatchError: unknown;
     try {
-      await core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
-        ctx: ctxPayload,
-        cfg,
-        dispatcherOptions,
-        replyOptions: {
-          disableBlockStreaming:
-            typeof account.blockStreaming === "boolean" ? !account.blockStreaming : undefined,
-          onModelSelected,
-        },
-      });
+      await subagentContext.run(() =>
+        core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
+          ctx: ctxPayload,
+          cfg,
+          dispatcherOptions,
+          replyOptions: {
+            disableBlockStreaming:
+              typeof account.blockStreaming === "boolean" ? !account.blockStreaming : undefined,
+            onModelSelected,
+            allowToolLifecycleWhenProgressHidden: statusReactionConfig.enabled ? true : undefined,
+            onToolStart: async (payload) => {
+              if (payload.phase === "end") {
+                statusReactions.cancelPending();
+                await statusReactions.setThinking();
+                return;
+              }
+              await statusReactions.setTool(payload.name);
+            },
+            onCompactionStart: async () => {
+              await statusReactions.setCompacting();
+            },
+            onCompactionEnd: async () => {
+              statusReactions.cancelPending();
+              await statusReactions.setThinking();
+            },
+          },
+        }),
+      );
     } catch (err) {
       dispatchError = err;
       runtime.error?.(`zulip reply failed: ${String(err)}`);
     }
 
-    if (reactionsEnabled) {
-      if (reactionClearOnFinish) {
-        await removeReactionSafe(reactionStart);
-      }
-      if (dispatchError) {
-        await addReactionSafe(reactionError);
-      } else {
-        await addReactionSafe(reactionSuccess);
-      }
+    await subagentContext.finish();
+    if (dispatchError) {
+      await statusReactions.setError();
+    } else {
+      await statusReactions.setDone();
+    }
+    if (account.config.reactions?.clearOnFinish !== false) {
+      const terminalHoldMs = dispatchError
+        ? (statusReactionConfig.timing?.errorHoldMs ?? DEFAULT_TIMING.errorHoldMs)
+        : (statusReactionConfig.timing?.doneHoldMs ?? DEFAULT_TIMING.doneHoldMs);
+      const cleanupTimer = setTimeout(() => {
+        void statusReactions.clear();
+      }, terminalHoldMs);
+      cleanupTimer.unref?.();
     }
 
     opts.statusSink?.({ lastInboundAt: Date.now() });

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -368,21 +368,33 @@ async function saveZulipMediaBuffer(params: {
   return { path: filePath, contentType };
 }
 
+const ABORTED_INBOUND_MESSAGE = Symbol("aborted-inbound-message");
+
 function delay(ms: number, signal?: AbortSignal): Promise<void> {
   if (signal?.aborted) {
     return Promise.resolve();
   }
   return new Promise((resolve) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
     const finish = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timer) {
+        clearTimeout(timer);
+      }
       signal?.removeEventListener("abort", onAbort);
       resolve();
     };
-    const timer = setTimeout(finish, ms);
-    const onAbort = () => {
-      clearTimeout(timer);
-      finish();
-    };
+    const onAbort = () => finish();
     signal?.addEventListener("abort", onAbort, { once: true });
+    if (signal?.aborted) {
+      finish();
+      return;
+    }
+    timer = setTimeout(finish, ms);
   });
 }
 
@@ -462,6 +474,9 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     message: ZulipMessage,
     options: { skipRecentDedupe?: boolean } = {},
   ) => {
+    if (opts.abortSignal?.aborted) {
+      return ABORTED_INBOUND_MESSAGE;
+    }
     const messageId = String(message.id ?? "");
     if (!messageId) {
       return;
@@ -896,6 +911,9 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         logVerboseMessage(`zulip: failed to remove reaction ${reaction.emojiName}: ${String(err)}`);
       }
     };
+    if (opts.abortSignal?.aborted) {
+      return ABORTED_INBOUND_MESSAGE;
+    }
     const statusReactions = createStatusReactionController({
       enabled: statusReactionConfig.enabled,
       adapter: createZulipStatusReactionAdapter({
@@ -947,7 +965,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     if (opts.abortSignal?.aborted) {
       await cancelReactionLifecycle();
       opts.statusSink?.({ lastInboundAt: Date.now() });
-      return;
+      return ABORTED_INBOUND_MESSAGE;
     }
 
     const textLimit = core.channel.text.resolveTextChunkLimit(cfg, "zulip", account.accountId, {
@@ -1095,14 +1113,14 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     if (reactionLifecycleCancelled || opts.abortSignal?.aborted) {
       await cancelReactionLifecycle();
       opts.statusSink?.({ lastInboundAt: Date.now() });
-      return;
+      return ABORTED_INBOUND_MESSAGE;
     }
 
     await subagentContext.finish();
     if (reactionLifecycleCancelled || opts.abortSignal?.aborted) {
       await cancelReactionLifecycle();
       opts.statusSink?.({ lastInboundAt: Date.now() });
-      return;
+      return ABORTED_INBOUND_MESSAGE;
     }
     const finalDeliveryFailed = (dispatchResult?.failedCounts?.final ?? 0) > 0;
     const terminalError = Boolean(dispatchError) || finalDeliveryFailed;
@@ -1114,7 +1132,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     if (reactionLifecycleCancelled || opts.abortSignal?.aborted) {
       await cancelReactionLifecycle();
       opts.statusSink?.({ lastInboundAt: Date.now() });
-      return;
+      return ABORTED_INBOUND_MESSAGE;
     }
     if (account.config.reactions?.clearOnFinish !== false) {
       const terminalHoldMs = terminalError
@@ -1185,7 +1203,15 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     options: { replay?: boolean } = {},
   ): Promise<void> => {
     try {
-      await handleMessage(message, { skipRecentDedupe: options.replay });
+      const outcome = await handleMessage(message, { skipRecentDedupe: options.replay });
+      if (outcome === ABORTED_INBOUND_MESSAGE) {
+        if (durableInboundJournal && durableId) {
+          await durableInboundJournal.release(durableId, {
+            lastError: "Zulip monitor stopped before delivery",
+          });
+        }
+        return;
+      }
       await completeDurableInboundMessage(durableId, metadata);
     } catch (err) {
       if (durableInboundJournal && durableId) {
@@ -1243,12 +1269,20 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     await deliverDurableInboundMessage(durableId, message, metadata);
   };
 
+  const handleMonitorAbort = () => {
+    void cleanupActiveReactionLifecycles();
+  };
+  opts.abortSignal?.addEventListener("abort", handleMonitorAbort, { once: true });
+
   const replayPendingDurableInboundMessages = async (): Promise<void> => {
     if (!durableInboundJournal) {
       return;
     }
     const pending = await durableInboundJournal.pending();
     for (const record of pending) {
+      if (opts.abortSignal?.aborted) {
+        break;
+      }
       const payload = record.payload as ZulipDurableInboundPayload;
       await deliverDurableInboundMessage(
         record.id,
@@ -1258,11 +1292,6 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       );
     }
   };
-
-  const handleMonitorAbort = () => {
-    void cleanupActiveReactionLifecycles();
-  };
-  opts.abortSignal?.addEventListener("abort", handleMonitorAbort, { once: true });
 
   try {
     await replayPendingDurableInboundMessages();

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -369,6 +369,7 @@ async function saveZulipMediaBuffer(params: {
 }
 
 const ABORTED_INBOUND_MESSAGE = Symbol("aborted-inbound-message");
+const RETRYABLE_INBOUND_MESSAGE = Symbol("retryable-inbound-message");
 
 function delay(ms: number, signal?: AbortSignal): Promise<void> {
   if (signal?.aborted) {
@@ -1137,7 +1138,9 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     }
 
     const successfulReplyCount =
-      (dispatchResult?.counts?.block ?? 0) + (dispatchResult?.counts?.final ?? 0);
+      (dispatchResult?.counts?.tool ?? 0) +
+      (dispatchResult?.counts?.block ?? 0) +
+      (dispatchResult?.counts?.final ?? 0);
     replyDeliveryCommitted ||= successfulReplyCount > 0;
     const abortOutcome = () =>
       replyDeliveryCommitted ? undefined : ABORTED_INBOUND_MESSAGE;
@@ -1156,6 +1159,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     }
     const finalDeliveryFailed = (dispatchResult?.failedCounts?.final ?? 0) > 0;
     const terminalError = Boolean(dispatchError) || finalDeliveryFailed;
+    const retryableNoDelivery = terminalError && !replyDeliveryCommitted;
     if (terminalError) {
       await statusReactions.setError();
     } else {
@@ -1187,6 +1191,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     }
 
     opts.statusSink?.({ lastInboundAt: Date.now() });
+    return retryableNoDelivery ? RETRYABLE_INBOUND_MESSAGE : undefined;
   };
 
   // Register event queue
@@ -1240,6 +1245,14 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         if (durableInboundJournal && durableId) {
           await durableInboundJournal.release(durableId, {
             lastError: "Zulip monitor stopped before delivery",
+          });
+        }
+        return;
+      }
+      if (outcome === RETRYABLE_INBOUND_MESSAGE) {
+        if (durableInboundJournal && durableId) {
+          await durableInboundJournal.release(durableId, {
+            lastError: "Zulip reply delivery failed before any visible response",
           });
         }
         return;

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -368,8 +368,22 @@ async function saveZulipMediaBuffer(params: {
   return { path: filePath, contentType };
 }
 
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    const finish = () => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    };
+    const timer = setTimeout(finish, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      finish();
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise<void> {
@@ -429,6 +443,14 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
   });
   const activeMessageTasks = new Set<Promise<void>>();
   const activeReactionCleanups = new Set<() => Promise<void>>();
+  let reactionCleanupChain = Promise.resolve();
+  const cleanupActiveReactionLifecycles = (): Promise<void> => {
+    const pending = Array.from(activeReactionCleanups, (cleanup) => cleanup());
+    reactionCleanupChain = Promise.allSettled([reactionCleanupChain, ...pending]).then(
+      () => undefined,
+    );
+    return reactionCleanupChain;
+  };
 
   const pairing = createChannelPairingController({
     core,
@@ -904,23 +926,29 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         activeReactionCleanups.delete(cancelReactionLifecycle);
       }
     };
-    const cancelReactionLifecycle = async () => {
-      if (reactionLifecycleCancelled) {
-        return;
-      }
-      reactionLifecycleCancelled = true;
-      if (terminalCleanupTimer) {
-        clearTimeout(terminalCleanupTimer);
-        terminalCleanupTimer = undefined;
-      }
-      activeReactionCleanups.delete(cancelReactionLifecycle);
-      await Promise.allSettled([statusReactions.clear(), subagentContext.cancel()]);
+    let reactionLifecycleCleanup: Promise<void> | undefined;
+    const cancelReactionLifecycle = () => {
+      reactionLifecycleCleanup ??= (async () => {
+        reactionLifecycleCancelled = true;
+        if (terminalCleanupTimer) {
+          clearTimeout(terminalCleanupTimer);
+          terminalCleanupTimer = undefined;
+        }
+        activeReactionCleanups.delete(cancelReactionLifecycle);
+        await Promise.allSettled([statusReactions.clear(), subagentContext.cancel()]);
+      })();
+      return reactionLifecycleCleanup;
     };
     activeReactionCleanups.add(cancelReactionLifecycle);
     void subagentContext.closed.then(() => {
       subagentLifecycleSettled = true;
       releaseReactionCleanupIfSettled();
     });
+    if (opts.abortSignal?.aborted) {
+      await cancelReactionLifecycle();
+      opts.statusSink?.({ lastInboundAt: Date.now() });
+      return;
+    }
 
     const textLimit = core.channel.text.resolveTextChunkLimit(cfg, "zulip", account.accountId, {
       fallbackLimit: account.textChunkLimit ?? 4000,
@@ -1071,12 +1099,22 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     }
 
     await subagentContext.finish();
+    if (reactionLifecycleCancelled || opts.abortSignal?.aborted) {
+      await cancelReactionLifecycle();
+      opts.statusSink?.({ lastInboundAt: Date.now() });
+      return;
+    }
     const finalDeliveryFailed = (dispatchResult?.failedCounts?.final ?? 0) > 0;
     const terminalError = Boolean(dispatchError) || finalDeliveryFailed;
     if (terminalError) {
       await statusReactions.setError();
     } else {
       await statusReactions.setDone();
+    }
+    if (reactionLifecycleCancelled || opts.abortSignal?.aborted) {
+      await cancelReactionLifecycle();
+      opts.statusSink?.({ lastInboundAt: Date.now() });
+      return;
     }
     if (account.config.reactions?.clearOnFinish !== false) {
       const terminalHoldMs = terminalError
@@ -1221,29 +1259,95 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     }
   };
 
-  await replayPendingDurableInboundMessages();
+  const handleMonitorAbort = () => {
+    void cleanupActiveReactionLifecycles();
+  };
+  opts.abortSignal?.addEventListener("abort", handleMonitorAbort, { once: true });
 
-  // Long-poll at 90s — nginx proxy_read_timeout is now 120s
-  while (!opts.abortSignal?.aborted) {
-    try {
-      const response = await getZulipEventsWithRetry(client, {
-        queueId,
-        lastEventId,
-        timeoutMs: 90000,
-        retryBaseDelayMs: 1000,
-        signal: opts.abortSignal,
-        dontBlock: false,
-      });
+  try {
+    await replayPendingDurableInboundMessages();
 
-      if (response.result === "error") {
-        const msg = response.msg ?? "";
-        const isBadQueue =
-          response.code === "BAD_EVENT_QUEUE_ID" || msg.toLowerCase().includes("bad event queue");
-        if (isBadQueue) {
-          runtime.log?.("zulip: queue expired, re-registering...");
+    // Long-poll at 90s — nginx proxy_read_timeout is now 120s
+    while (!opts.abortSignal?.aborted) {
+      try {
+        const response = await getZulipEventsWithRetry(client, {
+          queueId,
+          lastEventId,
+          timeoutMs: 90000,
+          retryBaseDelayMs: 1000,
+          signal: opts.abortSignal,
+          dontBlock: false,
+        });
+
+        if (response.result === "error") {
+          const msg = response.msg ?? "";
+          const isBadQueue =
+            response.code === "BAD_EVENT_QUEUE_ID" || msg.toLowerCase().includes("bad event queue");
+          if (isBadQueue) {
+            runtime.log?.("zulip: queue expired, re-registering...");
+            const newQueue = await registerZulipQueue(client, {
+              eventTypes: ["message"],
+              streams, // Pass ["*"] to trigger all_public_streams=true in registerZulipQueue
+            });
+            queueId = newQueue.queueId;
+            lastEventId = newQueue.lastEventId;
+            runtime.log?.(`zulip event queue re-registered: ${queueId}`);
+            resetPollBackoff();
+            continue;
+          }
+          throw new Error(`Zulip events error: ${response.msg}`);
+        }
+
+        const events = response.events ?? [];
+        runtime.log?.(`zulip: poll ok, ${events.length} events, lastEventId=${lastEventId}`);
+        if (events.length > 0) {
+          opts.statusSink?.({
+            connected: true,
+            lastConnectedAt: Date.now(),
+          });
+        }
+
+        if (events.length === 0) {
+          await delay(200, opts.abortSignal);
+        }
+
+        resetPollBackoff();
+
+        // Process messages with staggered start times for more natural feel
+        for (const event of events) {
+          if (opts.abortSignal?.aborted) {
+            break;
+          }
+          const nextEventId = Number((event as { id?: unknown })?.id);
+          const validEventId =
+            !Number.isNaN(nextEventId) && nextEventId >= 0 ? nextEventId : undefined;
+          if (validEventId !== undefined) {
+            lastEventId = validEventId;
+          }
+
+          if (event.type === "message" && event.message) {
+            // Start processing without awaiting (fire-and-forget with error handling)
+            const messageTask = processMessage(event.message, validEventId).catch((err) => {
+              runtime.error?.(`zulip: message processing failed: ${String(err)}`);
+            });
+            activeMessageTasks.add(messageTask);
+            void messageTask.finally(() => {
+              activeMessageTasks.delete(messageTask);
+            });
+            // Small delay between starting each message for natural pacing
+            await delay(200, opts.abortSignal);
+          }
+        }
+      } catch (err) {
+        if (opts.abortSignal?.aborted) {
+          break;
+        }
+        const errStr = String(err);
+        if (errStr.toLowerCase().includes("bad event queue")) {
+          runtime.log?.("zulip: bad event queue error thrown; re-registering...");
           const newQueue = await registerZulipQueue(client, {
             eventTypes: ["message"],
-            streams, // Pass ["*"] to trigger all_public_streams=true in registerZulipQueue
+            streams,
           });
           queueId = newQueue.queueId;
           lastEventId = newQueue.lastEventId;
@@ -1251,85 +1355,30 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
           resetPollBackoff();
           continue;
         }
-        throw new Error(`Zulip events error: ${response.msg}`);
-      }
-
-      const events = response.events ?? [];
-      runtime.log?.(`zulip: poll ok, ${events.length} events, lastEventId=${lastEventId}`);
-      if (events.length > 0) {
+        const status = (err as { status?: number })?.status;
+        const retryAfterMs = (err as { retryAfterMs?: number })?.retryAfterMs;
+        runtime.error?.(`zulip polling error: ${String(err)}`);
         opts.statusSink?.({
-          connected: true,
-          lastConnectedAt: Date.now(),
+          connected: false,
+          lastError: String(err),
         });
-      }
-
-      if (events.length === 0) {
-        await delay(200);
-      }
-
-      resetPollBackoff();
-
-      // Process messages with staggered start times for more natural feel
-      for (const event of events) {
-        const nextEventId = Number((event as { id?: unknown })?.id);
-        const validEventId = !Number.isNaN(nextEventId) && nextEventId >= 0 ? nextEventId : undefined;
-        if (validEventId !== undefined) {
-          lastEventId = validEventId;
+        const baseDelay = status === 429 ? 10000 : 1000;
+        if (!pollBackoffMs) {
+          pollBackoffMs = baseDelay;
+        } else {
+          pollBackoffMs = Math.min(120000, pollBackoffMs * 2);
         }
-
-        if (event.type === "message" && event.message) {
-          // Start processing without awaiting (fire-and-forget with error handling)
-          const messageTask = processMessage(event.message, validEventId).catch((err) => {
-            runtime.error?.(`zulip: message processing failed: ${String(err)}`);
-          });
-          activeMessageTasks.add(messageTask);
-          void messageTask.finally(() => {
-            activeMessageTasks.delete(messageTask);
-          });
-          // Small delay between starting each message for natural pacing
-          await delay(200);
-        }
+        const waitMs =
+          retryAfterMs && retryAfterMs > 0 ? Math.min(120000, retryAfterMs) : pollBackoffMs;
+        await delay(waitMs, opts.abortSignal);
       }
-    } catch (err) {
-      if (opts.abortSignal?.aborted) {
-        break;
-      }
-      const errStr = String(err);
-      if (errStr.toLowerCase().includes("bad event queue")) {
-        runtime.log?.("zulip: bad event queue error thrown; re-registering...");
-        const newQueue = await registerZulipQueue(client, {
-          eventTypes: ["message"],
-          streams,
-        });
-        queueId = newQueue.queueId;
-        lastEventId = newQueue.lastEventId;
-        runtime.log?.(`zulip event queue re-registered: ${queueId}`);
-        resetPollBackoff();
-        continue;
-      }
-      const status = (err as { status?: number })?.status;
-      const retryAfterMs = (err as { retryAfterMs?: number })?.retryAfterMs;
-      runtime.error?.(`zulip polling error: ${String(err)}`);
-      opts.statusSink?.({
-        connected: false,
-        lastError: String(err),
-      });
-      const baseDelay = status === 429 ? 10000 : 1000;
-      if (!pollBackoffMs) {
-        pollBackoffMs = baseDelay;
-      } else {
-        pollBackoffMs = Math.min(120000, pollBackoffMs * 2);
-      }
-      const waitMs =
-        retryAfterMs && retryAfterMs > 0 ? Math.min(120000, retryAfterMs) : pollBackoffMs;
-      await delay(waitMs);
     }
+  } finally {
+    opts.abortSignal?.removeEventListener("abort", handleMonitorAbort);
+    await cleanupActiveReactionLifecycles();
+    await Promise.allSettled(Array.from(activeMessageTasks));
+    await cleanupActiveReactionLifecycles();
   }
-
-  const pendingReactionCleanups = Array.from(activeReactionCleanups, (cleanup) => cleanup());
-  await Promise.allSettled(pendingReactionCleanups);
-  await Promise.allSettled(Array.from(activeMessageTasks));
-  await Promise.allSettled(Array.from(activeReactionCleanups, (cleanup) => cleanup()));
 
   // Cleanup
   await deleteZulipQueue(client, queueId);

--- a/src/zulip/status-reactions.test.ts
+++ b/src/zulip/status-reactions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   createZulipStatusReactionAdapter,
+  isSupportedZulipReactionValue,
   resolveZulipReactionSpec,
   resolveZulipStatusReactionConfig,
 } from "./status-reactions.js";
@@ -92,4 +93,22 @@ describe("Zulip status reaction configuration", () => {
     expect(add).not.toHaveBeenCalled();
     expect(remove).not.toHaveBeenCalled();
   });
+
+  it.each(["+1", "-1", ":+1:", ":-1:"])(
+    "accepts leading-sign Zulip emoji name %s",
+    (emoji) => {
+      expect(isSupportedZulipReactionValue(emoji)).toBe(true);
+      expect(resolveZulipReactionSpec(emoji)).toEqual({
+        emojiName: emoji.replaceAll(":", ""),
+      });
+    },
+  );
+
+  it.each(["+", "-", ":+:", ":-:", ":+1", "+1:", "white space", "🦄"])(
+    "rejects invalid Zulip emoji value %s",
+    (emoji) => {
+      expect(isSupportedZulipReactionValue(emoji)).toBe(false);
+      expect(() => resolveZulipReactionSpec(emoji)).toThrow(/Unsupported Zulip reaction/);
+    },
+  );
 });

--- a/src/zulip/status-reactions.test.ts
+++ b/src/zulip/status-reactions.test.ts
@@ -61,4 +61,35 @@ describe("Zulip status reaction configuration", () => {
     expect(add).toHaveBeenCalledWith(expected);
     expect(remove).toHaveBeenCalledWith(expected);
   });
+
+  it("preserves explicit empty legacy and subagent overrides", () => {
+    const result = resolveZulipStatusReactionConfig({
+      accountConfig: {
+        reactions: {
+          onStart: "",
+          onSuccess: "",
+          onError: "",
+          subagent: "",
+        },
+      },
+    });
+
+    expect(result.emojis.queued).toBe("");
+    expect(result.emojis.done).toBe("");
+    expect(result.emojis.error).toBe("");
+    expect(result.subagent).toBe("");
+  });
+
+  it("rejects arbitrary Unicode and treats an empty reaction as suppressed", async () => {
+    expect(() => resolveZulipReactionSpec("🦄")).toThrow(/Unsupported Zulip reaction/);
+    const add = vi.fn(async () => {});
+    const remove = vi.fn(async () => {});
+    const adapter = createZulipStatusReactionAdapter({ add, remove });
+
+    await adapter.setReaction("");
+    await adapter.removeReaction?.("");
+
+    expect(add).not.toHaveBeenCalled();
+    expect(remove).not.toHaveBeenCalled();
+  });
 });

--- a/src/zulip/status-reactions.test.ts
+++ b/src/zulip/status-reactions.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createZulipStatusReactionAdapter,
+  resolveZulipReactionSpec,
+  resolveZulipStatusReactionConfig,
+} from "./status-reactions.js";
+
+describe("Zulip status reaction configuration", () => {
+  it("merges global and account overrides while preserving legacy aliases", () => {
+    const result = resolveZulipStatusReactionConfig({
+      globalStatusReactions: {
+        enabled: false,
+        emojis: { thinking: "thinking" },
+        timing: { stallSoftMs: 20_000 },
+      },
+      accountConfig: {
+        reactions: {
+          enabled: true,
+          onStart: "queued_custom",
+          onSuccess: "done_custom",
+          onError: "error_custom",
+          emojis: { tool: "tool_custom" },
+          timing: { debounceMs: 25 },
+          subagent: ":robot_face:",
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      enabled: true,
+      subagent: "robot_face",
+      emojis: {
+        queued: "queued_custom",
+        thinking: "thinking",
+        tool: "tool_custom",
+        done: "done_custom",
+        error: "error_custom",
+      },
+      timing: { stallSoftMs: 20_000, debounceMs: 25 },
+    });
+  });
+
+  it("maps Unicode lifecycle emoji to complete Zulip reaction parameters", async () => {
+    expect(resolveZulipReactionSpec("⚠️")).toEqual({
+      emojiName: "warning",
+      emojiCode: "26a0",
+      reactionType: "unicode_emoji",
+    });
+    const add = vi.fn(async () => {});
+    const remove = vi.fn(async () => {});
+    const adapter = createZulipStatusReactionAdapter({ add, remove });
+
+    await adapter.setReaction("🤖");
+    await adapter.removeReaction?.("🤖");
+
+    const expected = {
+      emojiName: "robot_face",
+      emojiCode: "1f916",
+      reactionType: "unicode_emoji",
+    };
+    expect(add).toHaveBeenCalledWith(expected);
+    expect(remove).toHaveBeenCalledWith(expected);
+  });
+});

--- a/src/zulip/status-reactions.ts
+++ b/src/zulip/status-reactions.ts
@@ -1,0 +1,103 @@
+import type {
+  StatusReactionAdapter,
+  StatusReactionEmojis,
+  StatusReactionTiming,
+} from "openclaw/plugin-sdk/channel-feedback";
+import type { ZulipAccountConfig } from "../types.js";
+import { normalizeZulipEmojiName } from "./uploads.js";
+
+type ZulipReactionSpec = {
+  emojiName: string;
+  emojiCode?: string;
+  reactionType?: string;
+};
+
+const unicodeStatusReactions = new Map<string, ZulipReactionSpec>([
+  ["👀", { emojiName: "eyes", emojiCode: "1f440", reactionType: "unicode_emoji" }],
+  ["🧠", { emojiName: "brain", emojiCode: "1f9e0", reactionType: "unicode_emoji" }],
+  ["🛠", { emojiName: "hammer_and_wrench", emojiCode: "1f6e0", reactionType: "unicode_emoji" }],
+  ["💻", { emojiName: "computer", emojiCode: "1f4bb", reactionType: "unicode_emoji" }],
+  ["🌐", { emojiName: "globe_with_meridians", emojiCode: "1f310", reactionType: "unicode_emoji" }],
+  ["🛫", { emojiName: "airplane_departure", emojiCode: "1f6eb", reactionType: "unicode_emoji" }],
+  ["🏗", { emojiName: "building_construction", emojiCode: "1f3d7", reactionType: "unicode_emoji" }],
+  ["💁", { emojiName: "information_desk_person", emojiCode: "1f481", reactionType: "unicode_emoji" }],
+  ["✅", { emojiName: "check", emojiCode: "2705", reactionType: "unicode_emoji" }],
+  ["❌", { emojiName: "cross_mark", emojiCode: "274c", reactionType: "unicode_emoji" }],
+  ["⏳", { emojiName: "hourglass_flowing_sand", emojiCode: "23f3", reactionType: "unicode_emoji" }],
+  ["⚠", { emojiName: "warning", emojiCode: "26a0", reactionType: "unicode_emoji" }],
+  ["🗜", { emojiName: "compression", emojiCode: "1f5dc", reactionType: "unicode_emoji" }],
+  ["🤖", { emojiName: "robot_face", emojiCode: "1f916", reactionType: "unicode_emoji" }],
+]);
+
+export const ZULIP_STATUS_REACTION_DEFAULTS: Required<StatusReactionEmojis> = {
+  queued: "eyes",
+  thinking: "brain",
+  tool: "hammer_and_wrench",
+  coding: "computer",
+  web: "globe_with_meridians",
+  deploy: "airplane_departure",
+  build: "building_construction",
+  concierge: "information_desk_person",
+  done: "check",
+  error: "cross_mark",
+  stallSoft: "hourglass_flowing_sand",
+  stallHard: "warning",
+  compacting: "compression",
+};
+
+export function resolveZulipReactionSpec(raw: string): ZulipReactionSpec {
+  const normalizedUnicode = raw.replaceAll("\ufe0f", "");
+  return (
+    unicodeStatusReactions.get(normalizedUnicode) ?? {
+      emojiName: normalizeZulipEmojiName(raw),
+    }
+  );
+}
+
+export function resolveZulipStatusReactionConfig(params: {
+  accountConfig: ZulipAccountConfig;
+  globalStatusReactions?: {
+    enabled?: boolean;
+    emojis?: StatusReactionEmojis;
+    timing?: StatusReactionTiming;
+  };
+}): {
+  enabled: boolean;
+  emojis: Required<StatusReactionEmojis>;
+  timing?: StatusReactionTiming;
+  subagent: string;
+} {
+  const local = params.accountConfig.reactions;
+  const emojis = {
+    ...ZULIP_STATUS_REACTION_DEFAULTS,
+    ...params.globalStatusReactions?.emojis,
+    ...local?.emojis,
+  };
+  const legacyQueued = normalizeZulipEmojiName(local?.onStart);
+  const legacyDone = normalizeZulipEmojiName(local?.onSuccess);
+  const legacyError = normalizeZulipEmojiName(local?.onError);
+  return {
+    enabled: local?.enabled ?? params.globalStatusReactions?.enabled ?? true,
+    emojis: {
+      ...emojis,
+      queued: legacyQueued || emojis.queued,
+      done: legacyDone || emojis.done,
+      error: legacyError || emojis.error,
+    },
+    timing: {
+      ...params.globalStatusReactions?.timing,
+      ...local?.timing,
+    },
+    subagent: normalizeZulipEmojiName(local?.subagent) || "robot_face",
+  };
+}
+
+export function createZulipStatusReactionAdapter(params: {
+  add: (reaction: ZulipReactionSpec) => Promise<void>;
+  remove: (reaction: ZulipReactionSpec) => Promise<void>;
+}): StatusReactionAdapter {
+  return {
+    setReaction: async (emoji) => params.add(resolveZulipReactionSpec(emoji)),
+    removeReaction: async (emoji) => params.remove(resolveZulipReactionSpec(emoji)),
+  };
+}

--- a/src/zulip/status-reactions.ts
+++ b/src/zulip/status-reactions.ts
@@ -28,6 +28,21 @@ const unicodeStatusReactions = new Map<string, ZulipReactionSpec>([
   ["🗜", { emojiName: "compression", emojiCode: "1f5dc", reactionType: "unicode_emoji" }],
   ["🤖", { emojiName: "robot_face", emojiCode: "1f916", reactionType: "unicode_emoji" }],
 ]);
+const namedZulipEmojiPattern = /^:?[A-Za-z0-9][A-Za-z0-9_+-]*:?$/;
+
+export function isSupportedZulipReactionValue(raw: string): boolean {
+  if (raw === "") {
+    return true;
+  }
+  const normalizedUnicode = raw.replaceAll("\ufe0f", "");
+  if (unicodeStatusReactions.has(normalizedUnicode)) {
+    return true;
+  }
+  if (!namedZulipEmojiPattern.test(raw)) {
+    return false;
+  }
+  return !(raw.startsWith(":") !== raw.endsWith(":"));
+}
 
 export const ZULIP_STATUS_REACTION_DEFAULTS: Required<StatusReactionEmojis> = {
   queued: "eyes",
@@ -46,6 +61,11 @@ export const ZULIP_STATUS_REACTION_DEFAULTS: Required<StatusReactionEmojis> = {
 };
 
 export function resolveZulipReactionSpec(raw: string): ZulipReactionSpec {
+  if (!isSupportedZulipReactionValue(raw)) {
+    throw new Error(
+      `Unsupported Zulip reaction ${JSON.stringify(raw)}; use a named Zulip emoji or a documented built-in Unicode value.`,
+    );
+  }
   const normalizedUnicode = raw.replaceAll("\ufe0f", "");
   return (
     unicodeStatusReactions.get(normalizedUnicode) ?? {
@@ -73,22 +93,22 @@ export function resolveZulipStatusReactionConfig(params: {
     ...params.globalStatusReactions?.emojis,
     ...local?.emojis,
   };
-  const legacyQueued = normalizeZulipEmojiName(local?.onStart);
-  const legacyDone = normalizeZulipEmojiName(local?.onSuccess);
-  const legacyError = normalizeZulipEmojiName(local?.onError);
+  const resolveLegacy = (value: string | undefined, fallback: string) =>
+    value === undefined ? fallback : normalizeZulipEmojiName(value);
   return {
     enabled: local?.enabled ?? params.globalStatusReactions?.enabled ?? true,
     emojis: {
       ...emojis,
-      queued: legacyQueued || emojis.queued,
-      done: legacyDone || emojis.done,
-      error: legacyError || emojis.error,
+      queued: resolveLegacy(local?.onStart, emojis.queued),
+      done: resolveLegacy(local?.onSuccess, emojis.done),
+      error: resolveLegacy(local?.onError, emojis.error),
     },
     timing: {
       ...params.globalStatusReactions?.timing,
       ...local?.timing,
     },
-    subagent: normalizeZulipEmojiName(local?.subagent) || "robot_face",
+    subagent:
+      local?.subagent === undefined ? "robot_face" : normalizeZulipEmojiName(local.subagent),
   };
 }
 
@@ -97,7 +117,17 @@ export function createZulipStatusReactionAdapter(params: {
   remove: (reaction: ZulipReactionSpec) => Promise<void>;
 }): StatusReactionAdapter {
   return {
-    setReaction: async (emoji) => params.add(resolveZulipReactionSpec(emoji)),
-    removeReaction: async (emoji) => params.remove(resolveZulipReactionSpec(emoji)),
+    setReaction: async (emoji) => {
+      const reaction = resolveZulipReactionSpec(emoji);
+      if (reaction.emojiName) {
+        await params.add(reaction);
+      }
+    },
+    removeReaction: async (emoji) => {
+      const reaction = resolveZulipReactionSpec(emoji);
+      if (reaction.emojiName) {
+        await params.remove(reaction);
+      }
+    },
   };
 }

--- a/src/zulip/status-reactions.ts
+++ b/src/zulip/status-reactions.ts
@@ -28,7 +28,8 @@ const unicodeStatusReactions = new Map<string, ZulipReactionSpec>([
   ["🗜", { emojiName: "compression", emojiCode: "1f5dc", reactionType: "unicode_emoji" }],
   ["🤖", { emojiName: "robot_face", emojiCode: "1f916", reactionType: "unicode_emoji" }],
 ]);
-const namedZulipEmojiPattern = /^:?[A-Za-z0-9][A-Za-z0-9_+-]*:?$/;
+const namedZulipEmojiPattern =
+  /^:?(?:[A-Za-z0-9][A-Za-z0-9_+-]*|[+-][A-Za-z0-9][A-Za-z0-9_+-]*):?$/;
 
 export function isSupportedZulipReactionValue(raw: string): boolean {
   if (raw === "") {

--- a/src/zulip/subagent-reactions.test.ts
+++ b/src/zulip/subagent-reactions.test.ts
@@ -11,7 +11,7 @@ describe("Zulip subagent reaction correlation", () => {
     await clearZulipSubagentReactionContexts();
   });
 
-  it("keeps the indicator visible until every concurrently bound child ends", async () => {
+  it("tracks concurrent OpenClaw sessions_spawn children through public hook events", async () => {
     const show = vi.fn(async () => {});
     const hide = vi.fn(async () => {});
     const context = registerZulipSubagentReactionContext({ requesterSessionKey: "requester", show, hide });
@@ -115,6 +115,25 @@ describe("Zulip subagent reaction correlation", () => {
     );
 
     await clearZulipSubagentReactionContexts();
+    await handleZulipSubagentEnded({ runId: "run-1" }, {});
+
+    expect(hide).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels active run bindings during account monitor shutdown", async () => {
+    const hide = vi.fn(async () => {});
+    const context = registerZulipSubagentReactionContext({
+      requesterSessionKey: "requester",
+      show: vi.fn(async () => {}),
+      hide,
+    });
+    await handleZulipSubagentSpawned(
+      { runId: "run-1", requester: { channel: "zulip" } },
+      { requesterSessionKey: "requester" },
+    );
+
+    await context.cancel();
+    await expect(context.closed).resolves.toBeUndefined();
     await handleZulipSubagentEnded({ runId: "run-1" }, {});
 
     expect(hide).toHaveBeenCalledTimes(1);

--- a/src/zulip/subagent-reactions.test.ts
+++ b/src/zulip/subagent-reactions.test.ts
@@ -138,4 +138,77 @@ describe("Zulip subagent reaction correlation", () => {
 
     expect(hide).toHaveBeenCalledTimes(1);
   });
+
+  it("ends every generation bound to a reset child session without touching other children", async () => {
+    const show = vi.fn(async () => {});
+    const hide = vi.fn(async () => {});
+    const context = registerZulipSubagentReactionContext({
+      requesterSessionKey: "requester",
+      show,
+      hide,
+    });
+    await handleZulipSubagentSpawned(
+      { runId: "old-run", childSessionKey: "child-reset", requester: { channel: "zulip" } },
+      { requesterSessionKey: "requester" },
+    );
+    await handleZulipSubagentSpawned(
+      { runId: "new-run", childSessionKey: "child-reset", requester: { channel: "zulip" } },
+      { requesterSessionKey: "requester" },
+    );
+    await handleZulipSubagentSpawned(
+      { runId: "other-run", childSessionKey: "child-active", requester: { channel: "zulip" } },
+      { requesterSessionKey: "requester" },
+    );
+    await context.finish();
+
+    await handleZulipSubagentEnded(
+      { targetSessionKey: "child-reset" },
+      { childSessionKey: "child-reset" },
+    );
+    expect(hide).not.toHaveBeenCalled();
+
+    await handleZulipSubagentEnded({ runId: "other-run" }, {});
+    expect(hide).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not use child fallback for an ended event carrying an unknown stale run id", async () => {
+    const hide = vi.fn(async () => {});
+    const context = registerZulipSubagentReactionContext({
+      requesterSessionKey: "requester",
+      show: vi.fn(async () => {}),
+      hide,
+    });
+    await handleZulipSubagentSpawned(
+      { runId: "current-run", childSessionKey: "shared-child", requester: { channel: "zulip" } },
+      { requesterSessionKey: "requester" },
+    );
+    await context.finish();
+
+    await handleZulipSubagentEnded(
+      { runId: "stale-run", targetSessionKey: "shared-child" },
+      { childSessionKey: "shared-child" },
+    );
+    expect(hide).not.toHaveBeenCalled();
+
+    await handleZulipSubagentEnded({ runId: "current-run" }, {});
+    expect(hide).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not create child-session fallback bindings for non-Zulip spawns", async () => {
+    const show = vi.fn(async () => {});
+    const hide = vi.fn(async () => {});
+    registerZulipSubagentReactionContext({ requesterSessionKey: "requester", show, hide });
+
+    await handleZulipSubagentSpawned(
+      { runId: "discord-run", childSessionKey: "discord-child", requester: { channel: "discord" } },
+      { requesterSessionKey: "requester" },
+    );
+    await handleZulipSubagentEnded(
+      { targetSessionKey: "discord-child" },
+      { childSessionKey: "discord-child" },
+    );
+
+    expect(show).not.toHaveBeenCalled();
+    expect(hide).not.toHaveBeenCalled();
+  });
 });

--- a/src/zulip/subagent-reactions.test.ts
+++ b/src/zulip/subagent-reactions.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clearZulipSubagentReactionContexts,
+  handleZulipSubagentEnded,
+  handleZulipSubagentSpawned,
+  registerZulipSubagentReactionContext,
+} from "./subagent-reactions.js";
+
+describe("Zulip subagent reaction correlation", () => {
+  afterEach(async () => {
+    await clearZulipSubagentReactionContexts();
+  });
+
+  it("keeps the indicator visible until every concurrently bound child ends", async () => {
+    const show = vi.fn(async () => {});
+    const hide = vi.fn(async () => {});
+    const context = registerZulipSubagentReactionContext({ requesterSessionKey: "requester", show, hide });
+
+    await handleZulipSubagentSpawned(
+      { runId: "run-1", requester: { channel: "zulip" } },
+      { requesterSessionKey: "requester" },
+    );
+    await handleZulipSubagentSpawned(
+      { runId: "run-2", requester: { channel: "zulip" } },
+      { requesterSessionKey: "requester" },
+    );
+    await context.finish();
+    await handleZulipSubagentEnded({ runId: "run-1" }, {});
+
+    expect(show).toHaveBeenCalledTimes(1);
+    expect(hide).not.toHaveBeenCalled();
+
+    await handleZulipSubagentEnded({ runId: "run-2" }, {});
+    expect(hide).toHaveBeenCalledTimes(1);
+  });
+
+  it("binds run completion to the exact inbound context active at spawn time", async () => {
+    const first = { show: vi.fn(async () => {}), hide: vi.fn(async () => {}) };
+    const second = { show: vi.fn(async () => {}), hide: vi.fn(async () => {}) };
+    registerZulipSubagentReactionContext({ requesterSessionKey: "requester", ...first });
+    await handleZulipSubagentSpawned(
+      { runId: "old-run", requester: { channel: "zulip" } },
+      { requesterSessionKey: "requester" },
+    );
+
+    registerZulipSubagentReactionContext({ requesterSessionKey: "requester", ...second });
+    await handleZulipSubagentSpawned(
+      { runId: "new-run", requester: { channel: "zulip" } },
+      { requesterSessionKey: "requester" },
+    );
+    await handleZulipSubagentEnded({ runId: "old-run" }, {});
+
+    expect(first.hide).toHaveBeenCalledTimes(1);
+    expect(second.hide).not.toHaveBeenCalled();
+
+    await handleZulipSubagentEnded({ runId: "new-run" }, {});
+    expect(second.hide).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses async turn context when a newer inbound turn is already current", async () => {
+    const first = { show: vi.fn(async () => {}), hide: vi.fn(async () => {}) };
+    const second = { show: vi.fn(async () => {}), hide: vi.fn(async () => {}) };
+    const firstContext = registerZulipSubagentReactionContext({
+      requesterSessionKey: "requester",
+      ...first,
+    });
+
+    await firstContext.run(async () => {
+      registerZulipSubagentReactionContext({ requesterSessionKey: "requester", ...second });
+      await handleZulipSubagentSpawned(
+        { runId: "old-turn-run", requester: { channel: "zulip" } },
+        { requesterSessionKey: "requester" },
+      );
+    });
+
+    expect(first.show).toHaveBeenCalledTimes(1);
+    expect(second.show).not.toHaveBeenCalled();
+
+    await handleZulipSubagentEnded({ runId: "old-turn-run" }, {});
+    expect(first.hide).toHaveBeenCalledTimes(1);
+    expect(second.hide).not.toHaveBeenCalled();
+  });
+
+  it("keeps active children visible after the requester turn completes", async () => {
+    const show = vi.fn(async () => {});
+    const hide = vi.fn(async () => {});
+    const context = registerZulipSubagentReactionContext({
+      requesterSessionKey: "requester",
+      show,
+      hide,
+    });
+    await handleZulipSubagentSpawned(
+      { runId: "run-1", requester: { channel: "zulip" } },
+      { requesterSessionKey: "requester" },
+    );
+
+    await context.finish();
+    expect(hide).not.toHaveBeenCalled();
+
+    await handleZulipSubagentEnded({ runId: "run-1" }, {});
+
+    expect(hide).toHaveBeenCalledTimes(1);
+  });
+
+  it("cleans active indicators on gateway shutdown", async () => {
+    const hide = vi.fn(async () => {});
+    registerZulipSubagentReactionContext({
+      requesterSessionKey: "requester",
+      show: vi.fn(async () => {}),
+      hide,
+    });
+    await handleZulipSubagentSpawned(
+      { runId: "run-1", requester: { channel: "zulip" } },
+      { requesterSessionKey: "requester" },
+    );
+
+    await clearZulipSubagentReactionContexts();
+    await handleZulipSubagentEnded({ runId: "run-1" }, {});
+
+    expect(hide).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/zulip/subagent-reactions.ts
+++ b/src/zulip/subagent-reactions.ts
@@ -1,0 +1,146 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { OpenClawPluginApi } from "../sdk.js";
+
+type ReactionContext = {
+  requesterSessionKey: string;
+  activeRunIds: Set<string>;
+  indicatorDesired: boolean;
+  indicatorShown: boolean;
+  indicatorOperation: Promise<void>;
+  terminal: boolean;
+  show: () => Promise<void>;
+  hide: () => Promise<void>;
+};
+
+const currentContextBySession = new Map<string, ReactionContext>();
+const contextByRunId = new Map<string, ReactionContext>();
+const activeContexts = new Set<ReactionContext>();
+const reactionContextStorage = new AsyncLocalStorage<ReactionContext>();
+
+function updateIndicator(context: ReactionContext, visible: boolean): Promise<void> {
+  context.indicatorDesired = visible;
+  const applyDesiredState = async () => {
+    if (context.indicatorDesired === context.indicatorShown) {
+      return;
+    }
+    if (context.indicatorDesired) {
+      await context.show();
+      context.indicatorShown = true;
+      return;
+    }
+    await context.hide();
+    context.indicatorShown = false;
+  };
+  context.indicatorOperation = context.indicatorOperation.then(applyDesiredState, applyDesiredState);
+  return context.indicatorOperation;
+}
+
+function resolveRunId(event: { runId?: string }, ctx: { runId?: string }): string {
+  return event.runId?.trim() || ctx.runId?.trim() || "";
+}
+
+export function registerZulipSubagentReactionContext(params: {
+  requesterSessionKey: string;
+  show: () => Promise<void>;
+  hide: () => Promise<void>;
+}): {
+  run: <T>(callback: () => Promise<T>) => Promise<T>;
+  finish: () => Promise<void>;
+} {
+  const context: ReactionContext = {
+    requesterSessionKey: params.requesterSessionKey,
+    activeRunIds: new Set(),
+    indicatorDesired: false,
+    indicatorShown: false,
+    indicatorOperation: Promise.resolve(),
+    terminal: false,
+    show: params.show,
+    hide: params.hide,
+  };
+  currentContextBySession.set(params.requesterSessionKey, context);
+  activeContexts.add(context);
+
+  return {
+    run: (callback) => reactionContextStorage.run(context, callback),
+    finish: async () => {
+      if (context.terminal) {
+        return;
+      }
+      context.terminal = true;
+      if (currentContextBySession.get(context.requesterSessionKey) === context) {
+        currentContextBySession.delete(context.requesterSessionKey);
+      }
+      if (context.activeRunIds.size === 0) {
+        activeContexts.delete(context);
+        await updateIndicator(context, false);
+      }
+    },
+  };
+}
+
+export async function handleZulipSubagentSpawned(
+  event: { runId: string; requester?: { channel?: string } },
+  ctx: { runId?: string; requesterSessionKey?: string },
+): Promise<void> {
+  if (event.requester?.channel && event.requester.channel !== "zulip") {
+    return;
+  }
+  const runId = resolveRunId(event, ctx);
+  const requesterSessionKey = ctx.requesterSessionKey?.trim() ?? "";
+  if (!runId || !requesterSessionKey || contextByRunId.has(runId)) {
+    return;
+  }
+  const asyncContext = reactionContextStorage.getStore();
+  const context =
+    asyncContext?.requesterSessionKey === requesterSessionKey
+      ? asyncContext
+      : currentContextBySession.get(requesterSessionKey);
+  if (!context || context.terminal) {
+    return;
+  }
+  contextByRunId.set(runId, context);
+  context.activeRunIds.add(runId);
+  if (context.activeRunIds.size === 1) {
+    await updateIndicator(context, true);
+  }
+}
+
+export async function handleZulipSubagentEnded(
+  event: { runId?: string },
+  ctx: { runId?: string },
+): Promise<void> {
+  const runId = resolveRunId(event, ctx);
+  if (!runId) {
+    return;
+  }
+  const context = contextByRunId.get(runId);
+  if (!context) {
+    return;
+  }
+  contextByRunId.delete(runId);
+  context.activeRunIds.delete(runId);
+  if (context.activeRunIds.size === 0) {
+    if (context.terminal) {
+      activeContexts.delete(context);
+    }
+    await updateIndicator(context, false);
+  }
+}
+
+export async function clearZulipSubagentReactionContexts(): Promise<void> {
+  const contexts = Array.from(activeContexts);
+  currentContextBySession.clear();
+  contextByRunId.clear();
+  activeContexts.clear();
+  for (const context of contexts) {
+    context.terminal = true;
+    context.activeRunIds.clear();
+    await updateIndicator(context, false);
+  }
+}
+
+export function registerZulipSubagentReactionHooks(api: OpenClawPluginApi): void {
+  api.on("subagent_spawned", handleZulipSubagentSpawned);
+  api.on("subagent_ended", handleZulipSubagentEnded);
+  api.on("gateway_stop", clearZulipSubagentReactionContexts);
+}

--- a/src/zulip/subagent-reactions.ts
+++ b/src/zulip/subagent-reactions.ts
@@ -15,7 +15,8 @@ type ReactionContext = {
 };
 
 const currentContextBySession = new Map<string, ReactionContext>();
-const contextByRunId = new Map<string, ReactionContext>();
+const bindingByRunId = new Map<string, { context: ReactionContext; childSessionKey: string }>();
+const bindingsByChildSessionKey = new Map<string, Map<string, ReactionContext>>();
 const activeContexts = new Set<ReactionContext>();
 const reactionContextStorage = new AsyncLocalStorage<ReactionContext>();
 
@@ -39,6 +40,35 @@ function updateIndicator(context: ReactionContext, visible: boolean): Promise<vo
 
 function resolveRunId(event: { runId?: string }, ctx: { runId?: string }): string {
   return event.runId?.trim() || ctx.runId?.trim() || "";
+}
+
+function resolveChildSessionKey(
+  event: { childSessionKey?: string; targetSessionKey?: string },
+  ctx: { childSessionKey?: string },
+): string {
+  return (
+    event.childSessionKey?.trim() ||
+    event.targetSessionKey?.trim() ||
+    ctx.childSessionKey?.trim() ||
+    ""
+  );
+}
+
+function removeRunBinding(runId: string): ReactionContext | undefined {
+  const binding = bindingByRunId.get(runId);
+  if (!binding) {
+    return undefined;
+  }
+  bindingByRunId.delete(runId);
+  binding.context.activeRunIds.delete(runId);
+  if (binding.childSessionKey) {
+    const childBindings = bindingsByChildSessionKey.get(binding.childSessionKey);
+    childBindings?.delete(runId);
+    if (childBindings?.size === 0) {
+      bindingsByChildSessionKey.delete(binding.childSessionKey);
+    }
+  }
+  return binding.context;
 }
 
 function closeContext(context: ReactionContext): void {
@@ -100,12 +130,11 @@ export function registerZulipSubagentReactionContext(params: {
       if (currentContextBySession.get(context.requesterSessionKey) === context) {
         currentContextBySession.delete(context.requesterSessionKey);
       }
-      for (const runId of context.activeRunIds) {
-        if (contextByRunId.get(runId) === context) {
-          contextByRunId.delete(runId);
+      for (const runId of Array.from(context.activeRunIds)) {
+        if (bindingByRunId.get(runId)?.context === context) {
+          removeRunBinding(runId);
         }
       }
-      context.activeRunIds.clear();
       await updateIndicator(context, false);
       closeContext(context);
     },
@@ -113,15 +142,16 @@ export function registerZulipSubagentReactionContext(params: {
 }
 
 export async function handleZulipSubagentSpawned(
-  event: { runId: string; requester?: { channel?: string } },
-  ctx: { runId?: string; requesterSessionKey?: string },
+  event: { runId: string; childSessionKey?: string; requester?: { channel?: string } },
+  ctx: { runId?: string; childSessionKey?: string; requesterSessionKey?: string },
 ): Promise<void> {
   if (event.requester?.channel && event.requester.channel !== "zulip") {
     return;
   }
   const runId = resolveRunId(event, ctx);
+  const childSessionKey = resolveChildSessionKey(event, ctx);
   const requesterSessionKey = ctx.requesterSessionKey?.trim() ?? "";
-  if (!runId || !requesterSessionKey || contextByRunId.has(runId)) {
+  if (!runId || !requesterSessionKey || bindingByRunId.has(runId)) {
     return;
   }
   const asyncContext = reactionContextStorage.getStore();
@@ -132,7 +162,12 @@ export async function handleZulipSubagentSpawned(
   if (!context || context.terminal) {
     return;
   }
-  contextByRunId.set(runId, context);
+  bindingByRunId.set(runId, { context, childSessionKey });
+  if (childSessionKey) {
+    const childBindings = bindingsByChildSessionKey.get(childSessionKey) ?? new Map();
+    childBindings.set(runId, context);
+    bindingsByChildSessionKey.set(childSessionKey, childBindings);
+  }
   context.activeRunIds.add(runId);
   if (context.activeRunIds.size === 1) {
     await updateIndicator(context, true);
@@ -140,23 +175,41 @@ export async function handleZulipSubagentSpawned(
 }
 
 export async function handleZulipSubagentEnded(
-  event: { runId?: string },
-  ctx: { runId?: string },
+  event: { runId?: string; targetSessionKey?: string },
+  ctx: { runId?: string; childSessionKey?: string },
 ): Promise<void> {
   const runId = resolveRunId(event, ctx);
-  if (!runId) {
+  if (runId) {
+    const context = removeRunBinding(runId);
+    if (!context) {
+      return;
+    }
+    if (context.activeRunIds.size === 0) {
+      await updateIndicator(context, false);
+      if (context.terminal) {
+        closeContext(context);
+      }
+    }
     return;
   }
-  const context = contextByRunId.get(runId);
-  if (!context) {
+  const childSessionKey = resolveChildSessionKey(event, ctx);
+  const childBindings = bindingsByChildSessionKey.get(childSessionKey);
+  if (!childSessionKey || !childBindings) {
     return;
   }
-  contextByRunId.delete(runId);
-  context.activeRunIds.delete(runId);
-  if (context.activeRunIds.size === 0) {
-    await updateIndicator(context, false);
-    if (context.terminal) {
-      closeContext(context);
+  const affectedContexts = new Set<ReactionContext>();
+  for (const childRunId of Array.from(childBindings.keys())) {
+    const context = removeRunBinding(childRunId);
+    if (context) {
+      affectedContexts.add(context);
+    }
+  }
+  for (const context of affectedContexts) {
+    if (context.activeRunIds.size === 0) {
+      await updateIndicator(context, false);
+      if (context.terminal) {
+        closeContext(context);
+      }
     }
   }
 }
@@ -164,7 +217,8 @@ export async function handleZulipSubagentEnded(
 export async function clearZulipSubagentReactionContexts(): Promise<void> {
   const contexts = Array.from(activeContexts);
   currentContextBySession.clear();
-  contextByRunId.clear();
+  bindingByRunId.clear();
+  bindingsByChildSessionKey.clear();
   activeContexts.clear();
   for (const context of contexts) {
     context.terminal = true;

--- a/src/zulip/subagent-reactions.ts
+++ b/src/zulip/subagent-reactions.ts
@@ -8,6 +8,8 @@ type ReactionContext = {
   indicatorShown: boolean;
   indicatorOperation: Promise<void>;
   terminal: boolean;
+  closed: boolean;
+  resolveClosed: () => void;
   show: () => Promise<void>;
   hide: () => Promise<void>;
 };
@@ -39,6 +41,15 @@ function resolveRunId(event: { runId?: string }, ctx: { runId?: string }): strin
   return event.runId?.trim() || ctx.runId?.trim() || "";
 }
 
+function closeContext(context: ReactionContext): void {
+  if (context.closed) {
+    return;
+  }
+  context.closed = true;
+  activeContexts.delete(context);
+  context.resolveClosed();
+}
+
 export function registerZulipSubagentReactionContext(params: {
   requesterSessionKey: string;
   show: () => Promise<void>;
@@ -46,7 +57,13 @@ export function registerZulipSubagentReactionContext(params: {
 }): {
   run: <T>(callback: () => Promise<T>) => Promise<T>;
   finish: () => Promise<void>;
+  cancel: () => Promise<void>;
+  closed: Promise<void>;
 } {
+  let resolveClosed!: () => void;
+  const closed = new Promise<void>((resolve) => {
+    resolveClosed = resolve;
+  });
   const context: ReactionContext = {
     requesterSessionKey: params.requesterSessionKey,
     activeRunIds: new Set(),
@@ -54,6 +71,8 @@ export function registerZulipSubagentReactionContext(params: {
     indicatorShown: false,
     indicatorOperation: Promise.resolve(),
     terminal: false,
+    closed: false,
+    resolveClosed,
     show: params.show,
     hide: params.hide,
   };
@@ -62,6 +81,7 @@ export function registerZulipSubagentReactionContext(params: {
 
   return {
     run: (callback) => reactionContextStorage.run(context, callback),
+    closed,
     finish: async () => {
       if (context.terminal) {
         return;
@@ -71,9 +91,23 @@ export function registerZulipSubagentReactionContext(params: {
         currentContextBySession.delete(context.requesterSessionKey);
       }
       if (context.activeRunIds.size === 0) {
-        activeContexts.delete(context);
         await updateIndicator(context, false);
+        closeContext(context);
       }
+    },
+    cancel: async () => {
+      context.terminal = true;
+      if (currentContextBySession.get(context.requesterSessionKey) === context) {
+        currentContextBySession.delete(context.requesterSessionKey);
+      }
+      for (const runId of context.activeRunIds) {
+        if (contextByRunId.get(runId) === context) {
+          contextByRunId.delete(runId);
+        }
+      }
+      context.activeRunIds.clear();
+      await updateIndicator(context, false);
+      closeContext(context);
     },
   };
 }
@@ -120,10 +154,10 @@ export async function handleZulipSubagentEnded(
   contextByRunId.delete(runId);
   context.activeRunIds.delete(runId);
   if (context.activeRunIds.size === 0) {
-    if (context.terminal) {
-      activeContexts.delete(context);
-    }
     await updateIndicator(context, false);
+    if (context.terminal) {
+      closeContext(context);
+    }
   }
 }
 
@@ -136,6 +170,7 @@ export async function clearZulipSubagentReactionContexts(): Promise<void> {
     context.terminal = true;
     context.activeRunIds.clear();
     await updateIndicator(context, false);
+    closeContext(context);
   }
 }
 


### PR DESCRIPTION
Closes #35.

Adds truthful lifecycle reactions on the inbound Zulip message using OpenClaw's public status-reaction controller:

- queued, thinking, tool-category, compaction, stall, done, and error states
- a dedicated subagent indicator driven by actual `sessions_spawn` lifecycle hooks
- exact run-to-message correlation for concurrent children and overlapping turns
- reset/delete fallback through child-session correlation when an ended event has no run ID
- resolved final-delivery failures reported as error rather than done
- prompt, abort-aware cleanup across live polling, retry backoff, event batches, durable replay, terminal holds, and gateway shutdown
- account/global emoji and timing overrides with legacy reaction-key compatibility

Codex-native collaboration tasks do not currently expose public lifecycle hooks, so the subagent indicator intentionally covers OpenClaw `sessions_spawn` children only.

Verification:

- `pnpm build`
- `pnpm test` (175 tests)
- `pnpm exec tsc --noEmit`
- `git diff --check`
- manifest JSON validation
- `npm pack --dry-run --ignore-scripts`

Independent reviewer-of-record approved frozen commit `3a9d8a1bc1d9fd82c23a3eada690a2086c78a4e2` after three shutdown/delivery race corrections and exact regression coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches inbound reply handling, durable journaling, and concurrent shutdown races; mis-correlation could leave wrong reactions or retry behavior, though coverage is extensive.
> 
> **Overview**
> Replaces the Zulip channel’s coarse **start/success/error** reaction hooks with OpenClaw’s **status-reaction controller**, so inbound messages show **queued, thinking, tool-category, compaction, stall, done, and error** states driven by real reply lifecycle callbacks. **Lifecycle reactions default to on** (`clearOnFinish`, configurable emojis/timing); legacy `onStart` / `onSuccess` / `onError` map to queued/done/error.
> 
> Adds a separate **`subagent` reaction** (default `robot_face`) wired through **`subagent_spawned` / `subagent_ended`** (and gateway stop), with per-turn correlation for concurrent children and children that outlive the requester reply. Config and manifest gain validated **`reactions.emojis`**, **`timing`**, and **`subagent`** (named Zulip emoji or allowlisted Unicode only).
> 
> The monitor now propagates **`abortSignal`** into dispatch, classifies **failed final delivery** as error, keeps **durable inbound** retryable when nothing was delivered, and **cleans up reactions** on abort, batch pacing, retry backoff, durable replay, and shutdown races (with broad regression tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7999121ec77d66716aa061011eb1b1a84279f157. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->