### PR TITLE
fix(zulip): clear lifecycle reactions before gateway restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - **Agent reaction guidance**: Advertise model-controlled Zulip reactions through prompt guidance, defaulting to extensive while keeping lifecycle/status indicators separate.
 
 ### Bug Fixes
+- **Gateway restart cleanup**: Await active monitor lifecycle cancellation from the gateway-stop hook so interrupted turns do not leave orphaned status reactions on Zulip messages.
 - **Lifecycle reaction metadata**: Send every built-in lifecycle and subagent default with Zulip's canonical Unicode emoji name, code, and reaction type so realms accept tool, soft-stall, and child-run indicators.
 - **Reply routing**: Store canonical last-route delivery context for Zulip DMs and stream topics so final replies and follow-ups stay on the right conversation.
 - **Replay dedupe**: Durable replay bypasses volatile in-memory duplicate suppression after handler failures.

--- a/index.ts
+++ b/index.ts
@@ -3,6 +3,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import { zulipPlugin } from "./src/channel.js";
 import { setZulipRuntime } from "./src/runtime.js";
 import { registerZulipSubagentReactionHooks } from "./src/zulip/subagent-reactions.js";
+import { registerZulipMonitorReactionHooks } from "./src/zulip/monitor.js";
 import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 
@@ -49,6 +50,7 @@ const entry: {
   registerFull(api) {
     loadZulipEnv();
     registerZulipSubagentReactionHooks(api);
+    registerZulipMonitorReactionHooks(api);
   },
 });
 

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -539,6 +539,62 @@ describe("monitorZulipProvider", () => {
     );
   });
 
+  it("clears active reactions through the gateway-stop hook", async () => {
+    state.autoAbort = false;
+    state.account.config.reactions = { enabled: true, clearOnFinish: false };
+    let dispatched!: () => void;
+    const dispatchStarted = new Promise<void>((resolve) => {
+      dispatched = resolve;
+    });
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await dispatcherOptions.onReplyStart?.();
+        await replyOptions.onToolStart?.({ name: "exec", phase: "start" });
+        dispatched();
+        await new Promise<void>((resolve) => {
+          replyOptions.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+        });
+        return {};
+      },
+    );
+    state.pollResponses = [
+      {
+        result: "success",
+        events: [{ id: 1, type: "message", message: makeChannelMessage(1092) }],
+      },
+    ];
+
+    const monitorPromise = runMonitorOnce();
+    await dispatchStarted;
+    const {
+      clearActiveZulipMonitorReactionLifecycles,
+      registerZulipMonitorReactionHooks,
+    } = await import("./monitor.js");
+    const on = vi.fn();
+    registerZulipMonitorReactionHooks({ on } as never);
+    expect(on).toHaveBeenCalledWith(
+      "gateway_stop",
+      clearActiveZulipMonitorReactionLifecycles,
+    );
+
+    await clearActiveZulipMonitorReactionLifecycles();
+
+    expect(state.removeZulipReaction).toHaveBeenCalledWith(
+      state.client,
+      expect.objectContaining({ messageId: "1092", emojiName: "eyes" }),
+    );
+    state.abortController?.abort();
+    await monitorPromise;
+    expect(state.addZulipReaction).not.toHaveBeenCalledWith(
+      state.client,
+      expect.objectContaining({ messageId: "1092", emojiName: "check" }),
+    );
+    expect(state.addZulipReaction).not.toHaveBeenCalledWith(
+      state.client,
+      expect.objectContaining({ messageId: "1092", emojiName: "cross_mark" }),
+    );
+  });
+
   it("does not add a terminal reaction when abort races subagent settlement", async () => {
     state.autoAbort = false;
     state.account.config.reactions = { enabled: true, clearOnFinish: false };

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -320,7 +320,9 @@ function enableDurableInboundJournal() {
 }
 
 describe("monitorZulipProvider", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    const { startZulipMonitorReactionLifecycles } = await import("./monitor.js");
+    startZulipMonitorReactionLifecycles();
     state.core = state.createCore();
     state.core.channel.inbound.buildContext.mockImplementation(buildChannelInboundEventContext);
     state.durableStores = new Map();
@@ -546,6 +548,20 @@ describe("monitorZulipProvider", () => {
     const dispatchStarted = new Promise<void>((resolve) => {
       dispatched = resolve;
     });
+    let removalStarted!: () => void;
+    const removalAttempted = new Promise<void>((resolve) => {
+      removalStarted = resolve;
+    });
+    let releaseRemoval!: () => void;
+    const removalAllowed = new Promise<void>((resolve) => {
+      releaseRemoval = resolve;
+    });
+    state.removeZulipReaction.mockImplementation(async (_client, reaction) => {
+      if (reaction.messageId === "1092" && reaction.emojiName === "eyes") {
+        removalStarted();
+        await removalAllowed;
+      }
+    });
     state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
       async ({ dispatcherOptions, replyOptions }) => {
         await dispatcherOptions.onReplyStart?.();
@@ -560,7 +576,10 @@ describe("monitorZulipProvider", () => {
     state.pollResponses = [
       {
         result: "success",
-        events: [{ id: 1, type: "message", message: makeChannelMessage(1092) }],
+        events: [
+          { id: 1, type: "message", message: makeChannelMessage(1092) },
+          { id: 2, type: "message", message: makeChannelMessage(1093) },
+        ],
       },
     ];
 
@@ -569,19 +588,32 @@ describe("monitorZulipProvider", () => {
     const {
       clearActiveZulipMonitorReactionLifecycles,
       registerZulipMonitorReactionHooks,
+      startZulipMonitorReactionLifecycles,
     } = await import("./monitor.js");
     const on = vi.fn();
     registerZulipMonitorReactionHooks({ on } as never);
+    expect(on).toHaveBeenCalledWith("gateway_start", startZulipMonitorReactionLifecycles);
     expect(on).toHaveBeenCalledWith(
       "gateway_stop",
       clearActiveZulipMonitorReactionLifecycles,
     );
 
-    await clearActiveZulipMonitorReactionLifecycles();
+    const gatewayCleanup = clearActiveZulipMonitorReactionLifecycles();
+    await removalAttempted;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    releaseRemoval();
+    await gatewayCleanup;
 
     expect(state.removeZulipReaction).toHaveBeenCalledWith(
       state.client,
       expect.objectContaining({ messageId: "1092", emojiName: "eyes" }),
+    );
+    expect(
+      state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher,
+    ).toHaveBeenCalledTimes(1);
+    expect(state.addZulipReaction).not.toHaveBeenCalledWith(
+      state.client,
+      expect.objectContaining({ messageId: "1093" }),
     );
     state.abortController?.abort();
     await monitorPromise;

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -372,14 +372,21 @@ async function saveZulipMediaBuffer(params: {
 const ABORTED_INBOUND_MESSAGE = Symbol("aborted-inbound-message");
 const RETRYABLE_INBOUND_MESSAGE = Symbol("retryable-inbound-message");
 const activeMonitorReactionCleanups = new Set<() => Promise<void>>();
+let monitorReactionShutdownStarted = false;
+
+export function startZulipMonitorReactionLifecycles(): void {
+  monitorReactionShutdownStarted = false;
+}
 
 export async function clearActiveZulipMonitorReactionLifecycles(): Promise<void> {
+  monitorReactionShutdownStarted = true;
   await Promise.allSettled(
     Array.from(activeMonitorReactionCleanups, (cleanup) => cleanup()),
   );
 }
 
 export function registerZulipMonitorReactionHooks(api: OpenClawPluginApi): void {
+  api.on("gateway_start", startZulipMonitorReactionLifecycles);
   api.on("gateway_stop", clearActiveZulipMonitorReactionLifecycles);
 }
 
@@ -487,7 +494,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     message: ZulipMessage,
     options: { skipRecentDedupe?: boolean } = {},
   ) => {
-    if (opts.abortSignal?.aborted) {
+    if (opts.abortSignal?.aborted || monitorReactionShutdownStarted) {
       return ABORTED_INBOUND_MESSAGE;
     }
     const messageId = String(message.id ?? "");
@@ -901,7 +908,11 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       emojiCode?: string;
       reactionType?: string;
     }) => {
-      if (!statusReactionConfig.enabled || !reaction.emojiName) {
+      if (
+        monitorReactionShutdownStarted ||
+        !statusReactionConfig.enabled ||
+        !reaction.emojiName
+      ) {
         return;
       }
       try {
@@ -915,7 +926,11 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       emojiCode?: string;
       reactionType?: string;
     }) => {
-      if (statusReactionConfig.enabled && reaction.emojiName) {
+      if (
+        !monitorReactionShutdownStarted &&
+        statusReactionConfig.enabled &&
+        reaction.emojiName
+      ) {
         await addZulipReaction(client, { messageId, ...reaction });
       }
     };
@@ -942,7 +957,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         logVerboseMessage(`zulip: failed to remove reaction ${reaction.emojiName}: ${String(err)}`);
       }
     };
-    if (opts.abortSignal?.aborted) {
+    if (opts.abortSignal?.aborted || monitorReactionShutdownStarted) {
       return ABORTED_INBOUND_MESSAGE;
     }
     const statusReactions = createStatusReactionController({
@@ -993,7 +1008,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       subagentLifecycleSettled = true;
       releaseReactionCleanupIfSettled();
     });
-    if (opts.abortSignal?.aborted) {
+    if (opts.abortSignal?.aborted || monitorReactionShutdownStarted) {
       await cancelReactionLifecycle();
       opts.statusSink?.({ lastInboundAt: Date.now() });
       return ABORTED_INBOUND_MESSAGE;

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type {
   ChannelAccountSnapshot,
   OpenClawConfig,
+  OpenClawPluginApi,
   ReplyPayload,
   RuntimeEnv,
 } from "../sdk.js";
@@ -370,6 +371,17 @@ async function saveZulipMediaBuffer(params: {
 
 const ABORTED_INBOUND_MESSAGE = Symbol("aborted-inbound-message");
 const RETRYABLE_INBOUND_MESSAGE = Symbol("retryable-inbound-message");
+const activeMonitorReactionCleanups = new Set<() => Promise<void>>();
+
+export async function clearActiveZulipMonitorReactionLifecycles(): Promise<void> {
+  await Promise.allSettled(
+    Array.from(activeMonitorReactionCleanups, (cleanup) => cleanup()),
+  );
+}
+
+export function registerZulipMonitorReactionHooks(api: OpenClawPluginApi): void {
+  api.on("gateway_stop", clearActiveZulipMonitorReactionLifecycles);
+}
 
 function delay(ms: number, signal?: AbortSignal): Promise<void> {
   if (signal?.aborted) {
@@ -1338,6 +1350,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     }
   };
 
+  activeMonitorReactionCleanups.add(cleanupActiveReactionLifecycles);
   try {
     await replayPendingDurableInboundMessages();
 
@@ -1452,6 +1465,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     await cleanupActiveReactionLifecycles();
     await Promise.allSettled(Array.from(activeMessageTasks));
     await cleanupActiveReactionLifecycles();
+    activeMonitorReactionCleanups.delete(cleanupActiveReactionLifecycles);
   }
 
   // Cleanup


### PR DESCRIPTION
Closes #40.

This registers awaited gateway lifecycle hooks for Zulip monitor status reactions. Gateway stop atomically blocks new lifecycle additions, clears every active monitor lifecycle, and waits for removals before channel teardown. Gateway start resets the shutdown gate for same-process restarts.

The regression holds one active cleanup open while a second inbound event reaches the monitor, proving the late event neither dispatches a reply nor adds a reaction.

Verification:
- full test suite: 209/209
- focused monitor/subagent tests: 49/49
- TypeScript build/typecheck
- independent review: approved at b0f6f78040a1cbcd1efb22932e12a1d9efe28a54
- git diff check
- manifest JSON validation
- npm pack dry-run: 117 files

Local verification used Node 26.5.0 and emitted the expected unsupported-engine warning. GitHub CI on supported Node 22.19 and 24 is authoritative.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches inbound abort paths and reaction lifecycle timing during gateway shutdown; behavior is covered by new tests but races around concurrent messages and restarts remain sensitive.
> 
> **Overview**
> Fixes **orphaned Zulip status reactions** when the OpenClaw gateway restarts while a turn is still in progress.
> 
> The plugin now registers **`gateway_start` / `gateway_stop` hooks** (alongside existing subagent hooks) that reset a shutdown gate on start and, on stop, **await cleanup of every active monitor reaction lifecycle** before teardown. While shutdown is in progress, inbound handling treats the monitor as stopped: new messages abort early and **lifecycle emoji are not added** (removals still run so reactions can be cleared).
> 
> Each running monitor registers its per-session reaction cleanup in a **global set** so gateway stop can drain them all. Changelog documents this under gateway restart cleanup; a monitor test covers awaiting removal during stop and that a queued second message does not dispatch or react.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0f6f78040a1cbcd1efb22932e12a1d9efe28a54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->