### PR TITLE
fix: use Zulip canonical lifecycle emoji names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - **Agent reaction guidance**: Advertise model-controlled Zulip reactions through prompt guidance, defaulting to extensive while keeping lifecycle/status indicators separate.
 
 ### Bug Fixes
-- **Lifecycle reaction metadata**: Send every built-in lifecycle and subagent default as a fully specified Unicode reaction so Zulip realms do not reject SDK emoji names such as the soft-stall hourglass.
+- **Lifecycle reaction metadata**: Send every built-in lifecycle and subagent default with Zulip's canonical Unicode emoji name, code, and reaction type so realms accept tool, soft-stall, and child-run indicators.
 - **Reply routing**: Store canonical last-route delivery context for Zulip DMs and stream topics so final replies and follow-ups stay on the right conversation.
 - **Replay dedupe**: Durable replay bypasses volatile in-memory duplicate suppression after handler failures.
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Add the plugin id to `plugins.allow` in `~/.openclaw/openclaw.json`:
       "reactions": {
         "enabled": true,
         "clearOnFinish": true,
-        "subagent": "robot_face",
+        "subagent": "🤖",
         "timing": {
           "stallSoftMs": 10000,
           "stallHardMs": 30000
@@ -151,7 +151,7 @@ Add the plugin id to `plugins.allow` in `~/.openclaw/openclaw.json`:
         "emojis": {
           "thinking": "brain",
           "coding": "computer",
-          "web": "globe_with_meridians"
+          "web": "🌐"
         }
       },
 
@@ -197,7 +197,7 @@ hold. Set it to `false` to retain the final done/error reaction.
 The dedicated `subagent` reaction is driven only by `subagent_spawned` and
 `subagent_ended` hooks. It remains while at least one child run bound to that
 exact inbound turn is active, including concurrent children and children that
-outlive the requester's reply. The default is `robot_face`. Built-in lifecycle
+outlive the requester's reply. The default is `🤖`. Built-in lifecycle
 Unicode values (`👀`, `🧠`, `🛠️`, `💻`, `🌐`, `🛫`, `🏗️`, `💁`, `✅`, `❌`,
 `⏳`, `⚠️`, `🗜️`, and `🤖`) and named Zulip emoji are supported; arbitrary
 Unicode is rejected because Zulip requires exact reaction metadata. An empty

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -250,7 +250,7 @@
         },
         "reactions.subagent": {
           "label": "Active Subagent Reaction",
-          "placeholder": "robot_face"
+          "placeholder": "🤖"
         },
         "agentReactionGuidance": {
           "label": "Agent Reaction Guidance",
@@ -302,7 +302,7 @@
     },
     "reactions.subagent": {
       "label": "Active Subagent Reaction",
-      "placeholder": "robot_face"
+      "placeholder": "🤖"
     },
     "agentReactionGuidance": {
       "label": "Agent Reaction Guidance",

--- a/src/config-schema.test.ts
+++ b/src/config-schema.test.ts
@@ -10,7 +10,7 @@ describe("Zulip lifecycle reaction config", () => {
         clearOnFinish: true,
         emojis: { thinking: "brain", coding: "computer" },
         timing: { debounceMs: 25, stallSoftMs: 10_000, stallHardMs: 30_000 },
-        subagent: "robot_face",
+        subagent: "🤖",
       },
     });
 

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -551,7 +551,7 @@ describe("monitorZulipProvider", () => {
       releaseSubagentHide = resolve;
     });
     state.removeZulipReaction.mockImplementation(async (_client, reaction) => {
-      if (reaction.emojiName === "robot_face") {
+      if (reaction.emojiName === "robot") {
         subagentHideStarted();
         await allowHide;
       }
@@ -1447,7 +1447,7 @@ describe("monitorZulipProvider", () => {
       releaseSubagentHide = resolve;
     });
     state.removeZulipReaction.mockImplementation(async (_client, reaction) => {
-      if (reaction.emojiName === "robot_face") {
+      if (reaction.emojiName === "robot") {
         subagentHideStarted();
         await allowHide;
       }

--- a/src/zulip/status-reactions.test.ts
+++ b/src/zulip/status-reactions.test.ts
@@ -23,14 +23,14 @@ describe("Zulip status reaction configuration", () => {
           onError: "error_custom",
           emojis: { tool: "tool_custom" },
           timing: { debounceMs: 25 },
-          subagent: ":robot_face:",
+          subagent: ":custom_child:",
         },
       },
     });
 
     expect(result).toMatchObject({
       enabled: true,
-      subagent: "robot_face",
+      subagent: "custom_child",
       emojis: {
         queued: "queued_custom",
         thinking: "thinking",
@@ -56,7 +56,7 @@ describe("Zulip status reaction configuration", () => {
     await adapter.removeReaction?.("🤖");
 
     const expected = {
-      emojiName: "robot_face",
+      emojiName: "robot",
       emojiCode: "1f916",
       reactionType: "unicode_emoji",
     };
@@ -64,17 +64,39 @@ describe("Zulip status reaction configuration", () => {
     expect(remove).toHaveBeenCalledWith(expected);
   });
 
-  it("uses fully specified Unicode reactions for every built-in lifecycle default", () => {
-    for (const emoji of Object.values(ZULIP_STATUS_REACTION_DEFAULTS)) {
-      expect(resolveZulipReactionSpec(emoji)).toMatchObject({
-        emojiCode: expect.any(String),
+  it("uses Zulip's canonical name and complete metadata for every built-in Unicode value", () => {
+    const expected = new Map([
+      ["👀", ["eyes", "1f440"]],
+      ["🧠", ["brain", "1f9e0"]],
+      ["🛠️", ["working_on_it", "1f6e0"]],
+      ["💻", ["computer", "1f4bb"]],
+      ["🌐", ["www", "1f310"]],
+      ["🛫", ["airplane_departure", "1f6eb"]],
+      ["🏗️", ["construction", "1f3d7"]],
+      ["💁", ["information_desk_person", "1f481"]],
+      ["✅", ["check", "2705"]],
+      ["❌", ["cross_mark", "274c"]],
+      ["⏳", ["time_ticking", "23f3"]],
+      ["⚠️", ["warning", "26a0"]],
+      ["🗜️", ["compression", "1f5dc"]],
+      ["🤖", ["robot", "1f916"]],
+    ]);
+
+    for (const [emoji, [emojiName, emojiCode]] of expected) {
+      expect(resolveZulipReactionSpec(emoji)).toEqual({
+        emojiName,
+        emojiCode,
         reactionType: "unicode_emoji",
       });
     }
 
+    expect(new Set(Object.values(ZULIP_STATUS_REACTION_DEFAULTS))).toEqual(
+      new Set(Array.from(expected.keys()).filter((emoji) => emoji !== "🤖")),
+    );
+
     const result = resolveZulipStatusReactionConfig({ accountConfig: {} });
-    expect(resolveZulipReactionSpec(result.subagent)).toMatchObject({
-      emojiName: "robot_face",
+    expect(resolveZulipReactionSpec(result.subagent)).toEqual({
+      emojiName: "robot",
       emojiCode: "1f916",
       reactionType: "unicode_emoji",
     });

--- a/src/zulip/status-reactions.ts
+++ b/src/zulip/status-reactions.ts
@@ -15,18 +15,18 @@ type ZulipReactionSpec = {
 const unicodeStatusReactions = new Map<string, ZulipReactionSpec>([
   ["👀", { emojiName: "eyes", emojiCode: "1f440", reactionType: "unicode_emoji" }],
   ["🧠", { emojiName: "brain", emojiCode: "1f9e0", reactionType: "unicode_emoji" }],
-  ["🛠", { emojiName: "hammer_and_wrench", emojiCode: "1f6e0", reactionType: "unicode_emoji" }],
+  ["🛠", { emojiName: "working_on_it", emojiCode: "1f6e0", reactionType: "unicode_emoji" }],
   ["💻", { emojiName: "computer", emojiCode: "1f4bb", reactionType: "unicode_emoji" }],
-  ["🌐", { emojiName: "globe_with_meridians", emojiCode: "1f310", reactionType: "unicode_emoji" }],
+  ["🌐", { emojiName: "www", emojiCode: "1f310", reactionType: "unicode_emoji" }],
   ["🛫", { emojiName: "airplane_departure", emojiCode: "1f6eb", reactionType: "unicode_emoji" }],
-  ["🏗", { emojiName: "building_construction", emojiCode: "1f3d7", reactionType: "unicode_emoji" }],
+  ["🏗", { emojiName: "construction", emojiCode: "1f3d7", reactionType: "unicode_emoji" }],
   ["💁", { emojiName: "information_desk_person", emojiCode: "1f481", reactionType: "unicode_emoji" }],
   ["✅", { emojiName: "check", emojiCode: "2705", reactionType: "unicode_emoji" }],
   ["❌", { emojiName: "cross_mark", emojiCode: "274c", reactionType: "unicode_emoji" }],
-  ["⏳", { emojiName: "hourglass_flowing_sand", emojiCode: "23f3", reactionType: "unicode_emoji" }],
+  ["⏳", { emojiName: "time_ticking", emojiCode: "23f3", reactionType: "unicode_emoji" }],
   ["⚠", { emojiName: "warning", emojiCode: "26a0", reactionType: "unicode_emoji" }],
   ["🗜", { emojiName: "compression", emojiCode: "1f5dc", reactionType: "unicode_emoji" }],
-  ["🤖", { emojiName: "robot_face", emojiCode: "1f916", reactionType: "unicode_emoji" }],
+  ["🤖", { emojiName: "robot", emojiCode: "1f916", reactionType: "unicode_emoji" }],
 ]);
 const namedZulipEmojiPattern =
   /^:?(?:[A-Za-z0-9][A-Za-z0-9_+-]*|[+-][A-Za-z0-9][A-Za-z0-9_+-]*):?$/;


### PR DESCRIPTION
Closes #38.

## What changed

- replace five non-Zulip Unicode aliases with API-verified canonical names
- assert exact name/code/type tuples for all 14 built-in lifecycle and subagent reactions
- update examples and UI hints to use safe Unicode defaults
- preserve named custom emoji overrides and empty suppression

## Verification

- `pnpm build`
- `pnpm test` (208 tests)
- `git diff --check`
- manifest JSON validation
- npm package dry-run
- live Zulip add/remove for all 14 canonical mappings, with cleanup
- independent review approved frozen commit `d5b825a`

Local verification used Node 26.5.0 and emitted the expected engine warning; CI covers the supported Node 22.19 and 24 runtimes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to reaction metadata and docs/tests; no changes to message routing, auth, or inbound handling beyond corrected Zulip API reaction fields.
> 
> **Overview**
> Fixes lifecycle and subagent reaction adds/removes that some Zulip realms rejected because built-in Unicode defaults were sent with non-canonical `emojiName` values.
> 
> **`resolveZulipReactionSpec`** now maps all 14 built-in Unicode lifecycle defaults to Zulip-verified tuples (`emojiName`, `emojiCode`, `unicode_emoji`), including renames such as `robot_face` → `robot`, `hourglass_flowing_sand` → `time_ticking`, `hammer_and_wrench` → `working_on_it`, `globe_with_meridians` → `www`, and `building_construction` → `construction`. Named custom emoji overrides and empty-string suppression are unchanged.
> 
> Tests assert the full mapping table and adapter add/remove payloads; README, changelog, and plugin UI placeholders now show safe Unicode examples (e.g. `🤖` for subagent) instead of SDK-style names like `robot_face`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5b825a5b5c1ab5bc3307a898db51ce64d6e431b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->