### PR TITLE
fix: send complete Zulip lifecycle reaction metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - **Agent reaction guidance**: Advertise model-controlled Zulip reactions through prompt guidance, defaulting to extensive while keeping lifecycle/status indicators separate.
 
 ### Bug Fixes
+- **Lifecycle reaction metadata**: Send every built-in lifecycle and subagent default as a fully specified Unicode reaction so Zulip realms do not reject SDK emoji names such as the soft-stall hourglass.
 - **Reply routing**: Store canonical last-route delivery context for Zulip DMs and stream topics so final replies and follow-ups stay on the right conversation.
 - **Replay dedupe**: Durable replay bypasses volatile in-memory duplicate suppression after handler failures.
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,9 @@ outlive the requester's reply. The default is `robot_face`. Built-in lifecycle
 Unicode values (`👀`, `🧠`, `🛠️`, `💻`, `🌐`, `🛫`, `🏗️`, `💁`, `✅`, `❌`,
 `⏳`, `⚠️`, `🗜️`, and `🤖`) and named Zulip emoji are supported; arbitrary
 Unicode is rejected because Zulip requires exact reaction metadata. An empty
-string suppresses that state. Account-level
+string suppresses that state. The built-in defaults use these Unicode values
+so the plugin always sends Zulip's required emoji code and reaction type.
+Account-level
 `reactions.emojis` and `reactions.timing` override global
 `messages.statusReactions` values. The legacy `onStart`, `onSuccess`, and
 `onError` keys remain accepted as queued, done, and error aliases, and an

--- a/src/zulip/status-reactions.test.ts
+++ b/src/zulip/status-reactions.test.ts
@@ -4,6 +4,7 @@ import {
   isSupportedZulipReactionValue,
   resolveZulipReactionSpec,
   resolveZulipStatusReactionConfig,
+  ZULIP_STATUS_REACTION_DEFAULTS,
 } from "./status-reactions.js";
 
 describe("Zulip status reaction configuration", () => {
@@ -61,6 +62,22 @@ describe("Zulip status reaction configuration", () => {
     };
     expect(add).toHaveBeenCalledWith(expected);
     expect(remove).toHaveBeenCalledWith(expected);
+  });
+
+  it("uses fully specified Unicode reactions for every built-in lifecycle default", () => {
+    for (const emoji of Object.values(ZULIP_STATUS_REACTION_DEFAULTS)) {
+      expect(resolveZulipReactionSpec(emoji)).toMatchObject({
+        emojiCode: expect.any(String),
+        reactionType: "unicode_emoji",
+      });
+    }
+
+    const result = resolveZulipStatusReactionConfig({ accountConfig: {} });
+    expect(resolveZulipReactionSpec(result.subagent)).toMatchObject({
+      emojiName: "robot_face",
+      emojiCode: "1f916",
+      reactionType: "unicode_emoji",
+    });
   });
 
   it("preserves explicit empty legacy and subagent overrides", () => {

--- a/src/zulip/status-reactions.ts
+++ b/src/zulip/status-reactions.ts
@@ -46,19 +46,19 @@ export function isSupportedZulipReactionValue(raw: string): boolean {
 }
 
 export const ZULIP_STATUS_REACTION_DEFAULTS: Required<StatusReactionEmojis> = {
-  queued: "eyes",
-  thinking: "brain",
-  tool: "hammer_and_wrench",
-  coding: "computer",
-  web: "globe_with_meridians",
-  deploy: "airplane_departure",
-  build: "building_construction",
-  concierge: "information_desk_person",
-  done: "check",
-  error: "cross_mark",
-  stallSoft: "hourglass_flowing_sand",
-  stallHard: "warning",
-  compacting: "compression",
+  queued: "👀",
+  thinking: "🧠",
+  tool: "🛠️",
+  coding: "💻",
+  web: "🌐",
+  deploy: "🛫",
+  build: "🏗️",
+  concierge: "💁",
+  done: "✅",
+  error: "❌",
+  stallSoft: "⏳",
+  stallHard: "⚠️",
+  compacting: "🗜️",
 };
 
 export function resolveZulipReactionSpec(raw: string): ZulipReactionSpec {
@@ -108,8 +108,7 @@ export function resolveZulipStatusReactionConfig(params: {
       ...params.globalStatusReactions?.timing,
       ...local?.timing,
     },
-    subagent:
-      local?.subagent === undefined ? "robot_face" : normalizeZulipEmojiName(local.subagent),
+    subagent: local?.subagent === undefined ? "🤖" : normalizeZulipEmojiName(local.subagent),
   };
 }
 


### PR DESCRIPTION
Fix the live lifecycle-reaction failure discovered after #36 was deployed.

The built-in lifecycle defaults now use the documented Unicode values, allowing the Zulip adapter to send complete emoji name, code, and reaction type metadata. This covers queued, thinking, tool categories, compaction, stalls, terminal states, and the default subagent indicator. Named overrides and explicit empty suppression remain unchanged.

Verification:

- pnpm build
- pnpm test: 208 tests passed
- git diff --check
- manifest JSON validation
- npm pack dry-run
- independent review approved frozen commit d01e100

Closes #35

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to default reaction strings and docs/tests; custom named emoji overrides and suppression semantics are unchanged.
> 
> **Overview**
> Fixes lifecycle status reactions failing on Zulip after deployment by changing **built-in default emojis** from SDK-style names (`eyes`, `hourglass_flowing_sand`, `robot_face`, etc.) to the plugin’s documented **Unicode literals** (`👀`, `⏳`, `🤖`, …).
> 
> Those defaults now resolve through `resolveZulipReactionSpec` with complete `emojiCode` and `reactionType: unicode_emoji`, which Zulip requires; name-only specs (e.g. soft-stall hourglass) were being rejected. **Named overrides**, legacy `onStart`/`onSuccess`/`onError` aliases, and empty-string suppression are unchanged.
> 
> Adds regression coverage that every `ZULIP_STATUS_REACTION_DEFAULTS` value and the default subagent reaction produce full Unicode specs; **CHANGELOG** and **README** note the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d01e100c58504e0f95525e8f4c5fb974b78254e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->