### PR TITLE
feat(ci): add protected Zulip live smoke workflow

### DIFF
--- a/.github/workflows/zulip-live-smoke.yml
+++ b/.github/workflows/zulip-live-smoke.yml
@@ -60,16 +60,6 @@ jobs:
     environment: zulip-live-smoke
     runs-on: ubuntu-latest
     timeout-minutes: 35
-    env:
-      OPENCLAW_SMOKE_CONFIG_JSON: ${{ secrets.OPENCLAW_SMOKE_CONFIG_JSON }}
-      ZULIP_URL: ${{ secrets.ZULIP_URL }}
-      ZULIP_SMOKE_USER_EMAIL: ${{ secrets.ZULIP_SMOKE_USER_EMAIL }}
-      ZULIP_SMOKE_USER_API_KEY: ${{ secrets.ZULIP_SMOKE_USER_API_KEY }}
-      ZULIP_SMOKE_BOT_EMAIL: ${{ secrets.ZULIP_SMOKE_BOT_EMAIL }}
-      ZULIP_SMOKE_BOT_API_KEY: ${{ secrets.ZULIP_SMOKE_BOT_API_KEY }}
-      ZULIP_SMOKE_STREAM: ${{ vars.ZULIP_SMOKE_STREAM }}
-      SMOKE_TESTED_SHA: ${{ needs.authorize.outputs.candidate_sha }}
-      SMOKE_SCENARIO_TIMEOUT_MS: '120000'
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
@@ -89,17 +79,37 @@ jobs:
           pnpm run build
       - name: Prepare isolated OpenClaw state
         env:
+          OPENCLAW_SMOKE_CONFIG_JSON: ${{ secrets.OPENCLAW_SMOKE_CONFIG_JSON }}
           OPENCLAW_CONFIG_PATH: ${{ runner.temp }}/openclaw-smoke/openclaw.json
           OPENCLAW_STATE_DIR: ${{ runner.temp }}/openclaw-smoke/state
         run: |
           umask 077
           mkdir -p "$(dirname "$OPENCLAW_CONFIG_PATH")" "$OPENCLAW_STATE_DIR"
+          node --input-type=module <<'NODE'
+          const config = JSON.parse(process.env.OPENCLAW_SMOKE_CONFIG_JSON);
+          const zulip = config?.channels?.zulip ?? {};
+          const configured = [zulip, ...Object.values(zulip.accounts ?? {})]
+            .map((account) => account?.reactions?.subagent)
+            .filter((value) => value !== undefined);
+          const robotValues = new Set(["robot", ":robot:", "🤖", "🤖️"]);
+          if (configured.some((value) => !robotValues.has(value))) {
+            throw new Error("Protected smoke config must use the robot subagent reaction");
+          }
+          NODE
           printf '%s' "$OPENCLAW_SMOKE_CONFIG_JSON" > "$OPENCLAW_CONFIG_PATH"
           pnpm exec openclaw plugins install -l "$GITHUB_WORKSPACE"
           pnpm exec openclaw config set agents.defaults.workspace "$GITHUB_WORKSPACE/scripts/live-smoke/agent-workspace"
           pnpm exec openclaw config validate
       - name: Run bounded live scenarios
         env:
+          ZULIP_URL: ${{ secrets.ZULIP_URL }}
+          ZULIP_SMOKE_USER_EMAIL: ${{ secrets.ZULIP_SMOKE_USER_EMAIL }}
+          ZULIP_SMOKE_USER_API_KEY: ${{ secrets.ZULIP_SMOKE_USER_API_KEY }}
+          ZULIP_SMOKE_BOT_EMAIL: ${{ secrets.ZULIP_SMOKE_BOT_EMAIL }}
+          ZULIP_SMOKE_BOT_API_KEY: ${{ secrets.ZULIP_SMOKE_BOT_API_KEY }}
+          ZULIP_SMOKE_STREAM: ${{ vars.ZULIP_SMOKE_STREAM }}
+          SMOKE_TESTED_SHA: ${{ needs.authorize.outputs.candidate_sha }}
+          SMOKE_SCENARIO_TIMEOUT_MS: '120000'
           OPENCLAW_CONFIG_PATH: ${{ runner.temp }}/openclaw-smoke/openclaw.json
           OPENCLAW_STATE_DIR: ${{ runner.temp }}/openclaw-smoke/state
           SMOKE_GATEWAY_PORT: '18789'

--- a/.github/workflows/zulip-live-smoke.yml
+++ b/.github/workflows/zulip-live-smoke.yml
@@ -1,0 +1,118 @@
+name: Zulip live smoke (protected)
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate_sha:
+        description: Full commit SHA to test (must already be reachable from main)
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: zulip-live-smoke
+  cancel-in-progress: false
+
+jobs:
+  authorize:
+    name: Authorize trusted candidate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      candidate_sha: ${{ steps.candidate.outputs.sha }}
+    steps:
+      - name: Require dispatch from this repository's main branch
+        env:
+          DISPATCH_REPOSITORY: ${{ github.repository }}
+          DISPATCH_REF: ${{ github.ref }}
+        run: |
+          if [[ "$DISPATCH_REPOSITORY" != "FtlC-ian/openclaw-channel-zulip" || "$DISPATCH_REF" != "refs/heads/main" ]]; then
+            echo "Live credentials are available only to workflows dispatched from this repository's main branch" >&2
+            exit 1
+          fi
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Require a commit already reachable from main
+        id: candidate
+        env:
+          REQUESTED_SHA: ${{ inputs.candidate_sha }}
+        run: |
+          candidate="${REQUESTED_SHA:-$GITHUB_SHA}"
+          if [[ ! "$candidate" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "candidate_sha must be a full lowercase commit SHA" >&2
+            exit 1
+          fi
+          git fetch --no-tags origin main
+          git cat-file -e "$candidate^{commit}"
+          if ! git merge-base --is-ancestor "$candidate" origin/main; then
+            echo "Refusing to expose live credentials to a commit not reachable from main" >&2
+            exit 1
+          fi
+          echo "sha=$candidate" >> "$GITHUB_OUTPUT"
+
+  live-smoke:
+    name: Live Zulip scenarios
+    needs: authorize
+    environment: zulip-live-smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    env:
+      OPENCLAW_SMOKE_CONFIG_JSON: ${{ secrets.OPENCLAW_SMOKE_CONFIG_JSON }}
+      ZULIP_URL: ${{ secrets.ZULIP_URL }}
+      ZULIP_SMOKE_USER_EMAIL: ${{ secrets.ZULIP_SMOKE_USER_EMAIL }}
+      ZULIP_SMOKE_USER_API_KEY: ${{ secrets.ZULIP_SMOKE_USER_API_KEY }}
+      ZULIP_SMOKE_BOT_EMAIL: ${{ secrets.ZULIP_SMOKE_BOT_EMAIL }}
+      ZULIP_SMOKE_BOT_API_KEY: ${{ secrets.ZULIP_SMOKE_BOT_API_KEY }}
+      ZULIP_SMOKE_STREAM: ${{ vars.ZULIP_SMOKE_STREAM }}
+      SMOKE_TESTED_SHA: ${{ needs.authorize.outputs.candidate_sha }}
+      SMOKE_SCENARIO_TIMEOUT_MS: '120000'
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ needs.authorize.outputs.candidate_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 10.23.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Install locked dependencies and build candidate
+        run: |
+          pnpm install --frozen-lockfile --config.minimumReleaseAge=1440
+          pnpm run build
+      - name: Prepare isolated OpenClaw state
+        env:
+          OPENCLAW_CONFIG_PATH: ${{ runner.temp }}/openclaw-smoke/openclaw.json
+          OPENCLAW_STATE_DIR: ${{ runner.temp }}/openclaw-smoke/state
+        run: |
+          umask 077
+          mkdir -p "$(dirname "$OPENCLAW_CONFIG_PATH")" "$OPENCLAW_STATE_DIR"
+          printf '%s' "$OPENCLAW_SMOKE_CONFIG_JSON" > "$OPENCLAW_CONFIG_PATH"
+          pnpm exec openclaw plugins install -l "$GITHUB_WORKSPACE"
+          pnpm exec openclaw config set agents.defaults.workspace "$GITHUB_WORKSPACE/scripts/live-smoke/agent-workspace"
+          pnpm exec openclaw config validate
+      - name: Run bounded live scenarios
+        env:
+          OPENCLAW_CONFIG_PATH: ${{ runner.temp }}/openclaw-smoke/openclaw.json
+          OPENCLAW_STATE_DIR: ${{ runner.temp }}/openclaw-smoke/state
+          SMOKE_GATEWAY_PORT: '18789'
+        run: node scripts/live-smoke/run.mjs
+      - name: Record release evidence
+        if: always()
+        env:
+          TESTED_SHA: ${{ needs.authorize.outputs.candidate_sha }}
+        run: |
+          {
+            echo "### Protected Zulip live smoke"
+            echo ""
+            echo "- Result: ${{ job.status }}"
+            echo "- Tested commit: \`$TESTED_SHA\`"
+            echo "- Run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/zulip-live-smoke.yml
+++ b/.github/workflows/zulip-live-smoke.yml
@@ -88,12 +88,30 @@ jobs:
           node --input-type=module <<'NODE'
           const config = JSON.parse(process.env.OPENCLAW_SMOKE_CONFIG_JSON);
           const zulip = config?.channels?.zulip ?? {};
-          const configured = [zulip, ...Object.values(zulip.accounts ?? {})]
-            .map((account) => account?.reactions?.subagent)
+          const { accounts: accountConfigs = {}, ...baseZulip } = zulip;
+          const accounts = [baseZulip,
+            ...Object.values(accountConfigs).map((account) => ({ ...baseZulip, ...account }))];
+          if (accounts.some((account) => account.chatmode !== "onmessage" || account.requireMention !== false)) {
+            throw new Error("Protected smoke config must disable stream mention gating");
+          }
+          const configured = accounts.map((account) => account?.reactions?.subagent)
             .filter((value) => value !== undefined);
           const robotValues = new Set(["robot", ":robot:", "🤖", "🤖️"]);
           if (configured.some((value) => !robotValues.has(value))) {
             throw new Error("Protected smoke config must use the robot subagent reaction");
+          }
+          const lifecycleValues = [
+            ...Object.values(config?.messages?.statusReactions?.emojis ?? {}),
+            ...accounts.flatMap((account) => {
+              const reactions = account?.reactions ?? {};
+              return [reactions.onStart, reactions.onSuccess, reactions.onError,
+                ...Object.values(reactions.emojis ?? {})];
+            }),
+          ].filter((value) => value !== undefined);
+          const normalize = (value) => String(value).trim().replace(/^:+|:+$/g, "")
+            .replaceAll("\ufe0f", "").toLowerCase();
+          if (lifecycleValues.some((value) => ["robot", "🤖", "tada", "🎉"].includes(normalize(value)))) {
+            throw new Error("Protected smoke config reserves robot and tada reactions for exact evidence");
           }
           NODE
           printf '%s' "$OPENCLAW_SMOKE_CONFIG_JSON" > "$OPENCLAW_CONFIG_PATH"

--- a/README.md
+++ b/README.md
@@ -276,6 +276,12 @@ openclaw gateway restart
 
 Pull requests and pushes to `main` run the release-blocking **CI** workflow on Node 22.19 and Node 24. Each run installs from `pnpm-lock.yaml` with `--frozen-lockfile`, builds, runs the full test suite, checks whitespace errors with `git diff --check`, packs the release artifact, installs it with the locked OpenClaw host in a clean temporary project, and imports its public package entry point. The workflow has read-only repository permissions and does not receive repository or Zulip secrets.
 
+Release candidates also have a manual **Zulip live smoke (protected)** workflow.
+It can run only from `main`, accepts only a full commit SHA already reachable
+from `main`, and obtains dedicated-realm credentials only after approval through
+the protected `zulip-live-smoke` GitHub Environment. See
+[the release checklist](docs/RELEASE_CHECKLIST.md) for setup and evidence rules.
+
 The scheduled **OpenClaw compatibility (advisory)** workflow is intentionally separate from release gating. Once a week it chooses the first eligible release from OpenClaw's `latest` and `extended-stable` npm channels that has been published for at least 24 hours, then installs and tests it in a temporary copy of the plugin. That temporary install and the packed-artifact smoke test enforce pnpm's 24-hour release-age rule and may update only disposable lockfiles; they never change or commit this repository's lockfile. A failure identifies compatibility work to investigate; it does not replace the locked CI evidence required for a release.
 
 ---

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -41,6 +41,6 @@ rather than silently skipping it.
 
 The harness verifies the exact child result in the isolated OpenClaw session
 transcript and reads the edited Zulip message before and after its required
-two-second visibility window. Durable replay uses a random generation value
+four-second visibility window. Durable replay uses a random generation value
 written only after the old gateway process group is fully down; the replacement
 must read and return that value, so a queued pre-restart reply cannot pass.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,0 +1,35 @@
+# Release checklist
+
+Before publishing a release candidate:
+
+- Confirm CI passed for the exact commit being released.
+- From the `main` branch, dispatch **Zulip live smoke (protected)** with the
+  candidate's full commit SHA. The workflow rejects commits not already
+  reachable from `main` before the protected environment or its secrets are
+  available.
+- Record the successful run URL and tested SHA here and on GitHub issue #24:
+  `Live smoke: <run URL>; tested SHA: <40-character SHA>`.
+- Confirm the run summary reports every scenario as `PASS`. A skipped or
+  unobservable scenario is not successful coverage.
+- Confirm cleanup completed. Zulip messages are deleted where account
+  permissions permit. Zulip does not expose a public API for deleting uploaded
+  files, so the dedicated realm may retain the small uniquely named fixtures.
+- The interactive-reply scenario sends the exact native poll choice reply over
+  Zulip's public message API. Zulip exposes no public API for synthesizing a
+  browser widget click, so the workflow reports this API-equivalent boundary
+  rather than pretending to automate UI behavior.
+
+The `zulip-live-smoke` GitHub Environment must require reviewer approval and
+contain only dedicated test-realm credentials. Store the isolated OpenClaw
+configuration in `OPENCLAW_SMOKE_CONFIG_JSON`; store the test actor and bot
+credentials in the environment-scoped secrets named by the workflow. Set
+`ZULIP_SMOKE_STREAM` as an environment variable. Never define these as
+repository-level secrets.
+
+The isolated configuration must enable the checked-out local Zulip plugin, use
+the dedicated bot account, allow DMs from the smoke actor, monitor the smoke
+stream with an open group policy, enable typing and lifecycle reactions with
+`clearOnFinish: true`, and provide a model/tool policy that permits the message,
+file, and `sessions_spawn` operations described by the committed smoke-agent
+workspace. A run that cannot observe one of those behaviors fails rather than
+silently skipping it.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -29,7 +29,8 @@ repository-level secrets.
 The isolated configuration must enable the checked-out local Zulip plugin, use
 the dedicated bot account, allow DMs from the smoke actor, monitor the smoke
 stream with an open group policy, enable typing and lifecycle reactions with
-`clearOnFinish: true`, and provide a model/tool policy that permits the message,
-file, and `sessions_spawn` operations described by the committed smoke-agent
-workspace. A run that cannot observe one of those behaviors fails rather than
-silently skipping it.
+`clearOnFinish: true`, and use the default `robot` subagent reaction required
+by the committed evidence matcher. It must also provide a model/tool policy
+that permits the message, file, and `sessions_spawn` operations described by
+the committed smoke-agent workspace. A run that cannot observe one of those
+behaviors fails rather than silently skipping it.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -38,3 +38,9 @@ evidence. The configuration must also provide a model/tool policy that permits
 the message, file, and `sessions_spawn` operations described by the committed
 smoke-agent workspace. A run that cannot observe one of those behaviors fails
 rather than silently skipping it.
+
+The harness verifies the exact child result in the isolated OpenClaw session
+transcript and reads the edited Zulip message before and after its required
+two-second visibility window. Durable replay uses a random generation value
+written only after the old gateway process group is fully down; the replacement
+must read and return that value, so a queued pre-restart reply cannot pass.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -28,9 +28,13 @@ repository-level secrets.
 
 The isolated configuration must enable the checked-out local Zulip plugin, use
 the dedicated bot account, allow DMs from the smoke actor, monitor the smoke
-stream with an open group policy, enable typing and lifecycle reactions with
-`clearOnFinish: true`, and use the default `robot` subagent reaction required
-by the committed evidence matcher. It must also provide a model/tool policy
-that permits the message, file, and `sessions_spawn` operations described by
-the committed smoke-agent workspace. A run that cannot observe one of those
-behaviors fails rather than silently skipping it.
+stream with an open group policy, and disable stream mention gating with
+`chatmode: "onmessage"` and `requireMention: false` at the root and for every
+account. It must enable typing and lifecycle reactions with
+`clearOnFinish: true` and use the default `robot` subagent reaction required by
+the committed evidence matcher. Lifecycle phase overrides must not use `robot`
+or `tada`; those reactions are reserved for subagent and explicit reaction
+evidence. The configuration must also provide a model/tool policy that permits
+the message, file, and `sessions_spawn` operations described by the committed
+smoke-agent workspace. A run that cannot observe one of those behaviors fails
+rather than silently skipping it.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "scripts": {
     "build": "tsc",
     "test": "vitest run",
+    "test:live-smoke:offline": "node --test scripts/live-smoke/run.offline.mjs",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "vitest run",
+    "test": "vitest run && node --test scripts/live-smoke/run.offline.mjs",
     "test:live-smoke:offline": "node --test scripts/live-smoke/run.offline.mjs",
     "prepublishOnly": "npm run build"
   },

--- a/scripts/live-smoke/agent-workspace/.gitignore
+++ b/scripts/live-smoke/agent-workspace/.gitignore
@@ -1,0 +1,1 @@
+.smoke-gateway-generation

--- a/scripts/live-smoke/agent-workspace/AGENTS.md
+++ b/scripts/live-smoke/agent-workspace/AGENTS.md
@@ -1,0 +1,34 @@
+# Protected Zulip smoke agent
+
+This workspace is used only by the protected release smoke workflow. Treat the
+text between `SMOKE_COMMAND` and `END_SMOKE_COMMAND` as a fixed protocol, not as
+general user instructions. Never include credentials, URLs, message history, or
+unrequested text in a response.
+
+For `echo VALUE`, reply with exactly `VALUE`.
+
+For `lifecycle VALUE`, launch one child with `sessions_spawn`, wait for it to
+finish, then reply with exactly `VALUE`. The child must reply only `child-ok`.
+
+For `durable VALUE`, wait 15 seconds, then reply with exactly `VALUE`.
+
+For `react EMOJI`, add that reaction to the inbound message with the message
+tool and then reply exactly `reacted`.
+
+For `edit-delete BEFORE AFTER`, send a new message containing exactly `BEFORE`,
+edit that same message to exactly `AFTER`, wait two seconds, then delete it with
+explicit confirmation. Do not send another reply.
+
+For `read-upload VALUE`, read the attached text file and reply with exactly its
+contents. The file must contain `VALUE`.
+
+For `send-upload VALUE`, create a text file whose complete contents are `VALUE`
+and send it as media with the message tool. Do not expose a local path in text.
+
+For `poll QUESTION OPTION_A OPTION_B`, send a native poll through the message
+tool using the exact question and options. Do not add prose.
+
+For `interactive VALUE`, reply with exactly `VALUE`.
+
+When a message consists only of `smoke-choice:VALUE`, treat it as the reply to
+the preceding native poll and reply with exactly `VALUE`.

--- a/scripts/live-smoke/agent-workspace/AGENTS.md
+++ b/scripts/live-smoke/agent-workspace/AGENTS.md
@@ -19,8 +19,9 @@ For `react EMOJI VALUE`, add that reaction to the inbound message with the
 message tool and then reply with exactly `VALUE`.
 
 For `edit-delete BEFORE AFTER`, send a new message containing exactly `BEFORE`,
-edit that same message to exactly `AFTER`, keep it visible for at least four
-seconds, then delete it with explicit confirmation. Do not send another reply.
+edit that same message to exactly `AFTER`, keep it visible for at least six
+seconds so the harness can observe a full four-second window, then delete it
+with explicit confirmation. Do not send another reply.
 
 For `read-upload VALUE`, read the attached text file and reply with exactly its
 contents. The file must contain `VALUE`.

--- a/scripts/live-smoke/agent-workspace/AGENTS.md
+++ b/scripts/live-smoke/agent-workspace/AGENTS.md
@@ -12,8 +12,8 @@ finish, then reply with exactly `VALUE`. The child must reply only `child-ok`.
 
 For `durable VALUE`, wait 15 seconds, then reply with exactly `VALUE`.
 
-For `react EMOJI`, add that reaction to the inbound message with the message
-tool and then reply exactly `reacted`.
+For `react EMOJI VALUE`, add that reaction to the inbound message with the
+message tool and then reply with exactly `VALUE`.
 
 For `edit-delete BEFORE AFTER`, send a new message containing exactly `BEFORE`,
 edit that same message to exactly `AFTER`, wait two seconds, then delete it with

--- a/scripts/live-smoke/agent-workspace/AGENTS.md
+++ b/scripts/live-smoke/agent-workspace/AGENTS.md
@@ -7,17 +7,20 @@ unrequested text in a response.
 
 For `echo VALUE`, reply with exactly `VALUE`.
 
-For `lifecycle VALUE`, launch one child with `sessions_spawn`, wait for it to
-finish, then reply with exactly `VALUE`. The child must reply only `child-ok`.
+For `lifecycle VALUE CHILD_RESULT`, launch one child with `sessions_spawn` and
+instruct it to reply with exactly `CHILD_RESULT`. Wait for it to finish, verify
+that exact result, then reply with exactly `VALUE`.
 
-For `durable VALUE`, wait 15 seconds, then reply with exactly `VALUE`.
+For `durable VALUE`, wait 15 seconds, read the complete contents of
+`.smoke-gateway-generation`, then reply with exactly `VALUE:GENERATION`, where
+`GENERATION` is the file's exact contents. Do not cache the file before waiting.
 
 For `react EMOJI VALUE`, add that reaction to the inbound message with the
 message tool and then reply with exactly `VALUE`.
 
 For `edit-delete BEFORE AFTER`, send a new message containing exactly `BEFORE`,
-edit that same message to exactly `AFTER`, wait two seconds, then delete it with
-explicit confirmation. Do not send another reply.
+edit that same message to exactly `AFTER`, keep it visible for at least four
+seconds, then delete it with explicit confirmation. Do not send another reply.
 
 For `read-upload VALUE`, read the attached text file and reply with exactly its
 contents. The file must contain `VALUE`.

--- a/scripts/live-smoke/agent-workspace/AGENTS.md
+++ b/scripts/live-smoke/agent-workspace/AGENTS.md
@@ -11,9 +11,11 @@ For `lifecycle VALUE CHILD_RESULT`, launch one child with `sessions_spawn` and
 instruct it to reply with exactly `CHILD_RESULT`. Wait for it to finish, verify
 that exact result, then reply with exactly `VALUE`.
 
-For `durable VALUE`, wait 15 seconds, read the complete contents of
+For `durable VALUE`, wait at least 16 seconds, read the complete contents of
 `.smoke-gateway-generation`, then reply with exactly `VALUE:GENERATION`, where
-`GENERATION` is the file's exact contents. Do not cache the file before waiting.
+`GENERATION` is the file's exact contents. The extra second lets the harness
+prove a full 15-second delay using Zulip's integer server timestamps. Do not
+cache the file before waiting.
 
 For `react EMOJI VALUE`, add that reaction to the inbound message with the
 message tool and then reply with exactly `VALUE`.

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -577,13 +577,6 @@ async function main() {
         await queue.poll(signal);
         await delay(500, undefined, { signal });
       }
-      if (!summary?.added.length) throw new Error("No lifecycle reaction was observed on the inbound message");
-      if (!summary.sawSubagent) throw new Error("No truthful subagent lifecycle reaction was observed");
-      if (summary.subagentCount !== 1) throw new Error(`Observed ${summary.subagentCount} subagent lifecycle reactions; expected exactly one`);
-      if (!summary.allRemoved) throw new Error("Lifecycle reactions were not cleaned up after completion");
-      if (!subagentCompletedBeforeReply(queue.events, inboundId, reply)) {
-        throw new Error("The child lifecycle did not complete before the parent reply");
-      }
       const transcriptDeadline = Date.now() + timeoutMs;
       let childTranscripts;
       while (Date.now() < transcriptDeadline && (childTranscripts = await inspectChildTranscripts(env.OPENCLAW_STATE_DIR, childResult)).completedExact === 0) {
@@ -594,6 +587,14 @@ async function main() {
         throw new Error(`Found ${childTranscripts.total} child transcripts and ${childTranscripts.completedExact} exact completed results; expected exactly one of each`);
       }
       await assertFinalPrivateTypingStop(queue, eventStart, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, signal);
+      summary = lifecycleSummary(queue.events, inboundId);
+      if (!summary.added.length) throw new Error("No lifecycle reaction was observed on the inbound message");
+      if (!summary.sawSubagent) throw new Error("No truthful subagent lifecycle reaction was observed");
+      if (summary.subagentCount !== 1) throw new Error(`Observed ${summary.subagentCount} subagent lifecycle reactions; expected exactly one`);
+      if (!summary.allRemoved) throw new Error("Lifecycle reactions were not cleaned up after completion");
+      if (!subagentCompletedBeforeReply(queue.events, inboundId, reply)) {
+        throw new Error("The child lifecycle did not complete before the parent reply");
+      }
     });
 
     await scenario("explicit-reaction", async (signal) => {

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -165,34 +165,61 @@ export class EventQueue {
   }
 }
 
-class Gateway {
-  constructor(port) { this.port = String(port); }
-  async start() {
+export class Gateway {
+  constructor(port, { termTimeoutMs = 10000, killTimeoutMs = 5000 } = {}) {
+    this.port = String(port);
+    this.termTimeoutMs = termTimeoutMs;
+    this.killTimeoutMs = killTimeoutMs;
+  }
+  async start(signal) {
+    signal?.throwIfAborted();
+    if (this.process?.exitCode === null) throw new Error("Runner-local OpenClaw gateway is already running");
     this.process = spawn("pnpm", ["exec", "openclaw", "gateway", "run", "--bind", "loopback", "--port", this.port, "--auth", "none", "--compact"], {
       cwd: process.cwd(), env: process.env, stdio: ["ignore", "ignore", "ignore"],
     });
     const deadline = Date.now() + 30000;
     while (Date.now() < deadline) {
+      signal?.throwIfAborted();
       if (this.process.exitCode !== null) throw new Error("Runner-local OpenClaw gateway exited during startup");
       const ok = await new Promise((resolve) => {
         const probe = spawn("pnpm", ["exec", "openclaw", "gateway", "health", "--port", this.port, "--timeout", "2000"], { stdio: "ignore", env: process.env });
         probe.once("exit", (code) => resolve(code === 0));
       });
       if (ok) return;
-      await delay(1000);
+      await delay(1000, undefined, { signal });
     }
     throw new Error("Runner-local OpenClaw gateway did not become healthy within 30s");
   }
   async stop() {
-    if (!this.process || this.process.exitCode !== null) return;
-    this.process.kill("SIGTERM");
-    await new Promise((resolve) => {
-      const timer = setTimeout(resolve, 10000);
-      this.process.once("exit", () => { clearTimeout(timer); resolve(); });
-    });
-    if (this.process.exitCode === null) this.process.kill("SIGKILL");
+    if (this.stopPromise) return this.stopPromise;
+    this.stopPromise = this.stopCurrentProcess().finally(() => { this.stopPromise = undefined; });
+    return this.stopPromise;
   }
-  async restart() { await this.stop(); await this.start(); }
+  async stopCurrentProcess() {
+    const child = this.process;
+    if (!child || child.exitCode !== null) {
+      if (this.process === child) this.process = undefined;
+      return;
+    }
+    child.kill("SIGTERM");
+    if (!await waitForExit(child, this.termTimeoutMs) && child.exitCode === null) {
+      child.kill("SIGKILL");
+      if (!await waitForExit(child, this.killTimeoutMs)) {
+        throw new Error("Runner-local OpenClaw gateway did not exit after SIGKILL");
+      }
+    }
+    if (this.process === child) this.process = undefined;
+  }
+  async restart(signal) { await this.stop(); signal?.throwIfAborted(); await this.start(signal); }
+}
+
+function waitForExit(child, timeoutMs) {
+  if (child.exitCode !== null) return Promise.resolve(true);
+  return new Promise((resolve) => {
+    const onExit = () => { clearTimeout(timer); resolve(true); };
+    const timer = setTimeout(() => { child.removeListener("exit", onExit); resolve(false); }, timeoutMs);
+    child.once("exit", onExit);
+  });
 }
 
 function command(value) { return `SMOKE_COMMAND\n${value}\nEND_SMOKE_COMMAND`; }
@@ -274,9 +301,10 @@ async function main() {
     });
 
     await scenario("explicit-reaction", async (signal) => {
-      const inboundId = await sendDm(command("react 🎉"), signal);
+      const marker = `${runId}:reacted`;
+      const inboundId = await sendDm(command(`react 🎉 ${marker}`), signal);
       await queue.waitFor((e) => e.type === "reaction" && e.op === "add" && String(e.message_id) === inboundId && (e.emoji_name === "tada" || e.emoji_code === "1f389"), timeoutMs, "explicit reaction", signal);
-      const reply = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, "reacted"), timeoutMs, "reaction acknowledgement", signal);
+      const reply = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, marker), timeoutMs, "reaction acknowledgement", signal);
       messageIds.bot.add(String(reply.message.id));
     });
 
@@ -324,7 +352,7 @@ async function main() {
       if (queue.events.some((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, marker))) {
         throw new Error("Durable reply completed before interruption; replay was not exercised");
       }
-      await gateway.restart();
+      await gateway.restart(signal);
       const reply = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, marker), timeoutMs, "durable replay reply", signal);
       messageIds.bot.add(String(reply.message.id));
       const settleDeadline = Date.now() + 10000;

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -81,6 +81,19 @@ export function isDurableReplyEvent(event, botEmail, actorEmail, marker) {
   return isPrivateBotEvent(event, botEmail, actorEmail) && String(event.message?.content ?? "").includes(marker);
 }
 
+export function eventOccursBefore(events, first, second) {
+  const firstIndex = events.indexOf(first);
+  const secondIndex = events.indexOf(second);
+  return firstIndex >= 0 && secondIndex >= 0 && firstIndex < secondIndex;
+}
+
+export function hasProvableMinimumMessageDelay(commandEvent, replyEvent, minimumSeconds) {
+  const commandTimestamp = commandEvent?.message?.timestamp;
+  const replyTimestamp = replyEvent?.message?.timestamp;
+  return Number.isSafeInteger(commandTimestamp) && Number.isSafeInteger(replyTimestamp) &&
+    replyTimestamp - commandTimestamp > minimumSeconds;
+}
+
 export function captureMessageIds(events, predicate, target) {
   const matches = events.filter(predicate);
   for (const event of matches) {
@@ -613,9 +626,12 @@ async function main() {
     await scenario("explicit-reaction", async (signal) => {
       const marker = `${runId}:reacted`;
       const inboundId = await sendDm(command(`react 🎉 ${marker}`), signal);
-      await queue.waitFor((e) => e.type === "reaction" && e.op === "add" && String(e.message_id) === inboundId && (e.emoji_name === "tada" || e.emoji_code === "1f389"), timeoutMs, "explicit reaction", signal);
+      const reaction = await queue.waitFor((e) => e.type === "reaction" && e.op === "add" && String(e.message_id) === inboundId && (e.emoji_name === "tada" || e.emoji_code === "1f389"), timeoutMs, "explicit reaction", signal);
       const reply = await queue.waitFor((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, marker), timeoutMs, "reaction acknowledgement", signal);
       messageIds.bot.add(String(reply.message.id));
+      if (!eventOccursBefore(queue.events, reaction, reply)) {
+        throw new Error("Reaction acknowledgement arrived before the requested reaction");
+      }
     });
 
     await scenario("edit-delete", async (signal) => {
@@ -663,6 +679,9 @@ async function main() {
         const oldGeneration = randomBytes(16).toString("hex");
         await writeGatewayGeneration(gatewayGenerationPath, oldGeneration);
         const inboundId = await sendDm(command(`durable ${marker}`), signal);
+        const commandEvent = await queue.waitFor((e) => e.type === "message" &&
+          String(e.message?.id) === inboundId && e.message?.sender_email === env.ZULIP_SMOKE_USER_EMAIL,
+        timeoutMs, "durable command event", signal);
         await queue.waitFor((e) => e.type === "reaction" && e.op === "add" && String(e.message_id) === inboundId, timeoutMs, "durable accept signal", signal);
         if (captureReplies().length) {
           throw new Error("Durable reply completed before interruption; replay was not exercised");
@@ -677,6 +696,9 @@ async function main() {
           captureReplies();
           if (!isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, replacementReply)) {
             throw new Error("Durable reply did not contain the replacement gateway generation");
+          }
+          if (!hasProvableMinimumMessageDelay(commandEvent, e, 15)) {
+            throw new Error("Durable reply did not prove the required 15-second delay");
           }
           return true;
         }, timeoutMs, "durable replay reply", signal);

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -65,11 +65,15 @@ export function isBotMessage(event, botEmail, marker) {
   return isExactRenderedContent(event.message?.content, marker);
 }
 
-export function isPrivateBotMessage(event, botEmail, actorEmail, marker) {
-  if (!isBotMessage(event, botEmail, marker) || event.message?.type !== "private") return false;
+export function isPrivateBotEvent(event, botEmail, actorEmail) {
+  if (event?.type !== "message" || event.message?.type !== "private" || event.message?.sender_email !== botEmail) return false;
   const recipients = Array.isArray(event.message?.display_recipient) ? event.message.display_recipient : [];
   const emails = recipients.map((recipient) => recipient?.email).filter(Boolean);
   return emails.includes(botEmail) && emails.includes(actorEmail);
+}
+
+export function isPrivateBotMessage(event, botEmail, actorEmail, marker) {
+  return isPrivateBotEvent(event, botEmail, actorEmail) && isExactRenderedContent(event.message?.content, marker);
 }
 
 export function isPrivateTypingEvent(event, botEmail, actorEmail, op) {
@@ -441,7 +445,7 @@ async function main() {
       const inboundReply = await queue.waitFor((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, inboundMarker), timeoutMs, "inbound upload read", signal);
       messageIds.bot.add(String(inboundReply.message.id));
       const outboundMarker = `${runId}:outbound-upload`; await sendDm(command(`send-upload ${outboundMarker}`), signal);
-      const outbound = await queue.waitFor((e) => e.type === "message" && e.message?.sender_email === env.ZULIP_SMOKE_BOT_EMAIL && /user_uploads\//.test(String(e.message?.content ?? "")), timeoutMs, "outbound upload", signal);
+      const outbound = await queue.waitFor((e) => isPrivateBotEvent(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL) && /user_uploads\//.test(String(e.message?.content ?? "")), timeoutMs, "outbound upload", signal);
       messageIds.bot.add(String(outbound.message.id));
       const match = String(outbound.message.content).match(/(?:href=")?([^"' ]*\/user_uploads\/[^"'< ]+)/);
       if (!match || !isExactUtf8(await actor.download(match[1], signal), outboundMarker)) throw new Error("Downloaded outbound upload did not match its marker");
@@ -451,9 +455,7 @@ async function main() {
       const question = `${runId}:poll`; const optionA = `smoke-choice:${runId}:interactive-ok`; const optionB = `${runId}:beta`;
       await sendDm(command(`poll ${question} ${optionA} ${optionB}`), signal);
       const poll = await queue.waitFor((e) => {
-        if (e.type !== "message" || e.message?.type !== "private" || e.message?.sender_email !== env.ZULIP_SMOKE_BOT_EMAIL) return false;
-        const recipients = Array.isArray(e.message?.display_recipient) ? e.message.display_recipient : [];
-        if (!recipients.some((recipient) => recipient?.email === env.ZULIP_SMOKE_USER_EMAIL)) return false;
+        if (!isPrivateBotEvent(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL)) return false;
         const raw = e.message?.widget_content;
         let widget = raw;
         if (typeof raw === "string") { try { widget = JSON.parse(raw); } catch { return false; } }

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -284,16 +284,14 @@ export function extractExactUploadUrl(content) {
   const anchor = rendered.match(/^<p><a href="([^"<>]*\/user_uploads\/[^"<>]+)">([^<>]+)<\/a><\/p>$/);
   if (anchor) {
     const href = anchor[1].replaceAll("&amp;", "&");
+    if (/[?#]/.test(href)) return undefined;
     const basename = href.split(/[?#]/, 1)[0].split("/").at(-1);
     let decodedBasename = basename;
     let fullyDecodedBasename = basename;
     for (let depth = 0; depth < 100; depth += 1) {
       if (/%(?:2f|5c|00)/i.test(fullyDecodedBasename)) return undefined;
       let decoded;
-      try { decoded = decodeURIComponent(fullyDecodedBasename); } catch {
-        if (fullyDecodedBasename !== basename) return undefined;
-        break;
-      }
+      try { decoded = decodeURIComponent(fullyDecodedBasename); } catch { return undefined; }
       if (depth === 0) decodedBasename = decoded;
       if (decoded === fullyDecodedBasename) break;
       fullyDecodedBasename = decoded;
@@ -305,7 +303,8 @@ export function extractExactUploadUrl(content) {
     return href;
   }
   const bare = rendered.match(/^((?:https?:\/\/[^\s<>]+)?\/[^\s<>]*user_uploads\/[^\s<>]+)$/);
-  return bare?.[1].replaceAll("&amp;", "&");
+  const bareUrl = bare?.[1].replaceAll("&amp;", "&");
+  return bareUrl && !/[?#]/.test(bareUrl) ? bareUrl : undefined;
 }
 
 export function isExactPollMessage(message, question, options) {

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -98,6 +98,18 @@ export function isExactUtf8(bytes, expected) {
   return bytes.length === expectedBytes.length && bytes.every((value, index) => value === expectedBytes[index]);
 }
 
+export async function countMessageDeletionFailures(client, ids) {
+  let failures = 0;
+  for (const id of ids) {
+    try {
+      await client.request(`messages/${id}`, { method: "DELETE" });
+    } catch {
+      failures += 1;
+    }
+  }
+  return failures;
+}
+
 export function lifecycleSummary(events, inboundMessageId) {
   const relevant = events.filter((event) =>
     event?.type === "reaction" && String(event.message_id) === String(inboundMessageId),
@@ -357,6 +369,7 @@ async function main() {
   const gateway = new Gateway(env.SMOKE_GATEWAY_PORT || 18789);
   const messageIds = { actor: new Set(), bot: new Set() };
   const report = [];
+  let runError;
   const sendDm = async (content, signal) => {
     const result = await actor.request("messages", { method: "POST", body: { type: "private", to: JSON.stringify([env.ZULIP_SMOKE_BOT_EMAIL]), content }, signal });
     messageIds.actor.add(String(result.id)); return String(result.id);
@@ -485,15 +498,24 @@ async function main() {
       const replies = queue.events.filter((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, marker));
       if (replies.length !== 1) throw new Error(`Durable receive produced ${replies.length} visible replies; expected exactly one`);
     });
+  } catch (error) {
+    runError = error;
   } finally {
     await gateway.stop().catch(() => {});
-    for (const id of messageIds.bot) await bot.request(`messages/${id}`, { method: "DELETE" }).catch(() => {});
-    for (const id of messageIds.actor) await actor.request(`messages/${id}`, { method: "DELETE" }).catch(() => {});
+    const cleanupFailures =
+      await countMessageDeletionFailures(bot, messageIds.bot) +
+      await countMessageDeletionFailures(actor, messageIds.actor);
     await queue.close().catch(() => {});
     for (const item of report) console.log(`${item.ok ? "PASS" : "FAIL"} ${item.name} (${item.ms}ms)${item.error ? `: ${item.error}` : ""}`);
     console.log(`Evidence: tested commit ${env.SMOKE_TESTED_SHA}; run identifier ${runId}`);
-    console.log("Cleanup: messages deleted where permissions permit; Zulip exposes no public API for deleting uploaded files.");
+    console.log(`Cleanup: message deletion failures=${cleanupFailures}; Zulip exposes no public API for deleting uploaded files.`);
+    if (cleanupFailures > 0) {
+      const cleanupError = new Error(`Cleanup failed for ${cleanupFailures} smoke messages`);
+      if (runError) console.error(`Cleanup also failed: ${redactError(cleanupError)}`);
+      else throw cleanupError;
+    }
   }
+  if (runError) throw runError;
 }
 
 if (import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -284,27 +284,35 @@ export function extractExactUploadUrl(content) {
   const anchor = rendered.match(/^<p><a href="([^"<>]*\/user_uploads\/[^"<>]+)">([^<>]+)<\/a><\/p>$/);
   if (anchor) {
     const href = anchor[1].replaceAll("&amp;", "&");
-    if (/[?#]/.test(href)) return undefined;
-    const basename = href.split(/[?#]/, 1)[0].split("/").at(-1);
-    let decodedBasename = basename;
-    let fullyDecodedBasename = basename;
-    for (let depth = 0; depth < 100; depth += 1) {
-      if (/%(?:2f|5c|00)/i.test(fullyDecodedBasename)) return undefined;
-      let decoded;
-      try { decoded = decodeURIComponent(fullyDecodedBasename); } catch { return undefined; }
-      if (depth === 0) decodedBasename = decoded;
-      if (decoded === fullyDecodedBasename) break;
-      fullyDecodedBasename = decoded;
-      if (depth === 99) return undefined;
-    }
-    if (/[\\/\0]/.test(fullyDecodedBasename) || /^file:/i.test(fullyDecodedBasename) ||
-        fullyDecodedBasename === "." || fullyDecodedBasename === "..") return undefined;
+    const canonical = canonicalUploadUrl(href);
+    if (!canonical) return undefined;
+    const { basename, decodedBasename } = canonical;
     if (![anchor[1], href, basename, decodedBasename].includes(anchor[2])) return undefined;
     return href;
   }
   const bare = rendered.match(/^((?:https?:\/\/[^\s<>]+)?\/[^\s<>]*user_uploads\/[^\s<>]+)$/);
   const bareUrl = bare?.[1].replaceAll("&amp;", "&");
-  return bareUrl && !/[?#]/.test(bareUrl) ? bareUrl : undefined;
+  return bareUrl && canonicalUploadUrl(bareUrl) ? bareUrl : undefined;
+}
+
+function canonicalUploadUrl(href) {
+  if (/[?#]/.test(href)) return undefined;
+  const basename = href.split("/").at(-1);
+  if (!basename) return undefined;
+  let decodedBasename = basename;
+  let fullyDecodedBasename = basename;
+  for (let depth = 0; depth < 100; depth += 1) {
+    if (/%(?:2f|5c|00)/i.test(fullyDecodedBasename)) return undefined;
+    let decoded;
+    try { decoded = decodeURIComponent(fullyDecodedBasename); } catch { return undefined; }
+    if (depth === 0) decodedBasename = decoded;
+    if (decoded === fullyDecodedBasename) break;
+    fullyDecodedBasename = decoded;
+    if (depth === 99) return undefined;
+  }
+  if (/[\\/\0]/.test(fullyDecodedBasename) || /^file:/i.test(fullyDecodedBasename) ||
+      fullyDecodedBasename === "." || fullyDecodedBasename === "..") return undefined;
+  return { basename, decodedBasename };
 }
 
 export function isExactPollMessage(message, question, options) {

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -153,6 +153,10 @@ export async function assertMessageRemainsExact(client, id, expected, minimumMs,
 }
 
 export async function countCompletedChildTranscripts(stateDir, marker) {
+  return (await inspectChildTranscripts(stateDir, marker)).completedExact;
+}
+
+export async function inspectChildTranscripts(stateDir, marker) {
   const files = [];
   const visit = async (directory) => {
     let entries;
@@ -168,16 +172,18 @@ export async function countCompletedChildTranscripts(stateDir, marker) {
     }
   };
   await visit(resolve(stateDir, "agents"));
-  let matches = 0;
+  let total = 0;
+  let completedExact = 0;
   for (const file of files) {
     const records = (await readFile(file, "utf8")).split("\n").filter(Boolean).flatMap((line) => {
       try { return [JSON.parse(line)]; } catch { return []; }
     });
-    if (!records.some((record) => JSON.stringify(record).includes(marker))) continue;
+    if (!records.some(isSubagentTaskRecord)) continue;
+    total += 1;
     const results = records.flatMap(assistantMessageTexts);
-    if (results.at(-1) === marker) matches += 1;
+    if (results.at(-1) === marker) completedExact += 1;
   }
-  return matches;
+  return { total, completedExact };
 }
 
 export async function writeGatewayGeneration(path, generation) {
@@ -220,12 +226,36 @@ export function lifecycleSummary(events, inboundMessageId) {
   };
 }
 
+export function subagentCompletedBeforeReply(events, inboundMessageId, replyEvent) {
+  const replyIndex = events.indexOf(replyEvent);
+  if (replyIndex < 0) return false;
+  const active = new Set();
+  let sawSubagent = false;
+  for (const event of events.slice(0, replyIndex)) {
+    if (event?.type !== "reaction" || String(event.message_id) !== String(inboundMessageId) ||
+        (event.emoji_name !== "robot" && event.emoji_code !== "1f916")) continue;
+    sawSubagent = true;
+    const key = reactionKey(event);
+    if (event.op === "add") active.add(key);
+    else if (event.op === "remove") active.delete(key);
+  }
+  return sawSubagent && active.size === 0;
+}
+
 export function isExactPoll(widget, question, options) {
   const extra = widget?.extra_data;
   if (extra?.poll !== true || extra.heading !== question || !Array.isArray(extra.choices)) return false;
   if (extra.choices.length !== options.length) return false;
   return extra.choices.every((choice, index) => choice?.type === "multiple_choice" &&
     choice.short_name === options[index] && choice.long_name === options[index] && choice.reply === options[index]);
+}
+
+export function isExactPollMessage(message, question, options) {
+  let widget = message?.widget_content;
+  if (typeof widget === "string") {
+    try { widget = JSON.parse(widget); } catch { return false; }
+  }
+  return isExactRenderedContent(message?.content, question) && isExactPoll(widget, question, options);
 }
 
 export function normalizeScenarioError(signal, error) {
@@ -250,6 +280,14 @@ function assistantMessageTexts(value) {
     return text ? [text] : [];
   }
   return Object.values(value).flatMap(assistantMessageTexts);
+}
+
+function isSubagentTaskRecord(value) {
+  const message = value?.message;
+  if (message?.role !== "user") return false;
+  const content = typeof message.content === "string" ? message.content :
+    Array.isArray(message.content) ? message.content.map((part) => typeof part === "string" ? part : part?.text ?? "").join("") : "";
+  return content.includes("[Subagent Task]");
 }
 
 function escapeHtml(value) {
@@ -536,14 +574,17 @@ async function main() {
       if (!summary.sawSubagent) throw new Error("No truthful subagent lifecycle reaction was observed");
       if (summary.subagentCount !== 1) throw new Error(`Observed ${summary.subagentCount} subagent lifecycle reactions; expected exactly one`);
       if (!summary.allRemoved) throw new Error("Lifecycle reactions were not cleaned up after completion");
+      if (!subagentCompletedBeforeReply(queue.events, inboundId, reply)) {
+        throw new Error("The child lifecycle did not complete before the parent reply");
+      }
       const transcriptDeadline = Date.now() + timeoutMs;
-      let childTranscriptCount = 0;
-      while (Date.now() < transcriptDeadline && (childTranscriptCount = await countCompletedChildTranscripts(env.OPENCLAW_STATE_DIR, childResult)) === 0) {
+      let childTranscripts;
+      while (Date.now() < transcriptDeadline && (childTranscripts = await inspectChildTranscripts(env.OPENCLAW_STATE_DIR, childResult)).completedExact === 0) {
         await delay(250, undefined, { signal });
       }
-      childTranscriptCount = await countCompletedChildTranscripts(env.OPENCLAW_STATE_DIR, childResult);
-      if (childTranscriptCount !== 1) {
-        throw new Error(`Found ${childTranscriptCount} completed child transcripts with the exact required result; expected one`);
+      childTranscripts = await inspectChildTranscripts(env.OPENCLAW_STATE_DIR, childResult);
+      if (childTranscripts.total !== 1 || childTranscripts.completedExact !== 1) {
+        throw new Error(`Found ${childTranscripts.total} child transcripts and ${childTranscripts.completedExact} exact completed results; expected exactly one of each`);
       }
       await assertFinalPrivateTypingStop(queue, eventStart, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, signal);
     });
@@ -584,10 +625,7 @@ async function main() {
       await sendDm(command(`poll ${question} ${optionA} ${optionB}`), signal);
       const poll = await queue.waitFor((e) => {
         if (!isPrivateBotEvent(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL)) return false;
-        const raw = e.message?.widget_content;
-        let widget = raw;
-        if (typeof raw === "string") { try { widget = JSON.parse(raw); } catch { return false; } }
-        return isExactPoll(widget, question, [optionA, optionB]);
+        return isExactPollMessage(e.message, question, [optionA, optionB]);
       }, timeoutMs, "native poll", signal);
       messageIds.bot.add(String(poll.message.id));
       await sendDm(optionA, signal);

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -285,8 +285,18 @@ export function extractExactUploadUrl(content) {
   if (anchor) {
     const href = anchor[1].replaceAll("&amp;", "&");
     const basename = href.split(/[?#]/, 1)[0].split("/").at(-1);
-    let decodedBasename;
-    try { decodedBasename = decodeURIComponent(basename); } catch { decodedBasename = basename; }
+    let decodedBasename = basename;
+    let fullyDecodedBasename = basename;
+    for (let depth = 0; depth < 100; depth += 1) {
+      let decoded;
+      try { decoded = decodeURIComponent(fullyDecodedBasename); } catch { break; }
+      if (depth === 0) decodedBasename = decoded;
+      if (decoded === fullyDecodedBasename) break;
+      fullyDecodedBasename = decoded;
+      if (depth === 99) return undefined;
+    }
+    if (/[\\/\0]/.test(fullyDecodedBasename) || /^file:/i.test(fullyDecodedBasename) ||
+        fullyDecodedBasename === "." || fullyDecodedBasename === "..") return undefined;
     if (![anchor[1], href, basename, decodedBasename].includes(anchor[2])) return undefined;
     return href;
   }

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -594,9 +594,13 @@ async function main() {
       if (childTranscripts.total !== 1 || childTranscripts.completedExact !== 1) {
         throw new Error(`Found ${childTranscripts.total} child transcripts and ${childTranscripts.completedExact} exact completed results; expected exactly one of each`);
       }
-      await assertFinalPrivateTypingStop(queue, eventStart, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, signal);
-      await drainEventQueueUntilQuiet(queue, signal, 500, timeoutMs, 100, () => lifecycleSummary(queue.events, inboundId).allRemoved);
+      await drainEventQueueUntilQuiet(queue, signal, 500, timeoutMs, 100, () =>
+        lifecycleSummary(queue.events, inboundId).allRemoved &&
+        hasFinalPrivateTypingStop(queue.events.slice(eventStart), env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL));
       summary = lifecycleSummary(queue.events, inboundId);
+      if (!hasFinalPrivateTypingStop(queue.events.slice(eventStart), env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL)) {
+        throw new Error("Final direct typing state was not stopped after lifecycle completion");
+      }
       if (!summary.added.length) throw new Error("No lifecycle reaction was observed on the inbound message");
       if (!summary.sawSubagent) throw new Error("No truthful subagent lifecycle reaction was observed");
       if (summary.subagentCount !== 1) throw new Error(`Observed ${summary.subagentCount} subagent lifecycle reactions; expected exactly one`);

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -68,8 +68,7 @@ export function isBotMessage(event, botEmail, marker) {
 export function isPrivateBotEvent(event, botEmail, actorEmail) {
   if (event?.type !== "message" || event.message?.type !== "private" || event.message?.sender_email !== botEmail) return false;
   const recipients = Array.isArray(event.message?.display_recipient) ? event.message.display_recipient : [];
-  const emails = recipients.map((recipient) => recipient?.email).filter(Boolean);
-  return emails.includes(botEmail) && emails.includes(actorEmail);
+  return hasExactDirectParticipants(recipients, botEmail, actorEmail);
 }
 
 export function isPrivateBotMessage(event, botEmail, actorEmail, marker) {
@@ -81,7 +80,12 @@ export function isPrivateTypingEvent(event, botEmail, actorEmail, op) {
   const senderEmail = event.sender?.email ?? event.sender_email;
   if (senderEmail !== botEmail || (event.message_type && !["direct", "private"].includes(event.message_type))) return false;
   const recipients = Array.isArray(event.recipients) ? event.recipients : [];
-  return recipients.length === 0 || recipients.some((recipient) => (recipient?.email ?? recipient) === actorEmail);
+  return hasExactDirectParticipants(recipients, botEmail, actorEmail);
+}
+
+function hasExactDirectParticipants(recipients, botEmail, actorEmail) {
+  const emails = new Set(recipients.map((recipient) => recipient?.email ?? recipient).filter(Boolean));
+  return emails.size === 2 && emails.has(botEmail) && emails.has(actorEmail);
 }
 
 export function isExactRenderedContent(content, expected) {

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -272,10 +272,23 @@ export function subagentCompletedBeforeReply(events, inboundMessageId, replyEven
 
 export function isExactPoll(widget, question, options) {
   const extra = widget?.extra_data;
-  if (extra?.poll !== true || extra.heading !== question || !Array.isArray(extra.choices)) return false;
+  if (widget?.widget_type !== "zform" || extra?.type !== "choices" || extra.poll !== true ||
+      extra.heading !== question || !Array.isArray(extra.choices)) return false;
   if (extra.choices.length !== options.length) return false;
   return extra.choices.every((choice, index) => choice?.type === "multiple_choice" &&
     choice.short_name === options[index] && choice.long_name === options[index] && choice.reply === options[index]);
+}
+
+export function extractExactUploadUrl(content) {
+  const rendered = String(content ?? "");
+  const anchor = rendered.match(/^<p><a href="([^"<>]*\/user_uploads\/[^"<>]+)">([^<>]+)<\/a><\/p>$/);
+  if (anchor) {
+    const label = anchor[2];
+    if (/^(?:file:|\/(?:Users|Volumes|private|tmp)\/|[A-Za-z]:\\)/.test(label)) return undefined;
+    return anchor[1].replaceAll("&amp;", "&");
+  }
+  const bare = rendered.match(/^((?:https?:\/\/[^\s<>]+)?\/[^\s<>]*user_uploads\/[^\s<>]+)$/);
+  return bare?.[1].replaceAll("&amp;", "&");
 }
 
 export function isExactPollMessage(message, question, options) {
@@ -651,10 +664,11 @@ async function main() {
       const inboundReply = await queue.waitFor((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, inboundMarker), timeoutMs, "inbound upload read", signal);
       messageIds.bot.add(String(inboundReply.message.id));
       const outboundMarker = `${runId}:outbound-upload`; await sendDm(command(`send-upload ${outboundMarker}`), signal);
-      const outbound = await queue.waitFor((e) => isPrivateBotEvent(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL) && /user_uploads\//.test(String(e.message?.content ?? "")), timeoutMs, "outbound upload", signal);
+      const outbound = await queue.waitFor((e) => isPrivateBotEvent(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL) &&
+        Boolean(extractExactUploadUrl(e.message?.content)), timeoutMs, "outbound upload", signal);
       messageIds.bot.add(String(outbound.message.id));
-      const match = String(outbound.message.content).match(/(?:href=")?([^"' ]*\/user_uploads\/[^"'< ]+)/);
-      if (!match || !isExactUtf8(await actor.download(match[1], signal), outboundMarker)) throw new Error("Downloaded outbound upload did not match its marker");
+      const uploadUrl = extractExactUploadUrl(outbound.message.content);
+      if (!uploadUrl || !isExactUtf8(await actor.download(uploadUrl, signal), outboundMarker)) throw new Error("Downloaded outbound upload did not match its marker");
     });
 
     await scenario("poll-and-interactive-reply", async (signal) => {

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -22,7 +22,13 @@ export function validateEnvironment(env) {
   if (!/^[0-9a-f]{40}$/.test(env.SMOKE_TESTED_SHA)) throw new Error("SMOKE_TESTED_SHA must be a full commit SHA");
   const url = new URL(env.ZULIP_URL);
   if (url.protocol !== "https:") throw new Error("ZULIP_URL must use HTTPS");
-  return { ...env, ZULIP_URL: url.origin };
+  url.search = "";
+  url.hash = "";
+  return { ...env, ZULIP_URL: url.toString().replace(/\/+$/, "") };
+}
+
+export function buildApiUrl(baseUrl, path) {
+  return new URL(`${baseUrl.replace(/\/+$/, "")}/api/v1/${path.replace(/^\/+/, "")}`);
 }
 
 export function redactError(error) {
@@ -100,7 +106,7 @@ class ZulipClient {
   }
 
   async request(path, { method = "GET", params, body, signal } = {}) {
-    const url = new URL(`/api/v1/${path}`, this.baseUrl);
+    const url = buildApiUrl(this.baseUrl, path);
     if (params) for (const [key, value] of Object.entries(params)) url.searchParams.set(key, String(value));
     const response = await fetch(url, {
       method,
@@ -116,7 +122,7 @@ class ZulipClient {
   async upload(filename, contents, signal) {
     const form = new FormData();
     form.set("file", new Blob([contents], { type: "text/plain" }), filename);
-    const response = await fetch(new URL("/api/v1/user_uploads", this.baseUrl), {
+    const response = await fetch(buildApiUrl(this.baseUrl, "user_uploads"), {
       method: "POST", headers: { Authorization: this.authorization }, body: form,
       signal: signal ? AbortSignal.any([signal, AbortSignal.timeout(30000)]) : AbortSignal.timeout(30000),
     });

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -65,6 +65,21 @@ export function isBotMessage(event, botEmail, marker) {
   return isExactRenderedContent(event.message?.content, marker);
 }
 
+export function isPrivateBotMessage(event, botEmail, actorEmail, marker) {
+  if (!isBotMessage(event, botEmail, marker) || event.message?.type !== "private") return false;
+  const recipients = Array.isArray(event.message?.display_recipient) ? event.message.display_recipient : [];
+  const emails = recipients.map((recipient) => recipient?.email).filter(Boolean);
+  return emails.includes(botEmail) && emails.includes(actorEmail);
+}
+
+export function isPrivateTypingEvent(event, botEmail, actorEmail, op) {
+  if (event?.type !== "typing" || event.op !== op) return false;
+  const senderEmail = event.sender?.email ?? event.sender_email;
+  if (senderEmail !== botEmail || (event.message_type && !["direct", "private"].includes(event.message_type))) return false;
+  const recipients = Array.isArray(event.recipients) ? event.recipients : [];
+  return recipients.length === 0 || recipients.some((recipient) => (recipient?.email ?? recipient) === actorEmail);
+}
+
 export function isExactRenderedContent(content, expected) {
   const rendered = String(content ?? "");
   return rendered === expected || rendered === `<p>${escapeHtml(expected)}</p>`;
@@ -200,11 +215,13 @@ export class EventQueue {
 }
 
 export class Gateway {
-  constructor(port, { termTimeoutMs = 10000, killTimeoutMs = 5000, healthProbe } = {}) {
+  constructor(port, { termTimeoutMs = 10000, killTimeoutMs = 5000, healthProbe, healthProbeSpawn = spawn, healthProbeTimeoutMs = 5000 } = {}) {
     this.port = String(port);
     this.termTimeoutMs = termTimeoutMs;
     this.killTimeoutMs = killTimeoutMs;
     this.healthProbe = healthProbe;
+    this.healthProbeSpawn = healthProbeSpawn;
+    this.healthProbeTimeoutMs = healthProbeTimeoutMs;
   }
   async start(signal) {
     signal?.throwIfAborted();
@@ -229,11 +246,25 @@ export class Gateway {
   async isHealthy() {
     if (this.healthProbe) return this.healthProbe();
     return new Promise((resolve) => {
-      const probe = spawn("pnpm", ["exec", "openclaw", "gateway", "health", "--port", this.port, "--timeout", "2000"], { stdio: "ignore", env: process.env });
+      const probe = this.healthProbeSpawn("pnpm", ["exec", "openclaw", "gateway", "health", "--port", this.port, "--timeout", "2000"], {
+        stdio: "ignore", env: process.env, detached: process.platform !== "win32",
+      });
       let settled = false;
-      const finish = (value) => { if (!settled) { settled = true; resolve(value); } };
+      let timeout;
+      const finish = (value) => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timeout);
+          resolve(value);
+        }
+      };
       probe.once("error", () => finish(false));
       probe.once("exit", (code) => finish(code === 0));
+      timeout = setTimeout(() => {
+        try { signalProcessTree(probe, "SIGKILL"); } catch {}
+        finish(false);
+      }, this.healthProbeTimeoutMs);
+      timeout.unref?.();
     });
   }
   async waitUntilUnhealthy(timeoutMs) {
@@ -350,7 +381,7 @@ async function main() {
 
     await scenario("dm-round-trip", async (signal) => {
       const marker = `${runId}:dm-ok`; await sendDm(command(`echo ${marker}`), signal);
-      const event = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, marker), timeoutMs, "DM reply", signal);
+      const event = await queue.waitFor((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, marker), timeoutMs, "DM reply", signal);
       messageIds.bot.add(String(event.message.id));
     });
 
@@ -365,9 +396,14 @@ async function main() {
     await scenario("typing-and-lifecycle-reactions", async (signal) => {
       const marker = `${runId}:lifecycle-ok`; const eventStart = queue.events.length;
       const inboundId = await sendDm(command(`lifecycle ${marker}`), signal);
-      const reply = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, marker), timeoutMs, "lifecycle reply", signal);
+      const reply = await queue.waitFor((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, marker), timeoutMs, "lifecycle reply", signal);
       messageIds.bot.add(String(reply.message.id));
-      await queue.waitFor((e) => queue.events.indexOf(e) >= eventStart && e.type === "typing" && e.op === "stop", timeoutMs, "typing stop cleanup", signal);
+      await queue.waitFor((e) => {
+        const stopIndex = queue.events.indexOf(e);
+        if (stopIndex < eventStart || !isPrivateTypingEvent(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, "stop")) return false;
+        return queue.events.slice(eventStart, stopIndex).some((candidate) =>
+          isPrivateTypingEvent(candidate, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, "start"));
+      }, timeoutMs, "ordered typing start/stop cleanup", signal);
       const deadline = Date.now() + timeoutMs;
       let summary;
       while (Date.now() < deadline) {
@@ -379,22 +415,20 @@ async function main() {
       if (!summary?.added.length) throw new Error("No lifecycle reaction was observed on the inbound message");
       if (!summary.sawSubagent) throw new Error("No truthful subagent lifecycle reaction was observed");
       if (!summary.allRemoved) throw new Error("Lifecycle reactions were not cleaned up after completion");
-      const startedTyping = queue.events.slice(eventStart).some((e) => e.type === "typing" && e.op === "start");
-      if (!startedTyping) throw new Error("Typing start was not observed");
     });
 
     await scenario("explicit-reaction", async (signal) => {
       const marker = `${runId}:reacted`;
       const inboundId = await sendDm(command(`react 🎉 ${marker}`), signal);
       await queue.waitFor((e) => e.type === "reaction" && e.op === "add" && String(e.message_id) === inboundId && (e.emoji_name === "tada" || e.emoji_code === "1f389"), timeoutMs, "explicit reaction", signal);
-      const reply = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, marker), timeoutMs, "reaction acknowledgement", signal);
+      const reply = await queue.waitFor((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, marker), timeoutMs, "reaction acknowledgement", signal);
       messageIds.bot.add(String(reply.message.id));
     });
 
     await scenario("edit-delete", async (signal) => {
       const before = `${runId}:before-edit`; const after = `${runId}:after-edit`;
       await sendDm(command(`edit-delete ${before} ${after}`), signal);
-      const created = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, before), timeoutMs, "message before edit", signal);
+      const created = await queue.waitFor((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, before), timeoutMs, "message before edit", signal);
       const id = String(created.message.id); messageIds.bot.add(id);
       await queue.waitFor((e) => e.type === "update_message" && String(e.message_id) === id && isExactRenderedContent(e.content, after), timeoutMs, "message edit", signal);
       await queue.waitFor((e) => e.type === "delete_message" && (e.message_ids ?? [e.message_id]).map(String).includes(id), timeoutMs, "message delete", signal);
@@ -404,7 +438,7 @@ async function main() {
     await scenario("upload-download", async (signal) => {
       const inboundMarker = `${runId}:inbound-upload`; const uri = await actor.upload(`${runId}.txt`, inboundMarker, signal);
       await sendDm(`${command(`read-upload ${inboundMarker}`)}\n[attachment](${uri})`, signal);
-      const inboundReply = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, inboundMarker), timeoutMs, "inbound upload read", signal);
+      const inboundReply = await queue.waitFor((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, inboundMarker), timeoutMs, "inbound upload read", signal);
       messageIds.bot.add(String(inboundReply.message.id));
       const outboundMarker = `${runId}:outbound-upload`; await sendDm(command(`send-upload ${outboundMarker}`), signal);
       const outbound = await queue.waitFor((e) => e.type === "message" && e.message?.sender_email === env.ZULIP_SMOKE_BOT_EMAIL && /user_uploads\//.test(String(e.message?.content ?? "")), timeoutMs, "outbound upload", signal);
@@ -417,7 +451,9 @@ async function main() {
       const question = `${runId}:poll`; const optionA = `smoke-choice:${runId}:interactive-ok`; const optionB = `${runId}:beta`;
       await sendDm(command(`poll ${question} ${optionA} ${optionB}`), signal);
       const poll = await queue.waitFor((e) => {
-        if (e.type !== "message" || e.message?.sender_email !== env.ZULIP_SMOKE_BOT_EMAIL) return false;
+        if (e.type !== "message" || e.message?.type !== "private" || e.message?.sender_email !== env.ZULIP_SMOKE_BOT_EMAIL) return false;
+        const recipients = Array.isArray(e.message?.display_recipient) ? e.message.display_recipient : [];
+        if (!recipients.some((recipient) => recipient?.email === env.ZULIP_SMOKE_USER_EMAIL)) return false;
         const raw = e.message?.widget_content;
         let widget = raw;
         if (typeof raw === "string") { try { widget = JSON.parse(raw); } catch { return false; } }
@@ -425,22 +461,22 @@ async function main() {
       }, timeoutMs, "native poll", signal);
       messageIds.bot.add(String(poll.message.id));
       await sendDm(optionA, signal);
-      const reply = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, `${runId}:interactive-ok`), timeoutMs, "interactive reply", signal);
+      const reply = await queue.waitFor((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, `${runId}:interactive-ok`), timeoutMs, "interactive reply", signal);
       messageIds.bot.add(String(reply.message.id));
     });
 
     await scenario("durable-receive-completion-deduplication", async (signal) => {
       const marker = `${runId}:durable-ok`; const inboundId = await sendDm(command(`durable ${marker}`), signal);
       await queue.waitFor((e) => e.type === "reaction" && e.op === "add" && String(e.message_id) === inboundId, timeoutMs, "durable accept signal", signal);
-      if (queue.events.some((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, marker))) {
+      if (queue.events.some((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, marker))) {
         throw new Error("Durable reply completed before interruption; replay was not exercised");
       }
       await gateway.restart(signal);
-      const reply = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, marker), timeoutMs, "durable replay reply", signal);
+      const reply = await queue.waitFor((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, marker), timeoutMs, "durable replay reply", signal);
       messageIds.bot.add(String(reply.message.id));
       const settleDeadline = Date.now() + 10000;
       while (Date.now() < settleDeadline) { await queue.poll(signal); await delay(500, undefined, { signal }); }
-      const replies = queue.events.filter((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, marker));
+      const replies = queue.events.filter((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, marker));
       if (replies.length !== 1) throw new Error(`Durable receive produced ${replies.length} visible replies; expected exactly one`);
     });
   } finally {

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -89,6 +89,16 @@ export function captureMessageIds(events, predicate, target) {
   return matches;
 }
 
+export function captureObservedSmokeBotMessageIds(events, { botEmail, actorEmail, stream, runId }, target, excluded = new Set()) {
+  return captureMessageIds(events, (event) => {
+    if (event?.type !== "message" || event.message?.sender_email !== botEmail || excluded.has(String(event.message?.id))) return false;
+    if (isPrivateBotEvent(event, botEmail, actorEmail)) return true;
+    const content = String(event.message?.content ?? "");
+    return content.includes(runId) || (event.message?.type === "stream" &&
+      event.message?.display_recipient === stream && event.message?.subject === `${runId}-topic`);
+  }, target);
+}
+
 export function isPrivateTypingEvent(event, botEmail, actorEmail, op) {
   if (event?.type !== "typing" || event.op !== op) return false;
   const senderEmail = event.sender?.email ?? event.sender_email;
@@ -444,6 +454,7 @@ async function main() {
   const gateway = new Gateway(env.SMOKE_GATEWAY_PORT || 18789);
   const gatewayGenerationPath = resolve("scripts/live-smoke/agent-workspace/.smoke-gateway-generation");
   const messageIds = { actor: new Set(), bot: new Set() };
+  const deletedBotMessageIds = new Set();
   const report = [];
   let runError;
   const sendDm = async (content, signal) => {
@@ -538,9 +549,9 @@ async function main() {
       const created = await queue.waitFor((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, before), timeoutMs, "message before edit", signal);
       const id = String(created.message.id); messageIds.bot.add(id);
       await queue.waitFor((e) => e.type === "update_message" && String(e.message_id) === id && isExactRenderedContent(e.content, after), timeoutMs, "message edit", signal);
-      await assertMessageRemainsExact(actor, id, after, 2000, signal);
+      await assertMessageRemainsExact(actor, id, after, 4000, signal);
       await queue.waitFor((e) => e.type === "delete_message" && (e.message_ids ?? [e.message_id]).map(String).includes(id), timeoutMs, "message delete", signal);
-      messageIds.bot.delete(id);
+      messageIds.bot.delete(id); deletedBotMessageIds.add(id);
     });
 
     await scenario("upload-download", async (signal) => {
@@ -614,6 +625,13 @@ async function main() {
   } finally {
     await gateway.stop().catch(() => {});
     await unlink(gatewayGenerationPath).catch(() => {});
+    await queue.poll().catch(() => {});
+    captureObservedSmokeBotMessageIds(queue.events, {
+      botEmail: env.ZULIP_SMOKE_BOT_EMAIL,
+      actorEmail: env.ZULIP_SMOKE_USER_EMAIL,
+      stream: env.ZULIP_SMOKE_STREAM,
+      runId,
+    }, messageIds.bot, deletedBotMessageIds);
     const cleanupFailures =
       await countMessageDeletionFailures(bot, messageIds.bot) +
       await countMessageDeletionFailures(actor, messageIds.actor);

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -283,9 +283,12 @@ export function extractExactUploadUrl(content) {
   const rendered = String(content ?? "");
   const anchor = rendered.match(/^<p><a href="([^"<>]*\/user_uploads\/[^"<>]+)">([^<>]+)<\/a><\/p>$/);
   if (anchor) {
-    const label = anchor[2];
-    if (/^(?:file:|\/(?:Users|Volumes|private|tmp)\/|[A-Za-z]:\\)/.test(label)) return undefined;
-    return anchor[1].replaceAll("&amp;", "&");
+    const href = anchor[1].replaceAll("&amp;", "&");
+    const basename = href.split(/[?#]/, 1)[0].split("/").at(-1);
+    let decodedBasename;
+    try { decodedBasename = decodeURIComponent(basename); } catch { decodedBasename = basename; }
+    if (![anchor[1], href, basename, decodedBasename].includes(anchor[2])) return undefined;
+    return href;
   }
   const bare = rendered.match(/^((?:https?:\/\/[^\s<>]+)?\/[^\s<>]*user_uploads\/[^\s<>]+)$/);
   return bare?.[1].replaceAll("&amp;", "&");

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -168,7 +168,7 @@ export async function inspectChildTranscripts(stateDir, marker) {
     for (const entry of entries) {
       const path = resolve(directory, entry.name);
       if (entry.isDirectory()) await visit(path);
-      else if (entry.isFile() && /\.jsonl(?:\.(?:deleted|reset)\..+)?$/.test(entry.name)) files.push(path);
+      else if (entry.isFile() && isUsageCountedTranscriptName(entry.name)) files.push(path);
     }
   };
   await visit(resolve(stateDir, "agents"));
@@ -184,6 +184,13 @@ export async function inspectChildTranscripts(stateDir, marker) {
     if (results.at(-1) === marker) completedExact += 1;
   }
   return { total, completedExact };
+}
+
+export function isUsageCountedTranscriptName(name) {
+  const stamp = "\\d{4}-\\d{2}-\\d{2}T\\d{2}-\\d{2}-\\d{2}(?:\\.\\d{3})?Z";
+  if (new RegExp(`\\.jsonl\\.(?:deleted|reset)\\.${stamp}$`).test(name)) return true;
+  if (!name.endsWith(".jsonl") || name.endsWith(".trajectory.jsonl")) return false;
+  return !/\.checkpoint\.[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.jsonl$/i.test(name);
 }
 
 export async function writeGatewayGeneration(path, generation) {

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -114,13 +114,13 @@ export function hasFinalPrivateTypingStop(events, botEmail, actorEmail) {
   return lifecycle.some((event) => event.op === "start") && lifecycle.at(-1)?.op === "stop";
 }
 
-export async function drainEventQueueUntilQuiet(queue, signal, quietMs = 500, maxMs = 5000, pollIntervalMs = 100) {
+export async function drainEventQueueUntilQuiet(queue, signal, quietMs = 500, maxMs = 5000, pollIntervalMs = 100, isComplete = () => true) {
   const deadline = Date.now() + maxMs;
   let quietSince = Date.now();
   while (Date.now() < deadline) {
     const batch = await queue.poll(signal);
     if (batch.some((event) => event.type !== "heartbeat")) quietSince = Date.now();
-    if (Date.now() - quietSince >= quietMs) return;
+    if (Date.now() - quietSince >= quietMs && isComplete()) return;
     await delay(pollIntervalMs, undefined, { signal });
   }
   throw new Error("Event queue did not reach a stable quiet window");
@@ -595,6 +595,7 @@ async function main() {
         throw new Error(`Found ${childTranscripts.total} child transcripts and ${childTranscripts.completedExact} exact completed results; expected exactly one of each`);
       }
       await assertFinalPrivateTypingStop(queue, eventStart, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, signal);
+      await drainEventQueueUntilQuiet(queue, signal, 500, timeoutMs, 100, () => lifecycleSummary(queue.events, inboundId).allRemoved);
       summary = lifecycleSummary(queue.events, inboundId);
       if (!summary.added.length) throw new Error("No lifecycle reaction was observed on the inbound message");
       if (!summary.sawSubagent) throw new Error("No truthful subagent lifecycle reaction was observed");

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -288,8 +288,12 @@ export function extractExactUploadUrl(content) {
     let decodedBasename = basename;
     let fullyDecodedBasename = basename;
     for (let depth = 0; depth < 100; depth += 1) {
+      if (/%(?:2f|5c|00)/i.test(fullyDecodedBasename)) return undefined;
       let decoded;
-      try { decoded = decodeURIComponent(fullyDecodedBasename); } catch { break; }
+      try { decoded = decodeURIComponent(fullyDecodedBasename); } catch {
+        if (fullyDecodedBasename !== basename) return undefined;
+        break;
+      }
       if (depth === 0) decodedBasename = decoded;
       if (decoded === fullyDecodedBasename) break;
       fullyDecodedBasename = decoded;

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -166,29 +166,49 @@ export class EventQueue {
 }
 
 export class Gateway {
-  constructor(port, { termTimeoutMs = 10000, killTimeoutMs = 5000 } = {}) {
+  constructor(port, { termTimeoutMs = 10000, killTimeoutMs = 5000, healthProbe } = {}) {
     this.port = String(port);
     this.termTimeoutMs = termTimeoutMs;
     this.killTimeoutMs = killTimeoutMs;
+    this.healthProbe = healthProbe;
   }
   async start(signal) {
     signal?.throwIfAborted();
-    if (this.process?.exitCode === null) throw new Error("Runner-local OpenClaw gateway is already running");
+    if (this.process && isProcessTreeRunning(this.process)) throw new Error("Runner-local OpenClaw gateway is already running");
     this.process = spawn("pnpm", ["exec", "openclaw", "gateway", "run", "--bind", "loopback", "--port", this.port, "--auth", "none", "--compact"], {
-      cwd: process.cwd(), env: process.env, stdio: ["ignore", "ignore", "ignore"],
+      cwd: process.cwd(), env: process.env, stdio: ["ignore", "ignore", "ignore"], detached: process.platform !== "win32",
     });
+    const child = this.process;
     const deadline = Date.now() + 30000;
     while (Date.now() < deadline) {
       signal?.throwIfAborted();
-      if (this.process.exitCode !== null) throw new Error("Runner-local OpenClaw gateway exited during startup");
-      const ok = await new Promise((resolve) => {
-        const probe = spawn("pnpm", ["exec", "openclaw", "gateway", "health", "--port", this.port, "--timeout", "2000"], { stdio: "ignore", env: process.env });
-        probe.once("exit", (code) => resolve(code === 0));
-      });
-      if (ok) return;
+      if (!isChildRunning(child)) throw new Error("Runner-local OpenClaw gateway exited during startup");
+      if (await this.isHealthy()) {
+        await delay(500, undefined, { signal });
+        if (!isChildRunning(child)) throw new Error("Runner-local OpenClaw gateway exited during startup");
+        if (await this.isHealthy()) return;
+      }
       await delay(1000, undefined, { signal });
     }
     throw new Error("Runner-local OpenClaw gateway did not become healthy within 30s");
+  }
+  async isHealthy() {
+    if (this.healthProbe) return this.healthProbe();
+    return new Promise((resolve) => {
+      const probe = spawn("pnpm", ["exec", "openclaw", "gateway", "health", "--port", this.port, "--timeout", "2000"], { stdio: "ignore", env: process.env });
+      let settled = false;
+      const finish = (value) => { if (!settled) { settled = true; resolve(value); } };
+      probe.once("error", () => finish(false));
+      probe.once("exit", (code) => finish(code === 0));
+    });
+  }
+  async waitUntilUnhealthy(timeoutMs) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (!await this.isHealthy()) return;
+      await delay(100);
+    }
+    throw new Error("Runner-local OpenClaw gateway remained healthy after process shutdown");
   }
   async stop() {
     if (this.stopPromise) return this.stopPromise;
@@ -197,29 +217,58 @@ export class Gateway {
   }
   async stopCurrentProcess() {
     const child = this.process;
-    if (!child || child.exitCode !== null) {
+    if (!child || !isProcessTreeRunning(child)) {
       if (this.process === child) this.process = undefined;
       return;
     }
-    child.kill("SIGTERM");
-    if (!await waitForExit(child, this.termTimeoutMs) && child.exitCode === null) {
-      child.kill("SIGKILL");
-      if (!await waitForExit(child, this.killTimeoutMs)) {
-        throw new Error("Runner-local OpenClaw gateway did not exit after SIGKILL");
+    signalProcessTree(child, "SIGTERM");
+    if (!await waitForProcessTreeExit(child, this.termTimeoutMs)) {
+      signalProcessTree(child, "SIGKILL");
+      if (!await waitForProcessTreeExit(child, this.killTimeoutMs)) {
+        throw new Error("Runner-local OpenClaw gateway process group did not exit after SIGKILL");
       }
     }
+    await this.waitUntilUnhealthy(this.killTimeoutMs);
     if (this.process === child) this.process = undefined;
   }
   async restart(signal) { await this.stop(); signal?.throwIfAborted(); await this.start(signal); }
 }
 
-function waitForExit(child, timeoutMs) {
-  if (child.exitCode !== null) return Promise.resolve(true);
-  return new Promise((resolve) => {
-    const onExit = () => { clearTimeout(timer); resolve(true); };
-    const timer = setTimeout(() => { child.removeListener("exit", onExit); resolve(false); }, timeoutMs);
-    child.once("exit", onExit);
-  });
+export function isChildRunning(child) {
+  return child.exitCode === null && child.signalCode === null;
+}
+
+function isProcessTreeRunning(child) {
+  if (process.platform === "win32" || !child.pid) return isChildRunning(child);
+  try {
+    process.kill(-child.pid, 0);
+    return true;
+  } catch (error) {
+    if (error?.code === "ESRCH") return false;
+    if (error?.code === "EPERM") return true;
+    throw error;
+  }
+}
+
+export function signalProcessTree(child, signal) {
+  if (!isProcessTreeRunning(child)) return false;
+  if (process.platform === "win32" || !child.pid) return child.kill(signal);
+  try {
+    process.kill(-child.pid, signal);
+    return true;
+  } catch (error) {
+    if (error?.code === "ESRCH") return false;
+    throw error;
+  }
+}
+
+export async function waitForProcessTreeExit(child, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isProcessTreeRunning(child)) return true;
+    await delay(25);
+  }
+  return !isProcessTreeRunning(child);
 }
 
 function command(value) { return `SMOKE_COMMAND\n${value}\nEND_SMOKE_COMMAND`; }

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -114,6 +114,17 @@ export function hasFinalPrivateTypingStop(events, botEmail, actorEmail) {
   return lifecycle.some((event) => event.op === "start") && lifecycle.at(-1)?.op === "stop";
 }
 
+export async function assertFinalPrivateTypingStop(queue, eventStart, botEmail, actorEmail, signal, settleMs = 500) {
+  await delay(settleMs, undefined, { signal });
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const batch = await queue.poll(signal);
+    if (!batch.some((event) => event.type !== "heartbeat")) break;
+  }
+  if (!hasFinalPrivateTypingStop(queue.events.slice(eventStart), botEmail, actorEmail)) {
+    throw new Error("Final direct typing state was not stopped after lifecycle completion");
+  }
+}
+
 function hasExactDirectParticipants(recipients, botEmail, actorEmail) {
   const emails = new Set(recipients.map((recipient) => recipient?.email ?? recipient).filter(Boolean));
   return emails.size === 2 && emails.has(botEmail) && emails.has(actorEmail);
@@ -513,10 +524,6 @@ async function main() {
       const inboundId = await sendDm(command(`lifecycle ${marker} ${childResult}`), signal);
       const reply = await queue.waitFor((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, marker), timeoutMs, "lifecycle reply", signal);
       messageIds.bot.add(String(reply.message.id));
-      await queue.waitFor((e) => {
-        if (queue.events.indexOf(e) < eventStart || !isPrivateTypingEvent(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, "stop")) return false;
-        return hasFinalPrivateTypingStop(queue.events.slice(eventStart), env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL);
-      }, timeoutMs, "ordered typing start/stop cleanup", signal);
       const deadline = Date.now() + timeoutMs;
       let summary;
       while (Date.now() < deadline) {
@@ -538,6 +545,7 @@ async function main() {
       if (childTranscriptCount !== 1) {
         throw new Error(`Found ${childTranscriptCount} completed child transcripts with the exact required result; expected one`);
       }
+      await assertFinalPrivateTypingStop(queue, eventStart, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, signal);
     });
 
     await scenario("explicit-reaction", async (signal) => {

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -77,6 +77,10 @@ export function isPrivateBotMessage(event, botEmail, actorEmail, marker) {
   return isPrivateBotEvent(event, botEmail, actorEmail) && isExactRenderedContent(event.message?.content, marker);
 }
 
+export function isDurableReplyEvent(event, botEmail, actorEmail, marker) {
+  return isPrivateBotEvent(event, botEmail, actorEmail) && String(event.message?.content ?? "").includes(marker);
+}
+
 export function isPrivateTypingEvent(event, botEmail, actorEmail, op) {
   if (event?.type !== "typing" || event.op !== op) return false;
   const senderEmail = event.sender?.email ?? event.sender_email;
@@ -134,7 +138,8 @@ export async function countCompletedChildTranscripts(stateDir, marker) {
       try { return [JSON.parse(line)]; } catch { return []; }
     });
     if (!records.some((record) => JSON.stringify(record).includes(marker))) continue;
-    if (records.some((record) => assistantTextValues(record).includes(marker))) matches += 1;
+    const results = records.flatMap(assistantMessageTexts);
+    if (results.at(-1) === marker) matches += 1;
   }
   return matches;
 }
@@ -196,17 +201,19 @@ function reactionKey(event) {
   return `${user}:${event.emoji_name ?? ""}:${event.emoji_code ?? ""}:${event.reaction_type ?? ""}`;
 }
 
-function assistantTextValues(value) {
+function assistantMessageTexts(value) {
   if (!value || typeof value !== "object") return [];
   if (value.role === "assistant") {
     if (typeof value.content === "string") return [value.content];
     if (!Array.isArray(value.content)) return [];
-    return value.content.flatMap((part) => {
+    if (value.content.some((part) => part?.type === "toolCall" || part?.type === "tool_use")) return [];
+    const text = value.content.flatMap((part) => {
       if (typeof part === "string") return [part];
       return part?.type === "text" && typeof part.text === "string" ? [part.text] : [];
-    });
+    }).join("");
+    return text ? [text] : [];
   }
-  return Object.values(value).flatMap(assistantTextValues);
+  return Object.values(value).flatMap(assistantMessageTexts);
 }
 
 function escapeHtml(value) {
@@ -562,8 +569,7 @@ async function main() {
       await writeGatewayGeneration(gatewayGenerationPath, oldGeneration);
       const inboundId = await sendDm(command(`durable ${marker}`), signal);
       await queue.waitFor((e) => e.type === "reaction" && e.op === "add" && String(e.message_id) === inboundId, timeoutMs, "durable accept signal", signal);
-      const oldReply = `${marker}:${oldGeneration}`;
-      const prematureReply = queue.events.find((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, oldReply));
+      const prematureReply = queue.events.find((e) => isDurableReplyEvent(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, marker));
       if (prematureReply) {
         messageIds.bot.add(String(prematureReply.message.id));
         throw new Error("Durable reply completed before interruption; replay was not exercised");
@@ -574,20 +580,21 @@ async function main() {
       await gateway.start(signal);
       const replacementReply = `${marker}:${replacementGeneration}`;
       const reply = await queue.waitFor((e) => {
-        if (isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, oldReply)) {
-          messageIds.bot.add(String(e.message.id));
-          throw new Error("Durable reply originated from the pre-restart gateway");
+        if (!isDurableReplyEvent(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, marker)) return false;
+        messageIds.bot.add(String(e.message.id));
+        if (!isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, replacementReply)) {
+          throw new Error("Durable reply did not contain the replacement gateway generation");
         }
-        return isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, replacementReply);
+        return true;
       }, timeoutMs, "durable replay reply", signal);
       messageIds.bot.add(String(reply.message.id));
       const settleDeadline = Date.now() + 10000;
       while (Date.now() < settleDeadline) { await queue.poll(signal); await delay(500, undefined, { signal }); }
-      const oldReplies = queue.events.filter((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, oldReply));
-      for (const event of oldReplies) messageIds.bot.add(String(event.message.id));
-      const replies = queue.events.filter((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, replacementReply));
-      if (oldReplies.length || replies.length !== 1) {
-        throw new Error(`Durable receive produced ${oldReplies.length} old-generation and ${replies.length} replacement replies; expected zero and one`);
+      const replies = queue.events.filter((e) => isDurableReplyEvent(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, marker));
+      for (const event of replies) messageIds.bot.add(String(event.message.id));
+      const validReplies = replies.filter((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, replacementReply));
+      if (replies.length !== 1 || validReplies.length !== 1) {
+        throw new Error(`Durable receive produced ${replies.length} attributable replies (${validReplies.length} valid); expected exactly one valid replacement reply`);
       }
     });
   } catch (error) {

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -1,0 +1,306 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { resolve } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { pathToFileURL } from "node:url";
+
+export const REQUIRED_ENV = [
+  "ZULIP_URL",
+  "ZULIP_SMOKE_USER_EMAIL",
+  "ZULIP_SMOKE_USER_API_KEY",
+  "ZULIP_SMOKE_BOT_EMAIL",
+  "ZULIP_SMOKE_BOT_API_KEY",
+  "ZULIP_SMOKE_STREAM",
+  "SMOKE_TESTED_SHA",
+];
+
+export function validateEnvironment(env) {
+  const missing = REQUIRED_ENV.filter((name) => !env[name]?.trim());
+  if (missing.length) throw new Error(`Missing required protected configuration: ${missing.join(", ")}`);
+  if (!/^[0-9a-f]{40}$/.test(env.SMOKE_TESTED_SHA)) throw new Error("SMOKE_TESTED_SHA must be a full commit SHA");
+  const url = new URL(env.ZULIP_URL);
+  if (url.protocol !== "https:") throw new Error("ZULIP_URL must use HTTPS");
+  return { ...env, ZULIP_URL: url.origin };
+}
+
+export function redactError(error) {
+  const text = error instanceof Error ? error.message : String(error);
+  return text
+    .replace(/https?:\/\/[^\s]+/gi, "[redacted-url]")
+    .replace(/\bBasic\s+\S+/gi, "Basic [redacted]")
+    .replace(/([?&](?:api_key|token)=)[^&\s]+/gi, "$1[redacted]")
+    .slice(0, 500);
+}
+
+export function isBotMessage(event, botEmail, marker) {
+  return event?.type === "message" && event.message?.sender_email === botEmail &&
+    String(event.message?.content ?? "").includes(marker);
+}
+
+export function lifecycleSummary(events, inboundMessageId) {
+  const relevant = events.filter((event) =>
+    event?.type === "reaction" && String(event.message_id) === String(inboundMessageId),
+  );
+  const added = relevant.filter((event) => event.op === "add");
+  const removedKeys = new Set(relevant.filter((event) => event.op === "remove").map(reactionKey));
+  return {
+    added,
+    allRemoved: added.length > 0 && added.every((event) => removedKeys.has(reactionKey(event))),
+    sawSubagent: added.some((event) => event.emoji_name === "robot" || event.emoji_code === "1f916"),
+  };
+}
+
+function reactionKey(event) {
+  return `${event.emoji_name ?? ""}:${event.emoji_code ?? ""}:${event.reaction_type ?? ""}`;
+}
+
+class ZulipClient {
+  constructor(baseUrl, email, apiKey) {
+    this.baseUrl = baseUrl;
+    this.authorization = `Basic ${Buffer.from(`${email}:${apiKey}`).toString("base64")}`;
+  }
+
+  async request(path, { method = "GET", params, body } = {}) {
+    const url = new URL(`/api/v1/${path}`, this.baseUrl);
+    if (params) for (const [key, value] of Object.entries(params)) url.searchParams.set(key, String(value));
+    const response = await fetch(url, {
+      method,
+      headers: { Authorization: this.authorization },
+      body: body ? new URLSearchParams(Object.entries(body).map(([key, value]) => [key, String(value)])) : undefined,
+      signal: AbortSignal.timeout(30000),
+    });
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok || payload.result === "error") throw new Error(`Zulip API ${path} failed (${response.status}): ${payload.code ?? "unknown"}`);
+    return payload;
+  }
+
+  async upload(filename, contents) {
+    const form = new FormData();
+    form.set("file", new Blob([contents], { type: "text/plain" }), filename);
+    const response = await fetch(new URL("/api/v1/user_uploads", this.baseUrl), {
+      method: "POST", headers: { Authorization: this.authorization }, body: form,
+      signal: AbortSignal.timeout(30000),
+    });
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok || !payload.uri) throw new Error(`Zulip upload failed (${response.status})`);
+    return payload.uri;
+  }
+
+  async download(uri) {
+    const url = new URL(uri, this.baseUrl);
+    if (url.origin !== new URL(this.baseUrl).origin) throw new Error("Refusing cross-origin smoke upload");
+    const response = await fetch(url, { headers: { Authorization: this.authorization }, signal: AbortSignal.timeout(30000) });
+    if (!response.ok) throw new Error(`Zulip download failed (${response.status})`);
+    return response.text();
+  }
+}
+
+class EventQueue {
+  constructor(client) { this.client = client; this.events = []; this.lastEventId = -1; }
+  async open() {
+    const result = await this.client.request("register", { method: "POST", body: {
+      event_types: JSON.stringify(["message", "typing", "reaction", "update_message", "delete_message"]),
+      all_public_streams: "true",
+    }});
+    this.queueId = result.queue_id;
+    this.lastEventId = result.last_event_id;
+  }
+  async poll() {
+    const result = await this.client.request("events", { params: {
+      queue_id: this.queueId, last_event_id: this.lastEventId, dont_block: "true",
+    }});
+    for (const event of result.events ?? []) {
+      this.lastEventId = Math.max(this.lastEventId, event.id ?? this.lastEventId);
+      if (event.type !== "heartbeat") this.events.push(event);
+    }
+    return result.events ?? [];
+  }
+  async waitFor(predicate, timeoutMs, label) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const existing = this.events.find(predicate);
+      if (existing) return existing;
+      await this.poll();
+      await delay(500);
+    }
+    throw new Error(`${label} timed out after ${timeoutMs}ms`);
+  }
+  async close() {
+    if (this.queueId) await this.client.request("events", { method: "DELETE", params: { queue_id: this.queueId } }).catch(() => {});
+  }
+}
+
+class Gateway {
+  constructor(port) { this.port = String(port); }
+  async start() {
+    this.process = spawn("pnpm", ["exec", "openclaw", "gateway", "run", "--bind", "loopback", "--port", this.port, "--auth", "none", "--compact"], {
+      cwd: process.cwd(), env: process.env, stdio: ["ignore", "ignore", "ignore"],
+    });
+    const deadline = Date.now() + 30000;
+    while (Date.now() < deadline) {
+      if (this.process.exitCode !== null) throw new Error("Runner-local OpenClaw gateway exited during startup");
+      const ok = await new Promise((resolve) => {
+        const probe = spawn("pnpm", ["exec", "openclaw", "gateway", "health", "--port", this.port, "--timeout", "2000"], { stdio: "ignore", env: process.env });
+        probe.once("exit", (code) => resolve(code === 0));
+      });
+      if (ok) return;
+      await delay(1000);
+    }
+    throw new Error("Runner-local OpenClaw gateway did not become healthy within 30s");
+  }
+  async stop() {
+    if (!this.process || this.process.exitCode !== null) return;
+    this.process.kill("SIGTERM");
+    await new Promise((resolve) => {
+      const timer = setTimeout(resolve, 10000);
+      this.process.once("exit", () => { clearTimeout(timer); resolve(); });
+    });
+    if (this.process.exitCode === null) this.process.kill("SIGKILL");
+  }
+  async restart() { await this.stop(); await this.start(); }
+}
+
+function command(value) { return `SMOKE_COMMAND\n${value}\nEND_SMOKE_COMMAND`; }
+
+async function main() {
+  const env = validateEnvironment(process.env);
+  const timeoutMs = Number(env.SMOKE_SCENARIO_TIMEOUT_MS || 120000);
+  if (!Number.isFinite(timeoutMs) || timeoutMs < 10000 || timeoutMs > 300000) throw new Error("Invalid SMOKE_SCENARIO_TIMEOUT_MS");
+  const runId = `smoke-${env.SMOKE_TESTED_SHA.slice(0, 8)}-${randomBytes(5).toString("hex")}`;
+  const actor = new ZulipClient(env.ZULIP_URL, env.ZULIP_SMOKE_USER_EMAIL, env.ZULIP_SMOKE_USER_API_KEY);
+  const bot = new ZulipClient(env.ZULIP_URL, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_BOT_API_KEY);
+  const queue = new EventQueue(actor);
+  const gateway = new Gateway(env.SMOKE_GATEWAY_PORT || 18789);
+  const messageIds = { actor: new Set(), bot: new Set() };
+  const report = [];
+  const sendDm = async (content) => {
+    const result = await actor.request("messages", { method: "POST", body: { type: "private", to: JSON.stringify([env.ZULIP_SMOKE_BOT_EMAIL]), content } });
+    messageIds.actor.add(String(result.id)); return String(result.id);
+  };
+  const scenario = async (name, run) => {
+    const started = Date.now();
+    let timeout;
+    try {
+      await Promise.race([
+        run(),
+        new Promise((_, reject) => { timeout = setTimeout(() => reject(new Error(`${name} exceeded its scenario timeout`)), timeoutMs); }),
+      ]);
+      report.push({ name, ok: true, ms: Date.now() - started });
+    }
+    catch (error) { report.push({ name, ok: false, ms: Date.now() - started, error: redactError(error) }); throw error; }
+    finally { clearTimeout(timeout); }
+  };
+  try {
+    await queue.open();
+    await gateway.start();
+
+    await scenario("dm-round-trip", async () => {
+      const marker = `${runId}:dm-ok`; await sendDm(command(`echo ${marker}`));
+      const event = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, marker), timeoutMs, "DM reply");
+      messageIds.bot.add(String(event.message.id));
+    });
+
+    await scenario("stream-topic-reply", async () => {
+      const marker = `${runId}:stream-ok`; const topic = `${runId}-topic`;
+      const sent = await actor.request("messages", { method: "POST", body: { type: "stream", to: env.ZULIP_SMOKE_STREAM, topic, content: command(`echo ${marker}`) } });
+      messageIds.actor.add(String(sent.id));
+      const event = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, marker) && e.message?.display_recipient === env.ZULIP_SMOKE_STREAM && e.message?.subject === topic, timeoutMs, "stream/topic reply");
+      messageIds.bot.add(String(event.message.id));
+    });
+
+    await scenario("typing-and-lifecycle-reactions", async () => {
+      const marker = `${runId}:lifecycle-ok`; const eventStart = queue.events.length;
+      const inboundId = await sendDm(command(`lifecycle ${marker}`));
+      const reply = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, marker), timeoutMs, "lifecycle reply");
+      messageIds.bot.add(String(reply.message.id));
+      await queue.waitFor((e) => queue.events.indexOf(e) >= eventStart && e.type === "typing" && e.op === "stop", timeoutMs, "typing stop cleanup");
+      const deadline = Date.now() + timeoutMs;
+      let summary;
+      while (Date.now() < deadline) {
+        summary = lifecycleSummary(queue.events, inboundId);
+        if (summary.allRemoved && summary.sawSubagent) break;
+        await queue.poll();
+        await delay(500);
+      }
+      if (!summary?.added.length) throw new Error("No lifecycle reaction was observed on the inbound message");
+      if (!summary.sawSubagent) throw new Error("No truthful subagent lifecycle reaction was observed");
+      if (!summary.allRemoved) throw new Error("Lifecycle reactions were not cleaned up after completion");
+      const startedTyping = queue.events.slice(eventStart).some((e) => e.type === "typing" && e.op === "start");
+      if (!startedTyping) throw new Error("Typing start was not observed");
+    });
+
+    await scenario("explicit-reaction", async () => {
+      const inboundId = await sendDm(command("react 🎉"));
+      await queue.waitFor((e) => e.type === "reaction" && e.op === "add" && String(e.message_id) === inboundId && (e.emoji_name === "tada" || e.emoji_code === "1f389"), timeoutMs, "explicit reaction");
+      const reply = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, "reacted"), timeoutMs, "reaction acknowledgement");
+      messageIds.bot.add(String(reply.message.id));
+    });
+
+    await scenario("edit-delete", async () => {
+      const before = `${runId}:before-edit`; const after = `${runId}:after-edit`;
+      await sendDm(command(`edit-delete ${before} ${after}`));
+      const created = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, before), timeoutMs, "message before edit");
+      const id = String(created.message.id); messageIds.bot.add(id);
+      await queue.waitFor((e) => e.type === "update_message" && String(e.message_id) === id && String(e.content ?? "").includes(after), timeoutMs, "message edit");
+      await queue.waitFor((e) => e.type === "delete_message" && (e.message_ids ?? [e.message_id]).map(String).includes(id), timeoutMs, "message delete");
+      messageIds.bot.delete(id);
+    });
+
+    await scenario("upload-download", async () => {
+      const inboundMarker = `${runId}:inbound-upload`; const uri = await actor.upload(`${runId}.txt`, inboundMarker);
+      await sendDm(`${command(`read-upload ${inboundMarker}`)}\n[attachment](${uri})`);
+      const inboundReply = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, inboundMarker), timeoutMs, "inbound upload read");
+      messageIds.bot.add(String(inboundReply.message.id));
+      const outboundMarker = `${runId}:outbound-upload`; await sendDm(command(`send-upload ${outboundMarker}`));
+      const outbound = await queue.waitFor((e) => e.type === "message" && e.message?.sender_email === env.ZULIP_SMOKE_BOT_EMAIL && /user_uploads\//.test(String(e.message?.content ?? "")), timeoutMs, "outbound upload");
+      messageIds.bot.add(String(outbound.message.id));
+      const match = String(outbound.message.content).match(/(?:href=")?([^"' ]*\/user_uploads\/[^"'< ]+)/);
+      if (!match || (await actor.download(match[1])).trim() !== outboundMarker) throw new Error("Downloaded outbound upload did not match its marker");
+    });
+
+    await scenario("poll-and-interactive-reply", async () => {
+      const question = `${runId}:poll`; const optionA = `smoke-choice:${runId}:interactive-ok`; const optionB = `${runId}:beta`;
+      await sendDm(command(`poll ${question} ${optionA} ${optionB}`));
+      const poll = await queue.waitFor((e) => {
+        if (e.type !== "message" || e.message?.sender_email !== env.ZULIP_SMOKE_BOT_EMAIL) return false;
+        const raw = e.message?.widget_content;
+        let widget = raw;
+        if (typeof raw === "string") { try { widget = JSON.parse(raw); } catch { return false; } }
+        return widget?.extra_data?.poll === true && widget?.extra_data?.heading === question;
+      }, timeoutMs, "native poll");
+      messageIds.bot.add(String(poll.message.id));
+      await sendDm(optionA);
+      const reply = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, `${runId}:interactive-ok`), timeoutMs, "interactive reply");
+      messageIds.bot.add(String(reply.message.id));
+    });
+
+    await scenario("durable-receive-completion-deduplication", async () => {
+      const marker = `${runId}:durable-ok`; const inboundId = await sendDm(command(`durable ${marker}`));
+      await queue.waitFor((e) => e.type === "reaction" && e.op === "add" && String(e.message_id) === inboundId, timeoutMs, "durable accept signal");
+      if (queue.events.some((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, marker))) {
+        throw new Error("Durable reply completed before interruption; replay was not exercised");
+      }
+      await gateway.restart();
+      const reply = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, marker), timeoutMs, "durable replay reply");
+      messageIds.bot.add(String(reply.message.id));
+      const settleDeadline = Date.now() + 10000;
+      while (Date.now() < settleDeadline) { await queue.poll(); await delay(500); }
+      const replies = queue.events.filter((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, marker));
+      if (replies.length !== 1) throw new Error(`Durable receive produced ${replies.length} visible replies; expected exactly one`);
+    });
+  } finally {
+    await gateway.stop().catch(() => {});
+    for (const id of messageIds.bot) await bot.request(`messages/${id}`, { method: "DELETE" }).catch(() => {});
+    for (const id of messageIds.actor) await actor.request(`messages/${id}`, { method: "DELETE" }).catch(() => {});
+    await queue.close().catch(() => {});
+    for (const item of report) console.log(`${item.ok ? "PASS" : "FAIL"} ${item.name} (${item.ms}ms)${item.error ? `: ${item.error}` : ""}`);
+    console.log(`Evidence: tested commit ${env.SMOKE_TESTED_SHA}; run identifier ${runId}`);
+    console.log("Cleanup: messages deleted where permissions permit; Zulip exposes no public API for deleting uploaded files.");
+  }
+}
+
+if (import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  main().catch((error) => { console.error(`Live smoke failed: ${redactError(error)}`); process.exitCode = 1; });
+}

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -114,12 +114,20 @@ export function hasFinalPrivateTypingStop(events, botEmail, actorEmail) {
   return lifecycle.some((event) => event.op === "start") && lifecycle.at(-1)?.op === "stop";
 }
 
-export async function assertFinalPrivateTypingStop(queue, eventStart, botEmail, actorEmail, signal, settleMs = 500) {
-  await delay(settleMs, undefined, { signal });
-  for (let attempt = 0; attempt < 5; attempt += 1) {
+export async function drainEventQueueUntilQuiet(queue, signal, quietMs = 500, maxMs = 5000, pollIntervalMs = 100) {
+  const deadline = Date.now() + maxMs;
+  let quietSince = Date.now();
+  while (Date.now() < deadline) {
     const batch = await queue.poll(signal);
-    if (!batch.some((event) => event.type !== "heartbeat")) break;
+    if (batch.some((event) => event.type !== "heartbeat")) quietSince = Date.now();
+    if (Date.now() - quietSince >= quietMs) return;
+    await delay(pollIntervalMs, undefined, { signal });
   }
+  throw new Error("Event queue did not reach a stable quiet window");
+}
+
+export async function assertFinalPrivateTypingStop(queue, eventStart, botEmail, actorEmail, signal, quietMs = 500, maxMs = 5000, pollIntervalMs = 100) {
+  await drainEventQueueUntilQuiet(queue, signal, quietMs, maxMs, pollIntervalMs);
   if (!hasFinalPrivateTypingStop(queue.events.slice(eventStart), botEmail, actorEmail)) {
     throw new Error("Final direct typing state was not stopped after lifecycle completion");
   }

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -2,6 +2,7 @@
 
 import { spawn } from "node:child_process";
 import { randomBytes } from "node:crypto";
+import { chmod, readdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { pathToFileURL } from "node:url";
@@ -14,6 +15,7 @@ export const REQUIRED_ENV = [
   "ZULIP_SMOKE_BOT_API_KEY",
   "ZULIP_SMOKE_STREAM",
   "SMOKE_TESTED_SHA",
+  "OPENCLAW_STATE_DIR",
 ];
 
 export function validateEnvironment(env) {
@@ -98,6 +100,50 @@ export function isExactUtf8(bytes, expected) {
   return bytes.length === expectedBytes.length && bytes.every((value, index) => value === expectedBytes[index]);
 }
 
+export async function assertMessageRemainsExact(client, id, expected, minimumMs, signal) {
+  const assertCurrent = async () => {
+    const result = await client.request(`messages/${id}`, { signal });
+    if (!isExactRenderedContent(result.message?.content, expected)) {
+      throw new Error("Edited message was not readable with its exact content");
+    }
+  };
+  await assertCurrent();
+  await delay(minimumMs, undefined, { signal });
+  await assertCurrent();
+}
+
+export async function countCompletedChildTranscripts(stateDir, marker) {
+  const files = [];
+  const visit = async (directory) => {
+    let entries;
+    try { entries = await readdir(directory, { withFileTypes: true }); }
+    catch (error) {
+      if (error?.code === "ENOENT") return;
+      throw error;
+    }
+    for (const entry of entries) {
+      const path = resolve(directory, entry.name);
+      if (entry.isDirectory()) await visit(path);
+      else if (entry.isFile() && entry.name.endsWith(".jsonl")) files.push(path);
+    }
+  };
+  await visit(resolve(stateDir, "agents"));
+  let matches = 0;
+  for (const file of files) {
+    const records = (await readFile(file, "utf8")).split("\n").filter(Boolean).flatMap((line) => {
+      try { return [JSON.parse(line)]; } catch { return []; }
+    });
+    if (!records.some((record) => JSON.stringify(record).includes(marker))) continue;
+    if (records.some((record) => assistantTextValues(record).includes(marker))) matches += 1;
+  }
+  return matches;
+}
+
+export async function writeGatewayGeneration(path, generation) {
+  await writeFile(path, generation, { mode: 0o600 });
+  await chmod(path, 0o600);
+}
+
 export async function countMessageDeletionFailures(client, ids) {
   let failures = 0;
   for (const id of ids) {
@@ -129,6 +175,7 @@ export function lifecycleSummary(events, inboundMessageId) {
     added,
     allRemoved: added.length > 0 && active.size === 0,
     sawSubagent: added.some((event) => event.emoji_name === "robot" || event.emoji_code === "1f916"),
+    subagentCount: added.filter((event) => event.emoji_name === "robot" || event.emoji_code === "1f916").length,
   };
 }
 
@@ -147,6 +194,19 @@ export function normalizeScenarioError(signal, error) {
 function reactionKey(event) {
   const user = event.user_id ?? event.user?.user_id ?? event.user?.email ?? event.user?.full_name ?? "";
   return `${user}:${event.emoji_name ?? ""}:${event.emoji_code ?? ""}:${event.reaction_type ?? ""}`;
+}
+
+function assistantTextValues(value) {
+  if (!value || typeof value !== "object") return [];
+  if (value.role === "assistant") {
+    if (typeof value.content === "string") return [value.content];
+    if (!Array.isArray(value.content)) return [];
+    return value.content.flatMap((part) => {
+      if (typeof part === "string") return [part];
+      return part?.type === "text" && typeof part.text === "string" ? [part.text] : [];
+    });
+  }
+  return Object.values(value).flatMap(assistantTextValues);
 }
 
 function escapeHtml(value) {
@@ -367,6 +427,7 @@ async function main() {
   const bot = new ZulipClient(env.ZULIP_URL, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_BOT_API_KEY);
   const queue = new EventQueue(actor);
   const gateway = new Gateway(env.SMOKE_GATEWAY_PORT || 18789);
+  const gatewayGenerationPath = resolve("scripts/live-smoke/agent-workspace/.smoke-gateway-generation");
   const messageIds = { actor: new Set(), bot: new Set() };
   const report = [];
   let runError;
@@ -415,8 +476,8 @@ async function main() {
     });
 
     await scenario("typing-and-lifecycle-reactions", async (signal) => {
-      const marker = `${runId}:lifecycle-ok`; const eventStart = queue.events.length;
-      const inboundId = await sendDm(command(`lifecycle ${marker}`), signal);
+      const marker = `${runId}:lifecycle-ok`; const childResult = `${runId}:child-ok`; const eventStart = queue.events.length;
+      const inboundId = await sendDm(command(`lifecycle ${marker} ${childResult}`), signal);
       const reply = await queue.waitFor((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, marker), timeoutMs, "lifecycle reply", signal);
       messageIds.bot.add(String(reply.message.id));
       await queue.waitFor((e) => {
@@ -435,7 +496,17 @@ async function main() {
       }
       if (!summary?.added.length) throw new Error("No lifecycle reaction was observed on the inbound message");
       if (!summary.sawSubagent) throw new Error("No truthful subagent lifecycle reaction was observed");
+      if (summary.subagentCount !== 1) throw new Error(`Observed ${summary.subagentCount} subagent lifecycle reactions; expected exactly one`);
       if (!summary.allRemoved) throw new Error("Lifecycle reactions were not cleaned up after completion");
+      const transcriptDeadline = Date.now() + timeoutMs;
+      let childTranscriptCount = 0;
+      while (Date.now() < transcriptDeadline && (childTranscriptCount = await countCompletedChildTranscripts(env.OPENCLAW_STATE_DIR, childResult)) === 0) {
+        await delay(250, undefined, { signal });
+      }
+      childTranscriptCount = await countCompletedChildTranscripts(env.OPENCLAW_STATE_DIR, childResult);
+      if (childTranscriptCount !== 1) {
+        throw new Error(`Found ${childTranscriptCount} completed child transcripts with the exact required result; expected one`);
+      }
     });
 
     await scenario("explicit-reaction", async (signal) => {
@@ -452,6 +523,7 @@ async function main() {
       const created = await queue.waitFor((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, before), timeoutMs, "message before edit", signal);
       const id = String(created.message.id); messageIds.bot.add(id);
       await queue.waitFor((e) => e.type === "update_message" && String(e.message_id) === id && isExactRenderedContent(e.content, after), timeoutMs, "message edit", signal);
+      await assertMessageRemainsExact(actor, id, after, 2000, signal);
       await queue.waitFor((e) => e.type === "delete_message" && (e.message_ids ?? [e.message_id]).map(String).includes(id), timeoutMs, "message delete", signal);
       messageIds.bot.delete(id);
     });
@@ -485,23 +557,44 @@ async function main() {
     });
 
     await scenario("durable-receive-completion-deduplication", async (signal) => {
-      const marker = `${runId}:durable-ok`; const inboundId = await sendDm(command(`durable ${marker}`), signal);
+      const marker = `${runId}:durable-ok`;
+      const oldGeneration = randomBytes(16).toString("hex");
+      await writeGatewayGeneration(gatewayGenerationPath, oldGeneration);
+      const inboundId = await sendDm(command(`durable ${marker}`), signal);
       await queue.waitFor((e) => e.type === "reaction" && e.op === "add" && String(e.message_id) === inboundId, timeoutMs, "durable accept signal", signal);
-      if (queue.events.some((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, marker))) {
+      const oldReply = `${marker}:${oldGeneration}`;
+      const prematureReply = queue.events.find((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, oldReply));
+      if (prematureReply) {
+        messageIds.bot.add(String(prematureReply.message.id));
         throw new Error("Durable reply completed before interruption; replay was not exercised");
       }
-      await gateway.restart(signal);
-      const reply = await queue.waitFor((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, marker), timeoutMs, "durable replay reply", signal);
+      await gateway.stop();
+      const replacementGeneration = randomBytes(16).toString("hex");
+      await writeGatewayGeneration(gatewayGenerationPath, replacementGeneration);
+      await gateway.start(signal);
+      const replacementReply = `${marker}:${replacementGeneration}`;
+      const reply = await queue.waitFor((e) => {
+        if (isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, oldReply)) {
+          messageIds.bot.add(String(e.message.id));
+          throw new Error("Durable reply originated from the pre-restart gateway");
+        }
+        return isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, replacementReply);
+      }, timeoutMs, "durable replay reply", signal);
       messageIds.bot.add(String(reply.message.id));
       const settleDeadline = Date.now() + 10000;
       while (Date.now() < settleDeadline) { await queue.poll(signal); await delay(500, undefined, { signal }); }
-      const replies = queue.events.filter((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, marker));
-      if (replies.length !== 1) throw new Error(`Durable receive produced ${replies.length} visible replies; expected exactly one`);
+      const oldReplies = queue.events.filter((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, oldReply));
+      for (const event of oldReplies) messageIds.bot.add(String(event.message.id));
+      const replies = queue.events.filter((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, replacementReply));
+      if (oldReplies.length || replies.length !== 1) {
+        throw new Error(`Durable receive produced ${oldReplies.length} old-generation and ${replies.length} replacement replies; expected zero and one`);
+      }
     });
   } catch (error) {
     runError = error;
   } finally {
     await gateway.stop().catch(() => {});
+    await unlink(gatewayGenerationPath).catch(() => {});
     const cleanupFailures =
       await countMessageDeletionFailures(bot, messageIds.bot) +
       await countMessageDeletionFailures(actor, messageIds.actor);

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -81,6 +81,14 @@ export function isDurableReplyEvent(event, botEmail, actorEmail, marker) {
   return isPrivateBotEvent(event, botEmail, actorEmail) && String(event.message?.content ?? "").includes(marker);
 }
 
+export function captureMessageIds(events, predicate, target) {
+  const matches = events.filter(predicate);
+  for (const event of matches) {
+    if (event.message?.id !== undefined) target.add(String(event.message.id));
+  }
+  return matches;
+}
+
 export function isPrivateTypingEvent(event, botEmail, actorEmail, op) {
   if (event?.type !== "typing" || event.op !== op) return false;
   const senderEmail = event.sender?.email ?? event.sender_email;
@@ -565,36 +573,40 @@ async function main() {
 
     await scenario("durable-receive-completion-deduplication", async (signal) => {
       const marker = `${runId}:durable-ok`;
-      const oldGeneration = randomBytes(16).toString("hex");
-      await writeGatewayGeneration(gatewayGenerationPath, oldGeneration);
-      const inboundId = await sendDm(command(`durable ${marker}`), signal);
-      await queue.waitFor((e) => e.type === "reaction" && e.op === "add" && String(e.message_id) === inboundId, timeoutMs, "durable accept signal", signal);
-      const prematureReply = queue.events.find((e) => isDurableReplyEvent(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, marker));
-      if (prematureReply) {
-        messageIds.bot.add(String(prematureReply.message.id));
-        throw new Error("Durable reply completed before interruption; replay was not exercised");
-      }
-      await gateway.stop();
-      const replacementGeneration = randomBytes(16).toString("hex");
-      await writeGatewayGeneration(gatewayGenerationPath, replacementGeneration);
-      await gateway.start(signal);
-      const replacementReply = `${marker}:${replacementGeneration}`;
-      const reply = await queue.waitFor((e) => {
-        if (!isDurableReplyEvent(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, marker)) return false;
-        messageIds.bot.add(String(e.message.id));
-        if (!isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, replacementReply)) {
-          throw new Error("Durable reply did not contain the replacement gateway generation");
+      const isAttributable = (event) =>
+        isDurableReplyEvent(event, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, marker);
+      const captureReplies = () => captureMessageIds(queue.events, isAttributable, messageIds.bot);
+      try {
+        const oldGeneration = randomBytes(16).toString("hex");
+        await writeGatewayGeneration(gatewayGenerationPath, oldGeneration);
+        const inboundId = await sendDm(command(`durable ${marker}`), signal);
+        await queue.waitFor((e) => e.type === "reaction" && e.op === "add" && String(e.message_id) === inboundId, timeoutMs, "durable accept signal", signal);
+        if (captureReplies().length) {
+          throw new Error("Durable reply completed before interruption; replay was not exercised");
         }
-        return true;
-      }, timeoutMs, "durable replay reply", signal);
-      messageIds.bot.add(String(reply.message.id));
-      const settleDeadline = Date.now() + 10000;
-      while (Date.now() < settleDeadline) { await queue.poll(signal); await delay(500, undefined, { signal }); }
-      const replies = queue.events.filter((e) => isDurableReplyEvent(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, marker));
-      for (const event of replies) messageIds.bot.add(String(event.message.id));
-      const validReplies = replies.filter((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, replacementReply));
-      if (replies.length !== 1 || validReplies.length !== 1) {
-        throw new Error(`Durable receive produced ${replies.length} attributable replies (${validReplies.length} valid); expected exactly one valid replacement reply`);
+        await gateway.stop();
+        const replacementGeneration = randomBytes(16).toString("hex");
+        await writeGatewayGeneration(gatewayGenerationPath, replacementGeneration);
+        await gateway.start(signal);
+        const replacementReply = `${marker}:${replacementGeneration}`;
+        const reply = await queue.waitFor((e) => {
+          if (!isAttributable(e)) return false;
+          captureReplies();
+          if (!isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, replacementReply)) {
+            throw new Error("Durable reply did not contain the replacement gateway generation");
+          }
+          return true;
+        }, timeoutMs, "durable replay reply", signal);
+        messageIds.bot.add(String(reply.message.id));
+        const settleDeadline = Date.now() + 10000;
+        while (Date.now() < settleDeadline) { await queue.poll(signal); await delay(500, undefined, { signal }); }
+        const replies = captureReplies();
+        const validReplies = replies.filter((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, replacementReply));
+        if (replies.length !== 1 || validReplies.length !== 1) {
+          throw new Error(`Durable receive produced ${replies.length} attributable replies (${validReplies.length} valid); expected exactly one valid replacement reply`);
+        }
+      } finally {
+        captureReplies();
       }
     });
   } catch (error) {

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -52,6 +52,10 @@ export function lifecycleSummary(events, inboundMessageId) {
   };
 }
 
+export function normalizeScenarioError(signal, error) {
+  return signal.aborted && signal.reason instanceof Error ? signal.reason : error;
+}
+
 function reactionKey(event) {
   return `${event.emoji_name ?? ""}:${event.emoji_code ?? ""}:${event.reaction_type ?? ""}`;
 }
@@ -62,43 +66,44 @@ class ZulipClient {
     this.authorization = `Basic ${Buffer.from(`${email}:${apiKey}`).toString("base64")}`;
   }
 
-  async request(path, { method = "GET", params, body } = {}) {
+  async request(path, { method = "GET", params, body, signal } = {}) {
     const url = new URL(`/api/v1/${path}`, this.baseUrl);
     if (params) for (const [key, value] of Object.entries(params)) url.searchParams.set(key, String(value));
     const response = await fetch(url, {
       method,
       headers: { Authorization: this.authorization },
       body: body ? new URLSearchParams(Object.entries(body).map(([key, value]) => [key, String(value)])) : undefined,
-      signal: AbortSignal.timeout(30000),
+      signal: signal ? AbortSignal.any([signal, AbortSignal.timeout(30000)]) : AbortSignal.timeout(30000),
     });
     const payload = await response.json().catch(() => ({}));
     if (!response.ok || payload.result === "error") throw new Error(`Zulip API ${path} failed (${response.status}): ${payload.code ?? "unknown"}`);
     return payload;
   }
 
-  async upload(filename, contents) {
+  async upload(filename, contents, signal) {
     const form = new FormData();
     form.set("file", new Blob([contents], { type: "text/plain" }), filename);
     const response = await fetch(new URL("/api/v1/user_uploads", this.baseUrl), {
       method: "POST", headers: { Authorization: this.authorization }, body: form,
-      signal: AbortSignal.timeout(30000),
+      signal: signal ? AbortSignal.any([signal, AbortSignal.timeout(30000)]) : AbortSignal.timeout(30000),
     });
     const payload = await response.json().catch(() => ({}));
     if (!response.ok || !payload.uri) throw new Error(`Zulip upload failed (${response.status})`);
     return payload.uri;
   }
 
-  async download(uri) {
+  async download(uri, signal) {
     const url = new URL(uri, this.baseUrl);
     if (url.origin !== new URL(this.baseUrl).origin) throw new Error("Refusing cross-origin smoke upload");
-    const response = await fetch(url, { headers: { Authorization: this.authorization }, signal: AbortSignal.timeout(30000) });
+    const requestSignal = signal ? AbortSignal.any([signal, AbortSignal.timeout(30000)]) : AbortSignal.timeout(30000);
+    const response = await fetch(url, { headers: { Authorization: this.authorization }, signal: requestSignal });
     if (!response.ok) throw new Error(`Zulip download failed (${response.status})`);
     return response.text();
   }
 }
 
-class EventQueue {
-  constructor(client) { this.client = client; this.events = []; this.lastEventId = -1; }
+export class EventQueue {
+  constructor(client) { this.client = client; this.events = []; this.lastEventId = -1; this.pollPromise = undefined; }
   async open() {
     const result = await this.client.request("register", { method: "POST", body: {
       event_types: JSON.stringify(["message", "typing", "reaction", "update_message", "delete_message"]),
@@ -107,23 +112,27 @@ class EventQueue {
     this.queueId = result.queue_id;
     this.lastEventId = result.last_event_id;
   }
-  async poll() {
-    const result = await this.client.request("events", { params: {
+  async poll(signal) {
+    if (this.pollPromise) return this.pollPromise;
+    this.pollPromise = this.client.request("events", { params: {
       queue_id: this.queueId, last_event_id: this.lastEventId, dont_block: "true",
-    }});
-    for (const event of result.events ?? []) {
-      this.lastEventId = Math.max(this.lastEventId, event.id ?? this.lastEventId);
-      if (event.type !== "heartbeat") this.events.push(event);
-    }
-    return result.events ?? [];
+    }, signal }).then((result) => {
+      for (const event of result.events ?? []) {
+        this.lastEventId = Math.max(this.lastEventId, event.id ?? this.lastEventId);
+        if (event.type !== "heartbeat") this.events.push(event);
+      }
+      return result.events ?? [];
+    }).finally(() => { this.pollPromise = undefined; });
+    return this.pollPromise;
   }
-  async waitFor(predicate, timeoutMs, label) {
+  async waitFor(predicate, timeoutMs, label, signal) {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
+      signal?.throwIfAborted();
       const existing = this.events.find(predicate);
       if (existing) return existing;
-      await this.poll();
-      await delay(500);
+      await this.poll(signal);
+      await delay(500, undefined, { signal });
     }
     throw new Error(`${label} timed out after ${timeoutMs}ms`);
   }
@@ -175,54 +184,63 @@ async function main() {
   const gateway = new Gateway(env.SMOKE_GATEWAY_PORT || 18789);
   const messageIds = { actor: new Set(), bot: new Set() };
   const report = [];
-  const sendDm = async (content) => {
-    const result = await actor.request("messages", { method: "POST", body: { type: "private", to: JSON.stringify([env.ZULIP_SMOKE_BOT_EMAIL]), content } });
+  const sendDm = async (content, signal) => {
+    const result = await actor.request("messages", { method: "POST", body: { type: "private", to: JSON.stringify([env.ZULIP_SMOKE_BOT_EMAIL]), content }, signal });
     messageIds.actor.add(String(result.id)); return String(result.id);
   };
   const scenario = async (name, run) => {
     const started = Date.now();
+    const controller = new AbortController();
     let timeout;
     try {
       await Promise.race([
-        run(),
-        new Promise((_, reject) => { timeout = setTimeout(() => reject(new Error(`${name} exceeded its scenario timeout`)), timeoutMs); }),
+        run(controller.signal),
+        new Promise((_, reject) => { timeout = setTimeout(() => {
+          const error = new Error(`${name} exceeded its scenario timeout`);
+          controller.abort(error);
+          reject(error);
+        }, timeoutMs); }),
       ]);
       report.push({ name, ok: true, ms: Date.now() - started });
     }
-    catch (error) { report.push({ name, ok: false, ms: Date.now() - started, error: redactError(error) }); throw error; }
-    finally { clearTimeout(timeout); }
+    catch (error) {
+      const failure = normalizeScenarioError(controller.signal, error);
+      report.push({ name, ok: false, ms: Date.now() - started, error: redactError(failure) });
+      throw failure;
+    }
+    finally { clearTimeout(timeout); controller.abort(); }
   };
   try {
     await queue.open();
     await gateway.start();
 
-    await scenario("dm-round-trip", async () => {
-      const marker = `${runId}:dm-ok`; await sendDm(command(`echo ${marker}`));
-      const event = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, marker), timeoutMs, "DM reply");
+    await scenario("dm-round-trip", async (signal) => {
+      const marker = `${runId}:dm-ok`; await sendDm(command(`echo ${marker}`), signal);
+      const event = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, marker), timeoutMs, "DM reply", signal);
       messageIds.bot.add(String(event.message.id));
     });
 
-    await scenario("stream-topic-reply", async () => {
+    await scenario("stream-topic-reply", async (signal) => {
       const marker = `${runId}:stream-ok`; const topic = `${runId}-topic`;
-      const sent = await actor.request("messages", { method: "POST", body: { type: "stream", to: env.ZULIP_SMOKE_STREAM, topic, content: command(`echo ${marker}`) } });
+      const sent = await actor.request("messages", { method: "POST", body: { type: "stream", to: env.ZULIP_SMOKE_STREAM, topic, content: command(`echo ${marker}`) }, signal });
       messageIds.actor.add(String(sent.id));
-      const event = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, marker) && e.message?.display_recipient === env.ZULIP_SMOKE_STREAM && e.message?.subject === topic, timeoutMs, "stream/topic reply");
+      const event = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, marker) && e.message?.display_recipient === env.ZULIP_SMOKE_STREAM && e.message?.subject === topic, timeoutMs, "stream/topic reply", signal);
       messageIds.bot.add(String(event.message.id));
     });
 
-    await scenario("typing-and-lifecycle-reactions", async () => {
+    await scenario("typing-and-lifecycle-reactions", async (signal) => {
       const marker = `${runId}:lifecycle-ok`; const eventStart = queue.events.length;
-      const inboundId = await sendDm(command(`lifecycle ${marker}`));
-      const reply = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, marker), timeoutMs, "lifecycle reply");
+      const inboundId = await sendDm(command(`lifecycle ${marker}`), signal);
+      const reply = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, marker), timeoutMs, "lifecycle reply", signal);
       messageIds.bot.add(String(reply.message.id));
-      await queue.waitFor((e) => queue.events.indexOf(e) >= eventStart && e.type === "typing" && e.op === "stop", timeoutMs, "typing stop cleanup");
+      await queue.waitFor((e) => queue.events.indexOf(e) >= eventStart && e.type === "typing" && e.op === "stop", timeoutMs, "typing stop cleanup", signal);
       const deadline = Date.now() + timeoutMs;
       let summary;
       while (Date.now() < deadline) {
         summary = lifecycleSummary(queue.events, inboundId);
         if (summary.allRemoved && summary.sawSubagent) break;
-        await queue.poll();
-        await delay(500);
+        await queue.poll(signal);
+        await delay(500, undefined, { signal });
       }
       if (!summary?.added.length) throw new Error("No lifecycle reaction was observed on the inbound message");
       if (!summary.sawSubagent) throw new Error("No truthful subagent lifecycle reaction was observed");
@@ -231,62 +249,62 @@ async function main() {
       if (!startedTyping) throw new Error("Typing start was not observed");
     });
 
-    await scenario("explicit-reaction", async () => {
-      const inboundId = await sendDm(command("react 🎉"));
-      await queue.waitFor((e) => e.type === "reaction" && e.op === "add" && String(e.message_id) === inboundId && (e.emoji_name === "tada" || e.emoji_code === "1f389"), timeoutMs, "explicit reaction");
-      const reply = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, "reacted"), timeoutMs, "reaction acknowledgement");
+    await scenario("explicit-reaction", async (signal) => {
+      const inboundId = await sendDm(command("react 🎉"), signal);
+      await queue.waitFor((e) => e.type === "reaction" && e.op === "add" && String(e.message_id) === inboundId && (e.emoji_name === "tada" || e.emoji_code === "1f389"), timeoutMs, "explicit reaction", signal);
+      const reply = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, "reacted"), timeoutMs, "reaction acknowledgement", signal);
       messageIds.bot.add(String(reply.message.id));
     });
 
-    await scenario("edit-delete", async () => {
+    await scenario("edit-delete", async (signal) => {
       const before = `${runId}:before-edit`; const after = `${runId}:after-edit`;
-      await sendDm(command(`edit-delete ${before} ${after}`));
-      const created = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, before), timeoutMs, "message before edit");
+      await sendDm(command(`edit-delete ${before} ${after}`), signal);
+      const created = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, before), timeoutMs, "message before edit", signal);
       const id = String(created.message.id); messageIds.bot.add(id);
-      await queue.waitFor((e) => e.type === "update_message" && String(e.message_id) === id && String(e.content ?? "").includes(after), timeoutMs, "message edit");
-      await queue.waitFor((e) => e.type === "delete_message" && (e.message_ids ?? [e.message_id]).map(String).includes(id), timeoutMs, "message delete");
+      await queue.waitFor((e) => e.type === "update_message" && String(e.message_id) === id && String(e.content ?? "").includes(after), timeoutMs, "message edit", signal);
+      await queue.waitFor((e) => e.type === "delete_message" && (e.message_ids ?? [e.message_id]).map(String).includes(id), timeoutMs, "message delete", signal);
       messageIds.bot.delete(id);
     });
 
-    await scenario("upload-download", async () => {
-      const inboundMarker = `${runId}:inbound-upload`; const uri = await actor.upload(`${runId}.txt`, inboundMarker);
-      await sendDm(`${command(`read-upload ${inboundMarker}`)}\n[attachment](${uri})`);
-      const inboundReply = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, inboundMarker), timeoutMs, "inbound upload read");
+    await scenario("upload-download", async (signal) => {
+      const inboundMarker = `${runId}:inbound-upload`; const uri = await actor.upload(`${runId}.txt`, inboundMarker, signal);
+      await sendDm(`${command(`read-upload ${inboundMarker}`)}\n[attachment](${uri})`, signal);
+      const inboundReply = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, inboundMarker), timeoutMs, "inbound upload read", signal);
       messageIds.bot.add(String(inboundReply.message.id));
-      const outboundMarker = `${runId}:outbound-upload`; await sendDm(command(`send-upload ${outboundMarker}`));
-      const outbound = await queue.waitFor((e) => e.type === "message" && e.message?.sender_email === env.ZULIP_SMOKE_BOT_EMAIL && /user_uploads\//.test(String(e.message?.content ?? "")), timeoutMs, "outbound upload");
+      const outboundMarker = `${runId}:outbound-upload`; await sendDm(command(`send-upload ${outboundMarker}`), signal);
+      const outbound = await queue.waitFor((e) => e.type === "message" && e.message?.sender_email === env.ZULIP_SMOKE_BOT_EMAIL && /user_uploads\//.test(String(e.message?.content ?? "")), timeoutMs, "outbound upload", signal);
       messageIds.bot.add(String(outbound.message.id));
       const match = String(outbound.message.content).match(/(?:href=")?([^"' ]*\/user_uploads\/[^"'< ]+)/);
-      if (!match || (await actor.download(match[1])).trim() !== outboundMarker) throw new Error("Downloaded outbound upload did not match its marker");
+      if (!match || (await actor.download(match[1], signal)).trim() !== outboundMarker) throw new Error("Downloaded outbound upload did not match its marker");
     });
 
-    await scenario("poll-and-interactive-reply", async () => {
+    await scenario("poll-and-interactive-reply", async (signal) => {
       const question = `${runId}:poll`; const optionA = `smoke-choice:${runId}:interactive-ok`; const optionB = `${runId}:beta`;
-      await sendDm(command(`poll ${question} ${optionA} ${optionB}`));
+      await sendDm(command(`poll ${question} ${optionA} ${optionB}`), signal);
       const poll = await queue.waitFor((e) => {
         if (e.type !== "message" || e.message?.sender_email !== env.ZULIP_SMOKE_BOT_EMAIL) return false;
         const raw = e.message?.widget_content;
         let widget = raw;
         if (typeof raw === "string") { try { widget = JSON.parse(raw); } catch { return false; } }
         return widget?.extra_data?.poll === true && widget?.extra_data?.heading === question;
-      }, timeoutMs, "native poll");
+      }, timeoutMs, "native poll", signal);
       messageIds.bot.add(String(poll.message.id));
-      await sendDm(optionA);
-      const reply = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, `${runId}:interactive-ok`), timeoutMs, "interactive reply");
+      await sendDm(optionA, signal);
+      const reply = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, `${runId}:interactive-ok`), timeoutMs, "interactive reply", signal);
       messageIds.bot.add(String(reply.message.id));
     });
 
-    await scenario("durable-receive-completion-deduplication", async () => {
-      const marker = `${runId}:durable-ok`; const inboundId = await sendDm(command(`durable ${marker}`));
-      await queue.waitFor((e) => e.type === "reaction" && e.op === "add" && String(e.message_id) === inboundId, timeoutMs, "durable accept signal");
+    await scenario("durable-receive-completion-deduplication", async (signal) => {
+      const marker = `${runId}:durable-ok`; const inboundId = await sendDm(command(`durable ${marker}`), signal);
+      await queue.waitFor((e) => e.type === "reaction" && e.op === "add" && String(e.message_id) === inboundId, timeoutMs, "durable accept signal", signal);
       if (queue.events.some((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, marker))) {
         throw new Error("Durable reply completed before interruption; replay was not exercised");
       }
       await gateway.restart();
-      const reply = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, marker), timeoutMs, "durable replay reply");
+      const reply = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, marker), timeoutMs, "durable replay reply", signal);
       messageIds.bot.add(String(reply.message.id));
       const settleDeadline = Date.now() + 10000;
-      while (Date.now() < settleDeadline) { await queue.poll(); await delay(500); }
+      while (Date.now() < settleDeadline) { await queue.poll(signal); await delay(500, undefined, { signal }); }
       const replies = queue.events.filter((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, marker));
       if (replies.length !== 1) throw new Error(`Durable receive produced ${replies.length} visible replies; expected exactly one`);
     });

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -31,6 +31,26 @@ export function buildApiUrl(baseUrl, path) {
   return new URL(`${baseUrl.replace(/\/+$/, "")}/api/v1/${path.replace(/^\/+/, "")}`);
 }
 
+export function resolveUploadUrl(baseUrl, uri) {
+  const base = new URL(`${baseUrl.replace(/\/+$/, "")}/`);
+  const basePath = base.pathname === "/" ? "" : base.pathname.replace(/\/+$/, "");
+  const rawUri = String(uri ?? "");
+  let url;
+  if (/^https?:\/\//i.test(rawUri)) {
+    url = new URL(rawUri);
+  } else if (rawUri.startsWith("/")) {
+    const path = basePath && !rawUri.startsWith(`${basePath}/`) ? `${basePath}${rawUri}` : rawUri;
+    url = new URL(path, base.origin);
+  } else {
+    url = new URL(rawUri, base);
+  }
+  const uploadPrefix = `${basePath}/user_uploads/`;
+  if (url.origin !== base.origin || !url.pathname.startsWith(uploadPrefix)) {
+    throw new Error("Refusing smoke upload outside the configured Zulip realm");
+  }
+  return url;
+}
+
 export function redactError(error) {
   const text = error instanceof Error ? error.message : String(error);
   return text
@@ -128,12 +148,11 @@ class ZulipClient {
     });
     const payload = await response.json().catch(() => ({}));
     if (!response.ok || !payload.uri) throw new Error(`Zulip upload failed (${response.status})`);
-    return payload.uri;
+    return resolveUploadUrl(this.baseUrl, payload.uri).href;
   }
 
   async download(uri, signal) {
-    const url = new URL(uri, this.baseUrl);
-    if (url.origin !== new URL(this.baseUrl).origin) throw new Error("Refusing cross-origin smoke upload");
+    const url = resolveUploadUrl(this.baseUrl, uri);
     const requestSignal = signal ? AbortSignal.any([signal, AbortSignal.timeout(30000)]) : AbortSignal.timeout(30000);
     const response = await fetch(url, { headers: { Authorization: this.authorization }, signal: requestSignal });
     if (!response.ok) throw new Error(`Zulip download failed (${response.status})`);

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -40,8 +40,13 @@ export function isBotMessage(event, botEmail, marker) {
 }
 
 export function isExactRenderedContent(content, expected) {
-  const rendered = String(content ?? "").trim();
+  const rendered = String(content ?? "");
   return rendered === expected || rendered === `<p>${escapeHtml(expected)}</p>`;
+}
+
+export function isExactUtf8(bytes, expected) {
+  const expectedBytes = new TextEncoder().encode(expected);
+  return bytes.length === expectedBytes.length && bytes.every((value, index) => value === expectedBytes[index]);
 }
 
 export function lifecycleSummary(events, inboundMessageId) {
@@ -126,7 +131,7 @@ class ZulipClient {
     const requestSignal = signal ? AbortSignal.any([signal, AbortSignal.timeout(30000)]) : AbortSignal.timeout(30000);
     const response = await fetch(url, { headers: { Authorization: this.authorization }, signal: requestSignal });
     if (!response.ok) throw new Error(`Zulip download failed (${response.status})`);
-    return response.text();
+    return new Uint8Array(await response.arrayBuffer());
   }
 }
 
@@ -380,7 +385,7 @@ async function main() {
       const outbound = await queue.waitFor((e) => e.type === "message" && e.message?.sender_email === env.ZULIP_SMOKE_BOT_EMAIL && /user_uploads\//.test(String(e.message?.content ?? "")), timeoutMs, "outbound upload", signal);
       messageIds.bot.add(String(outbound.message.id));
       const match = String(outbound.message.content).match(/(?:href=")?([^"' ]*\/user_uploads\/[^"'< ]+)/);
-      if (!match || await actor.download(match[1], signal) !== outboundMarker) throw new Error("Downloaded outbound upload did not match its marker");
+      if (!match || !isExactUtf8(await actor.download(match[1], signal), outboundMarker)) throw new Error("Downloaded outbound upload did not match its marker");
     });
 
     await scenario("poll-and-interactive-reply", async (signal) => {

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -36,8 +36,12 @@ export function redactError(error) {
 
 export function isBotMessage(event, botEmail, marker) {
   if (event?.type !== "message" || event.message?.sender_email !== botEmail) return false;
-  const content = String(event.message?.content ?? "").trim();
-  return content === marker || content === `<p>${escapeHtml(marker)}</p>`;
+  return isExactRenderedContent(event.message?.content, marker);
+}
+
+export function isExactRenderedContent(content, expected) {
+  const rendered = String(content ?? "").trim();
+  return rendered === expected || rendered === `<p>${escapeHtml(expected)}</p>`;
 }
 
 export function lifecycleSummary(events, inboundMessageId) {
@@ -362,7 +366,7 @@ async function main() {
       await sendDm(command(`edit-delete ${before} ${after}`), signal);
       const created = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, before), timeoutMs, "message before edit", signal);
       const id = String(created.message.id); messageIds.bot.add(id);
-      await queue.waitFor((e) => e.type === "update_message" && String(e.message_id) === id && String(e.content ?? "").includes(after), timeoutMs, "message edit", signal);
+      await queue.waitFor((e) => e.type === "update_message" && String(e.message_id) === id && isExactRenderedContent(e.content, after), timeoutMs, "message edit", signal);
       await queue.waitFor((e) => e.type === "delete_message" && (e.message_ids ?? [e.message_id]).map(String).includes(id), timeoutMs, "message delete", signal);
       messageIds.bot.delete(id);
     });
@@ -376,7 +380,7 @@ async function main() {
       const outbound = await queue.waitFor((e) => e.type === "message" && e.message?.sender_email === env.ZULIP_SMOKE_BOT_EMAIL && /user_uploads\//.test(String(e.message?.content ?? "")), timeoutMs, "outbound upload", signal);
       messageIds.bot.add(String(outbound.message.id));
       const match = String(outbound.message.content).match(/(?:href=")?([^"' ]*\/user_uploads\/[^"'< ]+)/);
-      if (!match || (await actor.download(match[1], signal)).trim() !== outboundMarker) throw new Error("Downloaded outbound upload did not match its marker");
+      if (!match || await actor.download(match[1], signal) !== outboundMarker) throw new Error("Downloaded outbound upload did not match its marker");
     });
 
     await scenario("poll-and-interactive-reply", async (signal) => {

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -35,21 +35,39 @@ export function redactError(error) {
 }
 
 export function isBotMessage(event, botEmail, marker) {
-  return event?.type === "message" && event.message?.sender_email === botEmail &&
-    String(event.message?.content ?? "").includes(marker);
+  if (event?.type !== "message" || event.message?.sender_email !== botEmail) return false;
+  const content = String(event.message?.content ?? "").trim();
+  return content === marker || content === `<p>${escapeHtml(marker)}</p>`;
 }
 
 export function lifecycleSummary(events, inboundMessageId) {
   const relevant = events.filter((event) =>
     event?.type === "reaction" && String(event.message_id) === String(inboundMessageId),
   );
-  const added = relevant.filter((event) => event.op === "add");
-  const removedKeys = new Set(relevant.filter((event) => event.op === "remove").map(reactionKey));
+  const added = [];
+  const active = new Set();
+  for (const event of relevant) {
+    const key = reactionKey(event);
+    if (event.op === "add") {
+      added.push(event);
+      active.add(key);
+    } else if (event.op === "remove") {
+      active.delete(key);
+    }
+  }
   return {
     added,
-    allRemoved: added.length > 0 && added.every((event) => removedKeys.has(reactionKey(event))),
+    allRemoved: added.length > 0 && active.size === 0,
     sawSubagent: added.some((event) => event.emoji_name === "robot" || event.emoji_code === "1f916"),
   };
+}
+
+export function isExactPoll(widget, question, options) {
+  const extra = widget?.extra_data;
+  if (extra?.poll !== true || extra.heading !== question || !Array.isArray(extra.choices)) return false;
+  if (extra.choices.length !== options.length) return false;
+  return extra.choices.every((choice, index) => choice?.type === "multiple_choice" &&
+    choice.short_name === options[index] && choice.long_name === options[index] && choice.reply === options[index]);
 }
 
 export function normalizeScenarioError(signal, error) {
@@ -57,7 +75,13 @@ export function normalizeScenarioError(signal, error) {
 }
 
 function reactionKey(event) {
-  return `${event.emoji_name ?? ""}:${event.emoji_code ?? ""}:${event.reaction_type ?? ""}`;
+  const user = event.user_id ?? event.user?.user_id ?? event.user?.email ?? event.user?.full_name ?? "";
+  return `${user}:${event.emoji_name ?? ""}:${event.emoji_code ?? ""}:${event.reaction_type ?? ""}`;
+}
+
+function escapeHtml(value) {
+  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;").replaceAll("'", "&#39;");
 }
 
 class ZulipClient {
@@ -286,7 +310,7 @@ async function main() {
         const raw = e.message?.widget_content;
         let widget = raw;
         if (typeof raw === "string") { try { widget = JSON.parse(raw); } catch { return false; } }
-        return widget?.extra_data?.poll === true && widget?.extra_data?.heading === question;
+        return isExactPoll(widget, question, [optionA, optionB]);
       }, timeoutMs, "native poll", signal);
       messageIds.bot.add(String(poll.message.id));
       await sendDm(optionA, signal);

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -107,6 +107,13 @@ export function isPrivateTypingEvent(event, botEmail, actorEmail, op) {
   return hasExactDirectParticipants(recipients, botEmail, actorEmail);
 }
 
+export function hasFinalPrivateTypingStop(events, botEmail, actorEmail) {
+  const lifecycle = events.filter((event) =>
+    isPrivateTypingEvent(event, botEmail, actorEmail, "start") ||
+    isPrivateTypingEvent(event, botEmail, actorEmail, "stop"));
+  return lifecycle.some((event) => event.op === "start") && lifecycle.at(-1)?.op === "stop";
+}
+
 function hasExactDirectParticipants(recipients, botEmail, actorEmail) {
   const emails = new Set(recipients.map((recipient) => recipient?.email ?? recipient).filter(Boolean));
   return emails.size === 2 && emails.has(botEmail) && emails.has(actorEmail);
@@ -507,10 +514,8 @@ async function main() {
       const reply = await queue.waitFor((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, marker), timeoutMs, "lifecycle reply", signal);
       messageIds.bot.add(String(reply.message.id));
       await queue.waitFor((e) => {
-        const stopIndex = queue.events.indexOf(e);
-        if (stopIndex < eventStart || !isPrivateTypingEvent(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, "stop")) return false;
-        return queue.events.slice(eventStart, stopIndex).some((candidate) =>
-          isPrivateTypingEvent(candidate, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, "start"));
+        if (queue.events.indexOf(e) < eventStart || !isPrivateTypingEvent(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, "stop")) return false;
+        return hasFinalPrivateTypingStop(queue.events.slice(eventStart), env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL);
       }, timeoutMs, "ordered typing start/stop cleanup", signal);
       const deadline = Date.now() + timeoutMs;
       let summary;

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -168,7 +168,7 @@ export async function inspectChildTranscripts(stateDir, marker) {
     for (const entry of entries) {
       const path = resolve(directory, entry.name);
       if (entry.isDirectory()) await visit(path);
-      else if (entry.isFile() && entry.name.endsWith(".jsonl")) files.push(path);
+      else if (entry.isFile() && /\.jsonl(?:\.(?:deleted|reset)\..+)?$/.test(entry.name)) files.push(path);
     }
   };
   await visit(resolve(stateDir, "agents"));

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -164,6 +164,33 @@ test("waits through the locked default terminal hold until lifecycle cleanup", a
   assert.equal(Date.now() - started >= 2000, true);
 });
 
+test("does not settle when a late typing start follows the earlier stop", async () => {
+  const reaction = { type: "reaction", message_id: 42, user_id: 7, reaction_type: "unicode_emoji", emoji_name: "robot", emoji_code: "1f916" };
+  const typing = { type: "typing", message_type: "direct", sender: { email: "bot@example.test" }, recipients: [
+    { email: "bot@example.test" }, { email: "user@example.test" },
+  ] };
+  const events = [{ ...reaction, op: "add" }, { ...reaction, op: "remove" }, { ...typing, op: "start" }, { ...typing, op: "stop" }];
+  const started = Date.now();
+  let lateStartSent = false;
+  const queue = { events, async poll() {
+    if (!lateStartSent && Date.now() - started >= 20) {
+      lateStartSent = true;
+      const event = { ...typing, op: "start" };
+      this.events.push(event);
+      return [event];
+    }
+    return [];
+  } };
+  await assert.rejects(
+    drainEventQueueUntilQuiet(queue, undefined, 30, 100, 5, () =>
+      lifecycleSummary(queue.events, "42").allRemoved &&
+      hasFinalPrivateTypingStop(queue.events, "bot@example.test", "user@example.test")),
+    /stable quiet window/,
+  );
+  assert.equal(lateStartSent, true);
+  assert.equal(hasFinalPrivateTypingStop(queue.events, "bot@example.test", "user@example.test"), false);
+});
+
 test("matches complete raw or Zulip-rendered content", () => {
   assert.equal(isExactRenderedContent("after", "after"), true);
   assert.equal(isExactRenderedContent("<p>after</p>", "after"), true);

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -3,7 +3,7 @@ import { spawn } from "node:child_process";
 import { EventEmitter, once } from "node:events";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
-import { buildApiUrl, EventQueue, Gateway, isBotMessage, isChildRunning, isExactPoll, isExactRenderedContent, isExactUtf8, lifecycleSummary, normalizeScenarioError, redactError, resolveUploadUrl, signalProcessTree, validateEnvironment, waitForProcessTreeExit } from "./run.mjs";
+import { buildApiUrl, EventQueue, Gateway, isBotMessage, isChildRunning, isExactPoll, isExactRenderedContent, isExactUtf8, isPrivateBotMessage, isPrivateTypingEvent, lifecycleSummary, normalizeScenarioError, redactError, resolveUploadUrl, signalProcessTree, validateEnvironment, waitForProcessTreeExit } from "./run.mjs";
 
 const validEnv = {
   ZULIP_URL: "https://zulip.example.test/path",
@@ -45,6 +45,22 @@ test("matches only marked messages from the configured bot", () => {
   assert.equal(isBotMessage({ ...event, message: { ...event.message, content: "<p>marker</p>" } }, "bot@example.test", "marker"), true);
   assert.equal(isBotMessage({ ...event, message: { ...event.message, content: "prefix marker" } }, "bot@example.test", "marker"), false);
   assert.equal(isBotMessage(event, "other@example.test", "marker"), false);
+});
+
+test("requires private bot replies with the expected participants", () => {
+  const event = { type: "message", message: { type: "private", sender_email: "bot@example.test", content: "marker", display_recipient: [
+    { email: "bot@example.test" }, { email: "user@example.test" },
+  ] } };
+  assert.equal(isPrivateBotMessage(event, "bot@example.test", "user@example.test", "marker"), true);
+  assert.equal(isPrivateBotMessage({ ...event, message: { ...event.message, type: "stream" } }, "bot@example.test", "user@example.test", "marker"), false);
+  assert.equal(isPrivateBotMessage({ ...event, message: { ...event.message, display_recipient: [{ email: "bot@example.test" }] } }, "bot@example.test", "user@example.test", "marker"), false);
+});
+
+test("matches private typing events from the configured bot", () => {
+  const event = { type: "typing", op: "start", message_type: "direct", sender: { email: "bot@example.test" }, recipients: [{ email: "user@example.test" }] };
+  assert.equal(isPrivateTypingEvent(event, "bot@example.test", "user@example.test", "start"), true);
+  assert.equal(isPrivateTypingEvent({ ...event, op: "stop" }, "bot@example.test", "user@example.test", "start"), false);
+  assert.equal(isPrivateTypingEvent({ ...event, sender: { email: "other@example.test" } }, "bot@example.test", "user@example.test", "start"), false);
 });
 
 test("matches complete raw or Zulip-rendered content", () => {
@@ -120,6 +136,25 @@ test("waits for gateway exit after escalating to SIGKILL", async () => {
   await Promise.all([gateway.stop(), gateway.stop()]);
   assert.deepEqual(signals, ["SIGTERM", "SIGKILL"]);
   assert.equal(gateway.process, undefined);
+});
+
+test("kills a health probe that exceeds its process deadline", async () => {
+  const probe = new EventEmitter();
+  probe.exitCode = null;
+  probe.signalCode = null;
+  probe.kill = (signal) => {
+    probe.signalCode = signal;
+    setImmediate(() => probe.emit("exit", null, signal));
+    return true;
+  };
+  const gateway = new Gateway(18789, { healthProbeSpawn: () => probe, healthProbeTimeoutMs: 5 });
+  const keepAlive = setInterval(() => {}, 1000);
+  try {
+    assert.equal(await gateway.isHealthy(), false);
+    assert.equal(probe.signalCode, "SIGKILL");
+  } finally {
+    clearInterval(keepAlive);
+  }
 });
 
 test("treats signal-terminated children as stopped", () => {

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -5,7 +5,7 @@ import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { assertMessageRemainsExact, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, EventQueue, Gateway, hasFinalPrivateTypingStop, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, lifecycleSummary, normalizeScenarioError, redactError, resolveUploadUrl, signalProcessTree, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
+import { assertFinalPrivateTypingStop, assertMessageRemainsExact, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, EventQueue, Gateway, hasFinalPrivateTypingStop, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, lifecycleSummary, normalizeScenarioError, redactError, resolveUploadUrl, signalProcessTree, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
 
 const validEnv = {
   ZULIP_URL: "https://zulip.example.test/path",
@@ -83,6 +83,27 @@ test("requires the final matching typing event to stop", () => {
   assert.equal(hasFinalPrivateTypingStop([start, stop, start], "bot@example.test", "user@example.test"), false);
   assert.equal(hasFinalPrivateTypingStop([stop], "bot@example.test", "user@example.test"), false);
   assert.equal(hasFinalPrivateTypingStop([start, stop, { ...start, sender: { email: "other@example.test" } }], "bot@example.test", "user@example.test"), true);
+});
+
+test("rechecks the final typing state after draining later events", async () => {
+  const base = { type: "typing", message_type: "direct", sender: { email: "bot@example.test" }, recipients: [
+    { email: "bot@example.test" }, { email: "user@example.test" },
+  ] };
+  const start = { ...base, op: "start" };
+  const stop = { ...base, op: "stop" };
+  const queue = {
+    events: [start, stop],
+    batches: [[start], []],
+    async poll() {
+      const batch = this.batches.shift() ?? [];
+      this.events.push(...batch);
+      return batch;
+    },
+  };
+  await assert.rejects(
+    assertFinalPrivateTypingStop(queue, 0, "bot@example.test", "user@example.test", undefined, 0),
+    /Final direct typing state was not stopped/,
+  );
 });
 
 test("matches complete raw or Zulip-rendered content", () => {

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -5,7 +5,7 @@ import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { assertFinalPrivateTypingStop, assertMessageRemainsExact, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, drainEventQueueUntilQuiet, EventQueue, Gateway, hasFinalPrivateTypingStop, inspectChildTranscripts, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactPollMessage, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, isUsageCountedTranscriptName, lifecycleSummary, normalizeScenarioError, redactError, resolveUploadUrl, signalProcessTree, subagentCompletedBeforeReply, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
+import { assertFinalPrivateTypingStop, assertMessageRemainsExact, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, drainEventQueueUntilQuiet, eventOccursBefore, EventQueue, Gateway, hasFinalPrivateTypingStop, hasProvableMinimumMessageDelay, inspectChildTranscripts, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactPollMessage, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, isUsageCountedTranscriptName, lifecycleSummary, normalizeScenarioError, redactError, resolveUploadUrl, signalProcessTree, subagentCompletedBeforeReply, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
 
 const validEnv = {
   ZULIP_URL: "https://zulip.example.test/path",
@@ -207,6 +207,21 @@ test("attributes every configured-bot DM containing the unique durable marker", 
     assert.equal(isDurableReplyEvent({ ...base, message: { ...base.message, content } }, "bot@example.test", "user@example.test", "durable-marker"), true);
   }
   assert.equal(isDurableReplyEvent({ ...base, message: { ...base.message, sender_email: "other@example.test", content: "durable-marker" } }, "bot@example.test", "user@example.test", "durable-marker"), false);
+});
+
+test("requires the explicit reaction event to precede its acknowledgement", () => {
+  const reaction = { type: "reaction" };
+  const reply = { type: "message" };
+  assert.equal(eventOccursBefore([reaction, reply], reaction, reply), true);
+  assert.equal(eventOccursBefore([reply, reaction], reaction, reply), false);
+  assert.equal(eventOccursBefore([reaction], reaction, reply), false);
+});
+
+test("proves the durable delay from Zulip server message timestamps", () => {
+  const commandEvent = { message: { timestamp: 100 } };
+  assert.equal(hasProvableMinimumMessageDelay(commandEvent, { message: { timestamp: 116 } }, 15), true);
+  assert.equal(hasProvableMinimumMessageDelay(commandEvent, { message: { timestamp: 115 } }, 15), false);
+  assert.equal(hasProvableMinimumMessageDelay(commandEvent, { message: {} }, 15), false);
 });
 
 test("captures every attributable reply id before an early failure", () => {

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -215,6 +215,18 @@ test("requires the exact child result in an assistant transcript message", async
     ].join("\n"));
     assert.deepEqual(await inspectChildTranscripts(stateDir, marker), { total: 2, completedExact: 1 });
     await rm(join(sessionsDir, "extra-child.jsonl"));
+    await writeFile(join(sessionsDir, "archived-child.jsonl.deleted.2026-08-30T19-00-00.000Z"), [
+      JSON.stringify({ message: { role: "user", content: "[Subagent Task] hidden archived work" } }),
+      JSON.stringify({ message: { role: "assistant", content: [{ type: "text", text: "archived" }] } }),
+    ].join("\n"));
+    assert.deepEqual(await inspectChildTranscripts(stateDir, marker), { total: 2, completedExact: 1 });
+    await rm(join(sessionsDir, "archived-child.jsonl.deleted.2026-08-30T19-00-00.000Z"));
+    await writeFile(join(sessionsDir, "reset-child.jsonl.reset.2026-08-30T19-00-01.000Z"), [
+      JSON.stringify({ message: { role: "user", content: "[Subagent Task] hidden reset work" } }),
+      JSON.stringify({ message: { role: "assistant", content: [{ type: "text", text: "reset" }] } }),
+    ].join("\n"));
+    assert.deepEqual(await inspectChildTranscripts(stateDir, marker), { total: 2, completedExact: 1 });
+    await rm(join(sessionsDir, "reset-child.jsonl.reset.2026-08-30T19-00-01.000Z"));
     await writeFile(join(sessionsDir, "child.jsonl"), [
       JSON.stringify({ message: { role: "user", content: `[Subagent Task] reply ${marker}` } }),
       JSON.stringify({ message: { role: "assistant", content: [

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -410,6 +410,9 @@ test("accepts only a standalone outbound upload without captions or local paths"
   assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/file.txt">/tmp/file.txt</a></p>'), undefined);
   assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/file.txt">/home/runner/work/repo/file.txt</a></p>'), undefined);
   assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/file.txt">%2Froot%2Ffile.txt</a></p>'), undefined);
+  assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/%252Froot%252Fsecret.txt">%2Froot%2Fsecret.txt</a></p>'), undefined);
+  assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/%255Chome%255Csecret.txt">%5Chome%5Csecret.txt</a></p>'), undefined);
+  assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/..%252Fsecret.txt">..%2Fsecret.txt</a></p>'), undefined);
   assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/file.txt">unrequested prose</a></p>'), undefined);
   assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/My%20File.txt">My File.txt</a></p>'), "/user_uploads/x/My%20File.txt");
   assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/file.txt">/user_uploads/x/file.txt</a></p>'), "/user_uploads/x/file.txt");

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
-import { isBotMessage, lifecycleSummary, redactError, validateEnvironment } from "./run.mjs";
+import { EventQueue, isBotMessage, lifecycleSummary, normalizeScenarioError, redactError, validateEnvironment } from "./run.mjs";
 
 const validEnv = {
   ZULIP_URL: "https://zulip.example.test/path",
@@ -36,6 +36,30 @@ test("requires lifecycle and subagent reactions to be removed", () => {
   assert.deepEqual(lifecycleSummary([{ ...base, op: "add" }, { ...base, op: "remove" }], "42"), {
     added: [{ ...base, op: "add" }], allRemoved: true, sawSubagent: true,
   });
+});
+
+test("cancels a timed-out event wait", async () => {
+  const queue = new EventQueue({ request: async () => ({ events: [] }) });
+  const controller = new AbortController();
+  const waiting = queue.waitFor(() => false, 10000, "never", controller.signal);
+  controller.abort(new Error("scenario timed out"));
+  await assert.rejects(waiting, (error) => error.name === "AbortError");
+  assert.equal(normalizeScenarioError(controller.signal, new Error("aborted fetch")).message, "scenario timed out");
+});
+
+test("coalesces concurrent event polls", async () => {
+  let calls = 0;
+  let resolveRequest;
+  const queue = new EventQueue({ request: () => {
+    calls += 1;
+    return new Promise((resolve) => { resolveRequest = resolve; });
+  }});
+  const first = queue.poll();
+  const second = queue.poll();
+  assert.equal(calls, 1);
+  resolveRequest({ events: [{ id: 1, type: "message" }] });
+  await Promise.all([first, second]);
+  assert.equal(queue.events.length, 1);
 });
 
 test("workflow is manual, protected, pinned, and bounded", async () => {

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -3,7 +3,7 @@ import { spawn } from "node:child_process";
 import { EventEmitter, once } from "node:events";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
-import { buildApiUrl, EventQueue, Gateway, isBotMessage, isChildRunning, isExactPoll, isExactRenderedContent, isExactUtf8, lifecycleSummary, normalizeScenarioError, redactError, signalProcessTree, validateEnvironment, waitForProcessTreeExit } from "./run.mjs";
+import { buildApiUrl, EventQueue, Gateway, isBotMessage, isChildRunning, isExactPoll, isExactRenderedContent, isExactUtf8, lifecycleSummary, normalizeScenarioError, redactError, resolveUploadUrl, signalProcessTree, validateEnvironment, waitForProcessTreeExit } from "./run.mjs";
 
 const validEnv = {
   ZULIP_URL: "https://zulip.example.test/path",
@@ -24,6 +24,13 @@ test("validates protected configuration while preserving base paths", () => {
 test("preserves Zulip base paths when constructing API URLs", () => {
   assert.equal(buildApiUrl("https://zulip.example.test/path", "/messages").href, "https://zulip.example.test/path/api/v1/messages");
   assert.equal(buildApiUrl("https://zulip.example.test", "user_uploads").href, "https://zulip.example.test/api/v1/user_uploads");
+});
+
+test("keeps upload URLs inside the configured Zulip realm path", () => {
+  assert.equal(resolveUploadUrl("https://zulip.example.test/path", "/user_uploads/a.txt").href, "https://zulip.example.test/path/user_uploads/a.txt");
+  assert.equal(resolveUploadUrl("https://zulip.example.test/path", "/path/user_uploads/a.txt").href, "https://zulip.example.test/path/user_uploads/a.txt");
+  assert.throws(() => resolveUploadUrl("https://zulip.example.test/path", "https://zulip.example.test/user_uploads/a.txt"), /outside/);
+  assert.throws(() => resolveUploadUrl("https://zulip.example.test/path", "https://other.example.test/path/user_uploads/a.txt"), /outside/);
 });
 
 test("redacts URLs and authorization values", () => {

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -5,7 +5,7 @@ import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { assertFinalPrivateTypingStop, assertMessageRemainsExact, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, EventQueue, Gateway, hasFinalPrivateTypingStop, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, lifecycleSummary, normalizeScenarioError, redactError, resolveUploadUrl, signalProcessTree, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
+import { assertFinalPrivateTypingStop, assertMessageRemainsExact, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, EventQueue, Gateway, hasFinalPrivateTypingStop, inspectChildTranscripts, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactPollMessage, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, lifecycleSummary, normalizeScenarioError, redactError, resolveUploadUrl, signalProcessTree, subagentCompletedBeforeReply, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
 
 const validEnv = {
   ZULIP_URL: "https://zulip.example.test/path",
@@ -208,6 +208,13 @@ test("requires the exact child result in an assistant transcript message", async
       JSON.stringify({ message: { role: "assistant", content: [{ type: "text", text: marker }] } }),
     ].join("\n"));
     assert.equal(await countCompletedChildTranscripts(stateDir, marker), 1);
+    assert.deepEqual(await inspectChildTranscripts(stateDir, marker), { total: 1, completedExact: 1 });
+    await writeFile(join(sessionsDir, "extra-child.jsonl"), [
+      JSON.stringify({ message: { role: "user", content: "[Subagent Task] do unrelated work" } }),
+      JSON.stringify({ message: { role: "assistant", content: [{ type: "text", text: "unrelated" }] } }),
+    ].join("\n"));
+    assert.deepEqual(await inspectChildTranscripts(stateDir, marker), { total: 2, completedExact: 1 });
+    await rm(join(sessionsDir, "extra-child.jsonl"));
     await writeFile(join(sessionsDir, "child.jsonl"), [
       JSON.stringify({ message: { role: "user", content: `[Subagent Task] reply ${marker}` } }),
       JSON.stringify({ message: { role: "assistant", content: [
@@ -245,6 +252,13 @@ test("requires lifecycle and subagent reactions to be removed", () => {
   assert.equal(lifecycleSummary([{ ...base, op: "add" }, { ...base, user_id: 8, op: "add" }, { ...base, op: "remove" }], "42").allRemoved, false);
 });
 
+test("requires subagent lifecycle completion before the parent reply", () => {
+  const reaction = (id, op) => ({ type: "reaction", message_id: "42", user_id: 7, emoji_name: "robot", emoji_code: "1f916", reaction_type: "unicode_emoji", op, id });
+  const reply = { type: "message", id: 3 };
+  assert.equal(subagentCompletedBeforeReply([reaction(1, "add"), reaction(2, "remove"), reply], "42", reply), true);
+  assert.equal(subagentCompletedBeforeReply([reaction(1, "add"), reply, reaction(3, "remove")], "42", reply), false);
+});
+
 test("requires the poll's exact ordered choices and replies", () => {
   const widget = { extra_data: { poll: true, heading: "question", choices: [
     { type: "multiple_choice", short_name: "a", long_name: "a", reply: "a" },
@@ -253,6 +267,8 @@ test("requires the poll's exact ordered choices and replies", () => {
   assert.equal(isExactPoll(widget, "question", ["a", "b"]), true);
   assert.equal(isExactPoll(widget, "question", ["b", "a"]), false);
   assert.equal(isExactPoll({ extra_data: { ...widget.extra_data, choices: [{ ...widget.extra_data.choices[0], reply: "wrong" }, widget.extra_data.choices[1]] } }, "question", ["a", "b"]), false);
+  assert.equal(isExactPollMessage({ content: "<p>question</p>", widget_content: JSON.stringify(widget) }, "question", ["a", "b"]), true);
+  assert.equal(isExactPollMessage({ content: "<p>question plus prose</p>", widget_content: widget }, "question", ["a", "b"]), false);
 });
 
 test("cancels a timed-out event wait", async () => {

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -413,6 +413,9 @@ test("accepts only a standalone outbound upload without captions or local paths"
   assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/%252Froot%252Fsecret.txt">%2Froot%2Fsecret.txt</a></p>'), undefined);
   assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/%255Chome%255Csecret.txt">%5Chome%5Csecret.txt</a></p>'), undefined);
   assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/..%252Fsecret.txt">..%2Fsecret.txt</a></p>'), undefined);
+  assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/%252Froot%25.txt">%2Froot%.txt</a></p>'), undefined);
+  assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/..%252Fsecret%25.txt">..%2Fsecret%.txt</a></p>'), undefined);
+  assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/%255Chome%25ZZ.txt">%5Chome%ZZ.txt</a></p>'), undefined);
   assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/file.txt">unrequested prose</a></p>'), undefined);
   assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/My%20File.txt">My File.txt</a></p>'), "/user_uploads/x/My%20File.txt");
   assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/file.txt">/user_uploads/x/file.txt</a></p>'), "/user_uploads/x/file.txt");

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -54,16 +54,20 @@ test("requires private bot replies with the expected participants", () => {
   assert.equal(isPrivateBotMessage(event, "bot@example.test", "user@example.test", "marker"), true);
   assert.equal(isPrivateBotMessage({ ...event, message: { ...event.message, type: "stream" } }, "bot@example.test", "user@example.test", "marker"), false);
   assert.equal(isPrivateBotMessage({ ...event, message: { ...event.message, display_recipient: [{ email: "bot@example.test" }] } }, "bot@example.test", "user@example.test", "marker"), false);
+  assert.equal(isPrivateBotMessage({ ...event, message: { ...event.message, display_recipient: [...event.message.display_recipient, { email: "third@example.test" }] } }, "bot@example.test", "user@example.test", "marker"), false);
   const uploadEvent = { ...event, message: { ...event.message, content: "[file](/user_uploads/a.txt)" } };
   assert.equal(isPrivateBotEvent(uploadEvent, "bot@example.test", "user@example.test"), true);
   assert.equal(isPrivateBotEvent({ ...uploadEvent, message: { ...uploadEvent.message, type: "stream" } }, "bot@example.test", "user@example.test"), false);
 });
 
 test("matches private typing events from the configured bot", () => {
-  const event = { type: "typing", op: "start", message_type: "direct", sender: { email: "bot@example.test" }, recipients: [{ email: "user@example.test" }] };
+  const event = { type: "typing", op: "start", message_type: "direct", sender: { email: "bot@example.test" }, recipients: [
+    { email: "bot@example.test" }, { email: "user@example.test" },
+  ] };
   assert.equal(isPrivateTypingEvent(event, "bot@example.test", "user@example.test", "start"), true);
   assert.equal(isPrivateTypingEvent({ ...event, op: "stop" }, "bot@example.test", "user@example.test", "start"), false);
   assert.equal(isPrivateTypingEvent({ ...event, sender: { email: "other@example.test" } }, "bot@example.test", "user@example.test", "start"), false);
+  assert.equal(isPrivateTypingEvent({ ...event, recipients: [...event.recipients, { email: "third@example.test" }] }, "bot@example.test", "user@example.test", "start"), false);
 });
 
 test("matches complete raw or Zulip-rendered content", () => {

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -3,7 +3,7 @@ import { spawn } from "node:child_process";
 import { EventEmitter, once } from "node:events";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
-import { EventQueue, Gateway, isBotMessage, isChildRunning, isExactPoll, isExactRenderedContent, isExactUtf8, lifecycleSummary, normalizeScenarioError, redactError, signalProcessTree, validateEnvironment, waitForProcessTreeExit } from "./run.mjs";
+import { buildApiUrl, EventQueue, Gateway, isBotMessage, isChildRunning, isExactPoll, isExactRenderedContent, isExactUtf8, lifecycleSummary, normalizeScenarioError, redactError, signalProcessTree, validateEnvironment, waitForProcessTreeExit } from "./run.mjs";
 
 const validEnv = {
   ZULIP_URL: "https://zulip.example.test/path",
@@ -15,10 +15,15 @@ const validEnv = {
   SMOKE_TESTED_SHA: "a".repeat(40),
 };
 
-test("validates protected configuration without returning URL paths", () => {
-  assert.equal(validateEnvironment(validEnv).ZULIP_URL, "https://zulip.example.test");
+test("validates protected configuration while preserving base paths", () => {
+  assert.equal(validateEnvironment(validEnv).ZULIP_URL, "https://zulip.example.test/path");
   assert.throws(() => validateEnvironment({ ...validEnv, ZULIP_URL: "http://zulip.test" }), /HTTPS/);
   assert.throws(() => validateEnvironment({ ...validEnv, ZULIP_SMOKE_USER_API_KEY: "" }), /protected configuration/);
+});
+
+test("preserves Zulip base paths when constructing API URLs", () => {
+  assert.equal(buildApiUrl("https://zulip.example.test/path", "/messages").href, "https://zulip.example.test/path/api/v1/messages");
+  assert.equal(buildApiUrl("https://zulip.example.test", "user_uploads").href, "https://zulip.example.test/api/v1/user_uploads");
 });
 
 test("redacts URLs and authorization values", () => {

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -278,6 +278,8 @@ test("requires lifecycle and subagent reactions to be removed", () => {
   });
   assert.equal(lifecycleSummary([{ ...base, op: "add" }, { ...base, op: "remove" }, { ...base, op: "add" }], "42").allRemoved, false);
   assert.equal(lifecycleSummary([{ ...base, op: "add" }, { ...base, user_id: 8, op: "add" }, { ...base, op: "remove" }], "42").allRemoved, false);
+  const terminal = { ...base, emoji_name: "white_check_mark", emoji_code: "2705", op: "add" };
+  assert.equal(lifecycleSummary([{ ...base, op: "add" }, { ...base, op: "remove" }, terminal], "42").allRemoved, false);
 });
 
 test("requires subagent lifecycle completion before the parent reply", () => {

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -132,6 +132,38 @@ test("fails closed when the event queue never reaches a quiet window", async () 
   await assert.rejects(drainEventQueueUntilQuiet(queue, undefined, 10, 25, 0), /stable quiet window/);
 });
 
+test("waits through the locked default terminal hold until lifecycle cleanup", async () => {
+  const base = { type: "reaction", message_id: 42, user_id: 7, reaction_type: "unicode_emoji" };
+  const terminal = { ...base, emoji_name: "check", emoji_code: "2705" };
+  const events = [
+    { ...base, emoji_name: "robot", emoji_code: "1f916", op: "add" },
+    { ...base, emoji_name: "robot", emoji_code: "1f916", op: "remove" },
+  ];
+  const started = Date.now();
+  let added = false;
+  let removed = false;
+  const queue = { events, async poll() {
+    const elapsed = Date.now() - started;
+    if (!added && elapsed >= 25) {
+      added = true;
+      const event = { ...terminal, op: "add" };
+      this.events.push(event);
+      return [event];
+    }
+    if (!removed && elapsed >= 1525) {
+      removed = true;
+      const event = { ...terminal, op: "remove" };
+      this.events.push(event);
+      return [event];
+    }
+    return [];
+  } };
+  await drainEventQueueUntilQuiet(queue, undefined, 500, 4000, 25, () => lifecycleSummary(queue.events, "42").allRemoved);
+  assert.equal(removed, true);
+  assert.equal(lifecycleSummary(queue.events, "42").allRemoved, true);
+  assert.equal(Date.now() - started >= 2000, true);
+});
+
 test("matches complete raw or Zulip-rendered content", () => {
   assert.equal(isExactRenderedContent("after", "after"), true);
   assert.equal(isExactRenderedContent("<p>after</p>", "after"), true);

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -5,7 +5,7 @@ import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { assertFinalPrivateTypingStop, assertMessageRemainsExact, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, drainEventQueueUntilQuiet, eventOccursBefore, EventQueue, Gateway, hasFinalPrivateTypingStop, hasProvableMinimumMessageDelay, inspectChildTranscripts, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactPollMessage, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, isUsageCountedTranscriptName, lifecycleSummary, normalizeScenarioError, redactError, resolveUploadUrl, signalProcessTree, subagentCompletedBeforeReply, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
+import { assertFinalPrivateTypingStop, assertMessageRemainsExact, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, drainEventQueueUntilQuiet, eventOccursBefore, EventQueue, extractExactUploadUrl, Gateway, hasFinalPrivateTypingStop, hasProvableMinimumMessageDelay, inspectChildTranscripts, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactPollMessage, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, isUsageCountedTranscriptName, lifecycleSummary, normalizeScenarioError, redactError, resolveUploadUrl, signalProcessTree, subagentCompletedBeforeReply, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
 
 const validEnv = {
   ZULIP_URL: "https://zulip.example.test/path",
@@ -390,15 +390,25 @@ test("requires subagent lifecycle completion before the parent reply", () => {
 });
 
 test("requires the poll's exact ordered choices and replies", () => {
-  const widget = { extra_data: { poll: true, heading: "question", choices: [
+  const widget = { widget_type: "zform", extra_data: { type: "choices", poll: true, heading: "question", choices: [
     { type: "multiple_choice", short_name: "a", long_name: "a", reply: "a" },
     { type: "multiple_choice", short_name: "b", long_name: "b", reply: "b" },
   ] } };
   assert.equal(isExactPoll(widget, "question", ["a", "b"]), true);
+  assert.equal(isExactPoll({ extra_data: widget.extra_data }, "question", ["a", "b"]), false);
+  assert.equal(isExactPoll({ ...widget, extra_data: { ...widget.extra_data, type: "buttons" } }, "question", ["a", "b"]), false);
   assert.equal(isExactPoll(widget, "question", ["b", "a"]), false);
   assert.equal(isExactPoll({ extra_data: { ...widget.extra_data, choices: [{ ...widget.extra_data.choices[0], reply: "wrong" }, widget.extra_data.choices[1]] } }, "question", ["a", "b"]), false);
   assert.equal(isExactPollMessage({ content: "<p>question</p>", widget_content: JSON.stringify(widget) }, "question", ["a", "b"]), true);
   assert.equal(isExactPollMessage({ content: "<p>question plus prose</p>", widget_content: widget }, "question", ["a", "b"]), false);
+});
+
+test("accepts only a standalone outbound upload without captions or local paths", () => {
+  assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/file.txt">file.txt</a></p>'), "/user_uploads/x/file.txt");
+  assert.equal(extractExactUploadUrl("/user_uploads/x/file.txt"), "/user_uploads/x/file.txt");
+  assert.equal(extractExactUploadUrl('<p>unrequested prose <a href="/user_uploads/x/file.txt">file.txt</a></p>'), undefined);
+  assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/file.txt">/tmp/file.txt</a></p>'), undefined);
+  assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/file.txt">file.txt</a></p><p>extra</p>'), undefined);
 });
 
 test("cancels a timed-out event wait", async () => {

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -1,8 +1,9 @@
 import assert from "node:assert/strict";
-import { EventEmitter } from "node:events";
+import { spawn } from "node:child_process";
+import { EventEmitter, once } from "node:events";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
-import { EventQueue, Gateway, isBotMessage, isExactPoll, lifecycleSummary, normalizeScenarioError, redactError, validateEnvironment } from "./run.mjs";
+import { EventQueue, Gateway, isBotMessage, isChildRunning, isExactPoll, lifecycleSummary, normalizeScenarioError, redactError, signalProcessTree, validateEnvironment, waitForProcessTreeExit } from "./run.mjs";
 
 const validEnv = {
   ZULIP_URL: "https://zulip.example.test/path",
@@ -80,17 +81,39 @@ test("coalesces concurrent event polls", async () => {
 test("waits for gateway exit after escalating to SIGKILL", async () => {
   const child = new EventEmitter();
   child.exitCode = null;
+  child.signalCode = null;
   const signals = [];
   child.kill = (signal) => {
     signals.push(signal);
     if (signal === "SIGKILL") setImmediate(() => { child.exitCode = 137; child.emit("exit", 137); });
     return true;
   };
-  const gateway = new Gateway(18789, { termTimeoutMs: 1, killTimeoutMs: 100 });
+  const gateway = new Gateway(18789, { termTimeoutMs: 1, killTimeoutMs: 100, healthProbe: async () => false });
   gateway.process = child;
   await Promise.all([gateway.stop(), gateway.stop()]);
   assert.deepEqual(signals, ["SIGTERM", "SIGKILL"]);
   assert.equal(gateway.process, undefined);
+});
+
+test("treats signal-terminated children as stopped", () => {
+  assert.equal(isChildRunning({ exitCode: null, signalCode: "SIGTERM" }), false);
+  assert.equal(isChildRunning({ exitCode: null, signalCode: null }), true);
+});
+
+test("terminates the complete detached process group", { skip: process.platform === "win32" }, async () => {
+  const child = spawn(process.execPath, ["-e", "process.on('SIGTERM',()=>{});process.send('ready');setInterval(()=>{},1000)"], {
+    detached: true,
+    stdio: ["ignore", "ignore", "ignore", "ipc"],
+  });
+  try {
+    await once(child, "message");
+    signalProcessTree(child, "SIGTERM");
+    assert.equal(await waitForProcessTreeExit(child, 100), false);
+    signalProcessTree(child, "SIGKILL");
+    assert.equal(await waitForProcessTreeExit(child, 2000), true);
+  } finally {
+    signalProcessTree(child, "SIGKILL");
+  }
 });
 
 test("workflow is manual, protected, pinned, and bounded", async () => {

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { isBotMessage, lifecycleSummary, redactError, validateEnvironment } from "./run.mjs";
+
+const validEnv = {
+  ZULIP_URL: "https://zulip.example.test/path",
+  ZULIP_SMOKE_USER_EMAIL: "user@example.test",
+  ZULIP_SMOKE_USER_API_KEY: "user-key",
+  ZULIP_SMOKE_BOT_EMAIL: "bot@example.test",
+  ZULIP_SMOKE_BOT_API_KEY: "bot-key",
+  ZULIP_SMOKE_STREAM: "smoke",
+  SMOKE_TESTED_SHA: "a".repeat(40),
+};
+
+test("validates protected configuration without returning URL paths", () => {
+  assert.equal(validateEnvironment(validEnv).ZULIP_URL, "https://zulip.example.test");
+  assert.throws(() => validateEnvironment({ ...validEnv, ZULIP_URL: "http://zulip.test" }), /HTTPS/);
+  assert.throws(() => validateEnvironment({ ...validEnv, ZULIP_SMOKE_USER_API_KEY: "" }), /protected configuration/);
+});
+
+test("redacts URLs and authorization values", () => {
+  const output = redactError(new Error("failed https://private.test/path?token=abc Basic abcdefghijklmnopqrstuvwxyz123456"));
+  assert.equal(output.includes("private.test"), false);
+  assert.equal(output.includes("abcdefghijklmnopqrstuvwxyz"), false);
+});
+
+test("matches only marked messages from the configured bot", () => {
+  const event = { type: "message", message: { sender_email: "bot@example.test", content: "marker" } };
+  assert.equal(isBotMessage(event, "bot@example.test", "marker"), true);
+  assert.equal(isBotMessage(event, "other@example.test", "marker"), false);
+});
+
+test("requires lifecycle and subagent reactions to be removed", () => {
+  const base = { type: "reaction", message_id: 42, emoji_name: "robot", emoji_code: "1f916", reaction_type: "unicode_emoji" };
+  assert.deepEqual(lifecycleSummary([{ ...base, op: "add" }, { ...base, op: "remove" }], "42"), {
+    added: [{ ...base, op: "add" }], allRemoved: true, sawSubagent: true,
+  });
+});
+
+test("workflow is manual, protected, pinned, and bounded", async () => {
+  const workflow = await readFile(new URL("../../.github/workflows/zulip-live-smoke.yml", import.meta.url), "utf8");
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.doesNotMatch(workflow, /pull_request:|\n\s+push:/);
+  assert.match(workflow, /environment: zulip-live-smoke/);
+  assert.match(workflow, /DISPATCH_REF.*github\.ref/);
+  assert.match(workflow, /DISPATCH_REF\" != \"refs\/heads\/main/);
+  assert.match(workflow, /merge-base --is-ancestor/);
+  assert.match(workflow, /permissions:\n\s+contents: read/);
+  assert.match(workflow, /timeout-minutes: 35/);
+  for (const use of workflow.matchAll(/uses:\s+([^\s]+)/g)) assert.match(use[1], /@[0-9a-f]{40}$/);
+});

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -3,7 +3,7 @@ import { spawn } from "node:child_process";
 import { EventEmitter, once } from "node:events";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
-import { buildApiUrl, EventQueue, Gateway, isBotMessage, isChildRunning, isExactPoll, isExactRenderedContent, isExactUtf8, isPrivateBotMessage, isPrivateTypingEvent, lifecycleSummary, normalizeScenarioError, redactError, resolveUploadUrl, signalProcessTree, validateEnvironment, waitForProcessTreeExit } from "./run.mjs";
+import { buildApiUrl, EventQueue, Gateway, isBotMessage, isChildRunning, isExactPoll, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, lifecycleSummary, normalizeScenarioError, redactError, resolveUploadUrl, signalProcessTree, validateEnvironment, waitForProcessTreeExit } from "./run.mjs";
 
 const validEnv = {
   ZULIP_URL: "https://zulip.example.test/path",
@@ -54,6 +54,9 @@ test("requires private bot replies with the expected participants", () => {
   assert.equal(isPrivateBotMessage(event, "bot@example.test", "user@example.test", "marker"), true);
   assert.equal(isPrivateBotMessage({ ...event, message: { ...event.message, type: "stream" } }, "bot@example.test", "user@example.test", "marker"), false);
   assert.equal(isPrivateBotMessage({ ...event, message: { ...event.message, display_recipient: [{ email: "bot@example.test" }] } }, "bot@example.test", "user@example.test", "marker"), false);
+  const uploadEvent = { ...event, message: { ...event.message, content: "[file](/user_uploads/a.txt)" } };
+  assert.equal(isPrivateBotEvent(uploadEvent, "bot@example.test", "user@example.test"), true);
+  assert.equal(isPrivateBotEvent({ ...uploadEvent, message: { ...uploadEvent.message, type: "stream" } }, "bot@example.test", "user@example.test"), false);
 });
 
 test("matches private typing events from the configured bot", () => {

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -5,7 +5,7 @@ import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { assertMessageRemainsExact, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, EventQueue, Gateway, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, lifecycleSummary, normalizeScenarioError, redactError, resolveUploadUrl, signalProcessTree, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
+import { assertMessageRemainsExact, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, EventQueue, Gateway, hasFinalPrivateTypingStop, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, lifecycleSummary, normalizeScenarioError, redactError, resolveUploadUrl, signalProcessTree, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
 
 const validEnv = {
   ZULIP_URL: "https://zulip.example.test/path",
@@ -71,6 +71,18 @@ test("matches private typing events from the configured bot", () => {
   assert.equal(isPrivateTypingEvent({ ...event, op: "stop" }, "bot@example.test", "user@example.test", "start"), false);
   assert.equal(isPrivateTypingEvent({ ...event, sender: { email: "other@example.test" } }, "bot@example.test", "user@example.test", "start"), false);
   assert.equal(isPrivateTypingEvent({ ...event, recipients: [...event.recipients, { email: "third@example.test" }] }, "bot@example.test", "user@example.test", "start"), false);
+});
+
+test("requires the final matching typing event to stop", () => {
+  const base = { type: "typing", message_type: "direct", sender: { email: "bot@example.test" }, recipients: [
+    { email: "bot@example.test" }, { email: "user@example.test" },
+  ] };
+  const start = { ...base, op: "start" };
+  const stop = { ...base, op: "stop" };
+  assert.equal(hasFinalPrivateTypingStop([start, stop], "bot@example.test", "user@example.test"), true);
+  assert.equal(hasFinalPrivateTypingStop([start, stop, start], "bot@example.test", "user@example.test"), false);
+  assert.equal(hasFinalPrivateTypingStop([stop], "bot@example.test", "user@example.test"), false);
+  assert.equal(hasFinalPrivateTypingStop([start, stop, { ...start, sender: { email: "other@example.test" } }], "bot@example.test", "user@example.test"), true);
 });
 
 test("matches complete raw or Zulip-rendered content", () => {

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -5,7 +5,7 @@ import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { assertFinalPrivateTypingStop, assertMessageRemainsExact, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, EventQueue, Gateway, hasFinalPrivateTypingStop, inspectChildTranscripts, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactPollMessage, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, lifecycleSummary, normalizeScenarioError, redactError, resolveUploadUrl, signalProcessTree, subagentCompletedBeforeReply, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
+import { assertFinalPrivateTypingStop, assertMessageRemainsExact, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, EventQueue, Gateway, hasFinalPrivateTypingStop, inspectChildTranscripts, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactPollMessage, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, isUsageCountedTranscriptName, lifecycleSummary, normalizeScenarioError, redactError, resolveUploadUrl, signalProcessTree, subagentCompletedBeforeReply, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
 
 const validEnv = {
   ZULIP_URL: "https://zulip.example.test/path",
@@ -243,6 +243,22 @@ test("requires the exact child result in an assistant transcript message", async
   } finally {
     await rm(stateDir, { recursive: true, force: true });
   }
+});
+
+test("matches only locked OpenClaw session transcript filenames", () => {
+  for (const name of [
+    "child.jsonl",
+    "child.jsonl.deleted.2026-08-30T19-00-00Z",
+    "child.jsonl.deleted.2026-08-30T19-00-00.000Z",
+    "child.jsonl.reset.2026-08-30T19-00-00.000Z",
+  ]) assert.equal(isUsageCountedTranscriptName(name), true, name);
+  for (const name of [
+    "child.jsonl.deleted.not-a-timestamp",
+    "child.jsonl.reset.2026-08-30T19-00-00.000Z.extra",
+    "child.jsonl.deleted.2026-08-30T19-00-00.00Z",
+    "child.trajectory.jsonl",
+    "child.checkpoint.11111111-1111-4111-8111-111111111111.jsonl",
+  ]) assert.equal(isUsageCountedTranscriptName(name), false, name);
 });
 
 test("counts message cleanup failures without skipping later deletions", async () => {

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -3,7 +3,7 @@ import { spawn } from "node:child_process";
 import { EventEmitter, once } from "node:events";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
-import { EventQueue, Gateway, isBotMessage, isChildRunning, isExactPoll, isExactRenderedContent, lifecycleSummary, normalizeScenarioError, redactError, signalProcessTree, validateEnvironment, waitForProcessTreeExit } from "./run.mjs";
+import { EventQueue, Gateway, isBotMessage, isChildRunning, isExactPoll, isExactRenderedContent, isExactUtf8, lifecycleSummary, normalizeScenarioError, redactError, signalProcessTree, validateEnvironment, waitForProcessTreeExit } from "./run.mjs";
 
 const validEnv = {
   ZULIP_URL: "https://zulip.example.test/path",
@@ -39,6 +39,15 @@ test("matches complete raw or Zulip-rendered content", () => {
   assert.equal(isExactRenderedContent("after", "after"), true);
   assert.equal(isExactRenderedContent("<p>after</p>", "after"), true);
   assert.equal(isExactRenderedContent("<p>prefix after suffix</p>", "after"), false);
+  assert.equal(isExactRenderedContent(" after ", "after"), false);
+  assert.equal(isExactRenderedContent("\n<p>after</p>\n", "after"), false);
+});
+
+test("compares downloaded upload contents as exact UTF-8 bytes", () => {
+  const exact = new TextEncoder().encode("marker");
+  assert.equal(isExactUtf8(exact, "marker"), true);
+  assert.equal(isExactUtf8(Uint8Array.from([0xef, 0xbb, 0xbf, ...exact]), "marker"), false);
+  assert.equal(isExactUtf8(Uint8Array.from([...exact, 0x0a]), "marker"), false);
 });
 
 test("requires lifecycle and subagent reactions to be removed", () => {

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -5,7 +5,7 @@ import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { assertFinalPrivateTypingStop, assertMessageRemainsExact, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, EventQueue, Gateway, hasFinalPrivateTypingStop, inspectChildTranscripts, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactPollMessage, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, isUsageCountedTranscriptName, lifecycleSummary, normalizeScenarioError, redactError, resolveUploadUrl, signalProcessTree, subagentCompletedBeforeReply, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
+import { assertFinalPrivateTypingStop, assertMessageRemainsExact, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, drainEventQueueUntilQuiet, EventQueue, Gateway, hasFinalPrivateTypingStop, inspectChildTranscripts, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactPollMessage, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, isUsageCountedTranscriptName, lifecycleSummary, normalizeScenarioError, redactError, resolveUploadUrl, signalProcessTree, subagentCompletedBeforeReply, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
 
 const validEnv = {
   ZULIP_URL: "https://zulip.example.test/path",
@@ -101,9 +101,35 @@ test("rechecks the final typing state after draining later events", async () => 
     },
   };
   await assert.rejects(
-    assertFinalPrivateTypingStop(queue, 0, "bot@example.test", "user@example.test", undefined, 0),
+    assertFinalPrivateTypingStop(queue, 0, "bot@example.test", "user@example.test", undefined, 10, 100, 0),
     /Final direct typing state was not stopped/,
   );
+});
+
+test("drains through a transient empty poll before checking terminal lifecycle state", async () => {
+  const base = { type: "reaction", message_id: 42, user_id: 7, reaction_type: "unicode_emoji" };
+  const events = [
+    { ...base, emoji_name: "robot", emoji_code: "1f916", op: "add" },
+    { ...base, emoji_name: "robot", emoji_code: "1f916", op: "remove" },
+  ];
+  const started = Date.now();
+  let terminalSent = false;
+  const queue = { events, async poll() {
+    if (!terminalSent && Date.now() - started >= 10) {
+      terminalSent = true;
+      const terminal = { ...base, emoji_name: "white_check_mark", emoji_code: "2705", op: "add" };
+      this.events.push(terminal);
+      return [terminal];
+    }
+    return [];
+  } };
+  await drainEventQueueUntilQuiet(queue, undefined, 30, 200, 5);
+  assert.equal(lifecycleSummary(queue.events, "42").allRemoved, false);
+});
+
+test("fails closed when the event queue never reaches a quiet window", async () => {
+  const queue = { events: [], async poll() { return [{ type: "message" }]; } };
+  await assert.rejects(drainEventQueueUntilQuiet(queue, undefined, 10, 25, 0), /stable quiet window/);
 });
 
 test("matches complete raw or Zulip-rendered content", () => {

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -408,6 +408,11 @@ test("accepts only a standalone outbound upload without captions or local paths"
   assert.equal(extractExactUploadUrl("/user_uploads/x/file.txt"), "/user_uploads/x/file.txt");
   assert.equal(extractExactUploadUrl('<p>unrequested prose <a href="/user_uploads/x/file.txt">file.txt</a></p>'), undefined);
   assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/file.txt">/tmp/file.txt</a></p>'), undefined);
+  assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/file.txt">/home/runner/work/repo/file.txt</a></p>'), undefined);
+  assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/file.txt">%2Froot%2Ffile.txt</a></p>'), undefined);
+  assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/file.txt">unrequested prose</a></p>'), undefined);
+  assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/My%20File.txt">My File.txt</a></p>'), "/user_uploads/x/My%20File.txt");
+  assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/file.txt">/user_uploads/x/file.txt</a></p>'), "/user_uploads/x/file.txt");
   assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/file.txt">file.txt</a></p><p>extra</p>'), undefined);
 });
 

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -5,7 +5,7 @@ import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { assertMessageRemainsExact, buildApiUrl, captureMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, EventQueue, Gateway, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, lifecycleSummary, normalizeScenarioError, redactError, resolveUploadUrl, signalProcessTree, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
+import { assertMessageRemainsExact, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, EventQueue, Gateway, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, lifecycleSummary, normalizeScenarioError, redactError, resolveUploadUrl, signalProcessTree, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
 
 const validEnv = {
   ZULIP_URL: "https://zulip.example.test/path",
@@ -101,6 +101,27 @@ test("captures every attributable reply id before an early failure", () => {
   const matches = captureMessageIds(events, (event) => event.message.content !== "unrelated", ids);
   assert.equal(matches.length, 2);
   assert.deepEqual([...ids], ["1", "2"]);
+});
+
+test("captures every observed in-run bot message while excluding already deleted messages", () => {
+  const dm = (id, content, sender = "bot@example.test") => ({ type: "message", message: {
+    id, type: "private", sender_email: sender, content, display_recipient: [
+      { email: "bot@example.test" }, { email: "user@example.test" },
+    ],
+  } });
+  const events = [
+    dm(1, "malformed extra output"),
+    dm(2, "already deleted"),
+    dm(3, "other sender", "other@example.test"),
+    { type: "message", message: { id: 4, type: "stream", sender_email: "bot@example.test", content: "wrong", display_recipient: "smoke", subject: "run-id-topic" } },
+    { type: "message", message: { id: 5, type: "stream", sender_email: "bot@example.test", content: "run-id marker", display_recipient: "other", subject: "other" } },
+  ];
+  const ids = new Set();
+  const matches = captureObservedSmokeBotMessageIds(events, {
+    botEmail: "bot@example.test", actorEmail: "user@example.test", stream: "smoke", runId: "run-id",
+  }, ids, new Set(["2"]));
+  assert.equal(matches.length, 3);
+  assert.deepEqual([...ids], ["1", "4", "5"]);
 });
 
 test("compares downloaded upload contents as exact UTF-8 bytes", () => {
@@ -314,6 +335,6 @@ test("workflow is manual, protected, pinned, and bounded", async () => {
   assert.match(workflow, /reserves robot and tada reactions for exact evidence/);
   assert.match(agentProtocol, /verify\nthat exact result/);
   assert.match(agentProtocol, /\.smoke-gateway-generation/);
-  assert.match(agentProtocol, /at least four\nseconds/);
+  assert.match(agentProtocol, /at least six\nseconds/);
   for (const use of workflow.matchAll(/uses:\s+([^\s]+)/g)) assert.match(use[1], /@[0-9a-f]{40}$/);
 });

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -5,7 +5,7 @@ import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { assertMessageRemainsExact, buildApiUrl, countCompletedChildTranscripts, countMessageDeletionFailures, EventQueue, Gateway, isBotMessage, isChildRunning, isExactPoll, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, lifecycleSummary, normalizeScenarioError, redactError, resolveUploadUrl, signalProcessTree, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
+import { assertMessageRemainsExact, buildApiUrl, countCompletedChildTranscripts, countMessageDeletionFailures, EventQueue, Gateway, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, lifecycleSummary, normalizeScenarioError, redactError, resolveUploadUrl, signalProcessTree, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
 
 const validEnv = {
   ZULIP_URL: "https://zulip.example.test/path",
@@ -81,6 +81,16 @@ test("matches complete raw or Zulip-rendered content", () => {
   assert.equal(isExactRenderedContent("\n<p>after</p>\n", "after"), false);
 });
 
+test("attributes every configured-bot DM containing the unique durable marker", () => {
+  const base = { type: "message", message: { type: "private", sender_email: "bot@example.test", display_recipient: [
+    { email: "bot@example.test" }, { email: "user@example.test" },
+  ] } };
+  for (const content of ["durable-marker", "durable-marker:old", "<p>durable-marker:wrong</p>", "prefix durable-marker suffix"]) {
+    assert.equal(isDurableReplyEvent({ ...base, message: { ...base.message, content } }, "bot@example.test", "user@example.test", "durable-marker"), true);
+  }
+  assert.equal(isDurableReplyEvent({ ...base, message: { ...base.message, sender_email: "other@example.test", content: "durable-marker" } }, "bot@example.test", "user@example.test", "durable-marker"), false);
+});
+
 test("compares downloaded upload contents as exact UTF-8 bytes", () => {
   const exact = new TextEncoder().encode("marker");
   assert.equal(isExactUtf8(exact, "marker"), true);
@@ -132,6 +142,19 @@ test("requires the exact child result in an assistant transcript message", async
       JSON.stringify({ message: { role: "assistant", content: [{ type: "text", text: marker }] } }),
     ].join("\n"));
     assert.equal(await countCompletedChildTranscripts(stateDir, marker), 1);
+    await writeFile(join(sessionsDir, "child.jsonl"), [
+      JSON.stringify({ message: { role: "user", content: `[Subagent Task] reply ${marker}` } }),
+      JSON.stringify({ message: { role: "assistant", content: [
+        { type: "text", text: marker }, { type: "text", text: "WRONG-EXTRA" },
+      ] } }),
+    ].join("\n"));
+    assert.equal(await countCompletedChildTranscripts(stateDir, marker), 0);
+    await writeFile(join(sessionsDir, "child.jsonl"), [
+      JSON.stringify({ message: { role: "user", content: `[Subagent Task] reply ${marker}` } }),
+      JSON.stringify({ message: { role: "assistant", content: [{ type: "text", text: marker }] } }),
+      JSON.stringify({ message: { role: "assistant", content: [{ type: "text", text: "WRONG-LATER" }] } }),
+    ].join("\n"));
+    assert.equal(await countCompletedChildTranscripts(stateDir, marker), 0);
   } finally {
     await rm(stateDir, { recursive: true, force: true });
   }

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -3,7 +3,7 @@ import { spawn } from "node:child_process";
 import { EventEmitter, once } from "node:events";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
-import { EventQueue, Gateway, isBotMessage, isChildRunning, isExactPoll, lifecycleSummary, normalizeScenarioError, redactError, signalProcessTree, validateEnvironment, waitForProcessTreeExit } from "./run.mjs";
+import { EventQueue, Gateway, isBotMessage, isChildRunning, isExactPoll, isExactRenderedContent, lifecycleSummary, normalizeScenarioError, redactError, signalProcessTree, validateEnvironment, waitForProcessTreeExit } from "./run.mjs";
 
 const validEnv = {
   ZULIP_URL: "https://zulip.example.test/path",
@@ -33,6 +33,12 @@ test("matches only marked messages from the configured bot", () => {
   assert.equal(isBotMessage({ ...event, message: { ...event.message, content: "<p>marker</p>" } }, "bot@example.test", "marker"), true);
   assert.equal(isBotMessage({ ...event, message: { ...event.message, content: "prefix marker" } }, "bot@example.test", "marker"), false);
   assert.equal(isBotMessage(event, "other@example.test", "marker"), false);
+});
+
+test("matches complete raw or Zulip-rendered content", () => {
+  assert.equal(isExactRenderedContent("after", "after"), true);
+  assert.equal(isExactRenderedContent("<p>after</p>", "after"), true);
+  assert.equal(isExactRenderedContent("<p>prefix after suffix</p>", "after"), false);
 });
 
 test("requires lifecycle and subagent reactions to be removed", () => {

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -419,6 +419,12 @@ test("accepts only a standalone outbound upload without captions or local paths"
   assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/file.txt?source=/home/runner/file.txt">/user_uploads/x/file.txt?source=/home/runner/file.txt</a></p>'), undefined);
   assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/file.txt#/home/runner/file.txt">/user_uploads/x/file.txt#/home/runner/file.txt</a></p>'), undefined);
   assert.equal(extractExactUploadUrl("/user_uploads/x/file.txt?source=%252Fhome%252Frunner"), undefined);
+  assert.equal(extractExactUploadUrl("/user_uploads/x/%2Froot%2Fsecret.txt"), undefined);
+  assert.equal(extractExactUploadUrl("/user_uploads/x/%252Froot%252Fsecret.txt"), undefined);
+  assert.equal(extractExactUploadUrl("/user_uploads/x/..%252Fsecret.txt"), undefined);
+  assert.equal(extractExactUploadUrl("/user_uploads/x/%255Chome%255Csecret.txt"), undefined);
+  assert.equal(extractExactUploadUrl("/user_uploads/x/%2500secret.txt"), undefined);
+  assert.equal(extractExactUploadUrl("/user_uploads/x/%ZZ.txt"), undefined);
   assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/%ZZ.txt">%ZZ.txt</a></p>'), undefined);
   assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/100%.txt">100%.txt</a></p>'), undefined);
   assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/file.txt">unrequested prose</a></p>'), undefined);

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -221,6 +221,8 @@ test("workflow is manual, protected, pinned, and bounded", async () => {
     assert.match(liveStep, new RegExp(`secrets\\.${secret}`));
     assert.doesNotMatch(prepareStep, new RegExp(`secrets\\.${secret}`));
   }
+  assert.match(workflow, /Protected smoke config must disable stream mention gating/);
   assert.match(workflow, /Protected smoke config must use the robot subagent reaction/);
+  assert.match(workflow, /reserves robot and tada reactions for exact evidence/);
   for (const use of workflow.matchAll(/uses:\s+([^\s]+)/g)) assert.match(use[1], /@[0-9a-f]{40}$/);
 });

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -5,7 +5,7 @@ import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { assertMessageRemainsExact, buildApiUrl, countCompletedChildTranscripts, countMessageDeletionFailures, EventQueue, Gateway, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, lifecycleSummary, normalizeScenarioError, redactError, resolveUploadUrl, signalProcessTree, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
+import { assertMessageRemainsExact, buildApiUrl, captureMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, EventQueue, Gateway, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, lifecycleSummary, normalizeScenarioError, redactError, resolveUploadUrl, signalProcessTree, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
 
 const validEnv = {
   ZULIP_URL: "https://zulip.example.test/path",
@@ -89,6 +89,18 @@ test("attributes every configured-bot DM containing the unique durable marker", 
     assert.equal(isDurableReplyEvent({ ...base, message: { ...base.message, content } }, "bot@example.test", "user@example.test", "durable-marker"), true);
   }
   assert.equal(isDurableReplyEvent({ ...base, message: { ...base.message, sender_email: "other@example.test", content: "durable-marker" } }, "bot@example.test", "user@example.test", "durable-marker"), false);
+});
+
+test("captures every attributable reply id before an early failure", () => {
+  const ids = new Set();
+  const events = [
+    { message: { id: 1, content: "wrong" } },
+    { message: { id: 2, content: "valid" } },
+    { message: { id: 3, content: "unrelated" } },
+  ];
+  const matches = captureMessageIds(events, (event) => event.message.content !== "unrelated", ids);
+  assert.equal(matches.length, 2);
+  assert.deepEqual([...ids], ["1", "2"]);
 });
 
 test("compares downloaded upload contents as exact UTF-8 bytes", () => {

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
-import { EventQueue, isBotMessage, lifecycleSummary, normalizeScenarioError, redactError, validateEnvironment } from "./run.mjs";
+import { EventQueue, isBotMessage, isExactPoll, lifecycleSummary, normalizeScenarioError, redactError, validateEnvironment } from "./run.mjs";
 
 const validEnv = {
   ZULIP_URL: "https://zulip.example.test/path",
@@ -28,14 +28,28 @@ test("redacts URLs and authorization values", () => {
 test("matches only marked messages from the configured bot", () => {
   const event = { type: "message", message: { sender_email: "bot@example.test", content: "marker" } };
   assert.equal(isBotMessage(event, "bot@example.test", "marker"), true);
+  assert.equal(isBotMessage({ ...event, message: { ...event.message, content: "<p>marker</p>" } }, "bot@example.test", "marker"), true);
+  assert.equal(isBotMessage({ ...event, message: { ...event.message, content: "prefix marker" } }, "bot@example.test", "marker"), false);
   assert.equal(isBotMessage(event, "other@example.test", "marker"), false);
 });
 
 test("requires lifecycle and subagent reactions to be removed", () => {
-  const base = { type: "reaction", message_id: 42, emoji_name: "robot", emoji_code: "1f916", reaction_type: "unicode_emoji" };
+  const base = { type: "reaction", message_id: 42, user_id: 7, emoji_name: "robot", emoji_code: "1f916", reaction_type: "unicode_emoji" };
   assert.deepEqual(lifecycleSummary([{ ...base, op: "add" }, { ...base, op: "remove" }], "42"), {
     added: [{ ...base, op: "add" }], allRemoved: true, sawSubagent: true,
   });
+  assert.equal(lifecycleSummary([{ ...base, op: "add" }, { ...base, op: "remove" }, { ...base, op: "add" }], "42").allRemoved, false);
+  assert.equal(lifecycleSummary([{ ...base, op: "add" }, { ...base, user_id: 8, op: "add" }, { ...base, op: "remove" }], "42").allRemoved, false);
+});
+
+test("requires the poll's exact ordered choices and replies", () => {
+  const widget = { extra_data: { poll: true, heading: "question", choices: [
+    { type: "multiple_choice", short_name: "a", long_name: "a", reply: "a" },
+    { type: "multiple_choice", short_name: "b", long_name: "b", reply: "b" },
+  ] } };
+  assert.equal(isExactPoll(widget, "question", ["a", "b"]), true);
+  assert.equal(isExactPoll(widget, "question", ["b", "a"]), false);
+  assert.equal(isExactPoll({ extra_data: { ...widget.extra_data, choices: [{ ...widget.extra_data.choices[0], reply: "wrong" }, widget.extra_data.choices[1]] } }, "question", ["a", "b"]), false);
 });
 
 test("cancels a timed-out event wait", async () => {

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -3,7 +3,7 @@ import { spawn } from "node:child_process";
 import { EventEmitter, once } from "node:events";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
-import { buildApiUrl, EventQueue, Gateway, isBotMessage, isChildRunning, isExactPoll, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, lifecycleSummary, normalizeScenarioError, redactError, resolveUploadUrl, signalProcessTree, validateEnvironment, waitForProcessTreeExit } from "./run.mjs";
+import { buildApiUrl, countMessageDeletionFailures, EventQueue, Gateway, isBotMessage, isChildRunning, isExactPoll, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, lifecycleSummary, normalizeScenarioError, redactError, resolveUploadUrl, signalProcessTree, validateEnvironment, waitForProcessTreeExit } from "./run.mjs";
 
 const validEnv = {
   ZULIP_URL: "https://zulip.example.test/path",
@@ -83,6 +83,16 @@ test("compares downloaded upload contents as exact UTF-8 bytes", () => {
   assert.equal(isExactUtf8(exact, "marker"), true);
   assert.equal(isExactUtf8(Uint8Array.from([0xef, 0xbb, 0xbf, ...exact]), "marker"), false);
   assert.equal(isExactUtf8(Uint8Array.from([...exact, 0x0a]), "marker"), false);
+});
+
+test("counts message cleanup failures without skipping later deletions", async () => {
+  const attempted = [];
+  const client = { request: async (path) => {
+    attempted.push(path);
+    if (path.endsWith("/2")) throw new Error("synthetic cleanup failure");
+  } };
+  assert.equal(await countMessageDeletionFailures(client, ["1", "2", "3"]), 1);
+  assert.deepEqual(attempted, ["messages/1", "messages/2", "messages/3"]);
 });
 
 test("requires lifecycle and subagent reactions to be removed", () => {
@@ -195,5 +205,22 @@ test("workflow is manual, protected, pinned, and bounded", async () => {
   assert.match(workflow, /merge-base --is-ancestor/);
   assert.match(workflow, /permissions:\n\s+contents: read/);
   assert.match(workflow, /timeout-minutes: 35/);
+  assert.doesNotMatch(workflow, /timeout-minutes: 35\n\s+env:/);
+  const prepareStep = workflow.slice(
+    workflow.indexOf("- name: Prepare isolated OpenClaw state"),
+    workflow.indexOf("- name: Run bounded live scenarios"),
+  );
+  const liveStep = workflow.slice(
+    workflow.indexOf("- name: Run bounded live scenarios"),
+    workflow.indexOf("- name: Record release evidence"),
+  );
+  assert.equal(workflow.match(/secrets\.OPENCLAW_SMOKE_CONFIG_JSON/g)?.length, 1);
+  assert.match(prepareStep, /secrets\.OPENCLAW_SMOKE_CONFIG_JSON/);
+  for (const secret of ["ZULIP_URL", "ZULIP_SMOKE_USER_EMAIL", "ZULIP_SMOKE_USER_API_KEY", "ZULIP_SMOKE_BOT_EMAIL", "ZULIP_SMOKE_BOT_API_KEY"]) {
+    assert.equal(workflow.match(new RegExp(`secrets\\.${secret}`, "g"))?.length, 1);
+    assert.match(liveStep, new RegExp(`secrets\\.${secret}`));
+    assert.doesNotMatch(prepareStep, new RegExp(`secrets\\.${secret}`));
+  }
+  assert.match(workflow, /Protected smoke config must use the robot subagent reaction/);
   for (const use of workflow.matchAll(/uses:\s+([^\s]+)/g)) assert.match(use[1], /@[0-9a-f]{40}$/);
 });

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
-import { EventQueue, isBotMessage, isExactPoll, lifecycleSummary, normalizeScenarioError, redactError, validateEnvironment } from "./run.mjs";
+import { EventQueue, Gateway, isBotMessage, isExactPoll, lifecycleSummary, normalizeScenarioError, redactError, validateEnvironment } from "./run.mjs";
 
 const validEnv = {
   ZULIP_URL: "https://zulip.example.test/path",
@@ -74,6 +75,22 @@ test("coalesces concurrent event polls", async () => {
   resolveRequest({ events: [{ id: 1, type: "message" }] });
   await Promise.all([first, second]);
   assert.equal(queue.events.length, 1);
+});
+
+test("waits for gateway exit after escalating to SIGKILL", async () => {
+  const child = new EventEmitter();
+  child.exitCode = null;
+  const signals = [];
+  child.kill = (signal) => {
+    signals.push(signal);
+    if (signal === "SIGKILL") setImmediate(() => { child.exitCode = 137; child.emit("exit", 137); });
+    return true;
+  };
+  const gateway = new Gateway(18789, { termTimeoutMs: 1, killTimeoutMs: 100 });
+  gateway.process = child;
+  await Promise.all([gateway.stop(), gateway.stop()]);
+  assert.deepEqual(signals, ["SIGTERM", "SIGKILL"]);
+  assert.equal(gateway.process, undefined);
 });
 
 test("workflow is manual, protected, pinned, and bounded", async () => {

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -416,6 +416,11 @@ test("accepts only a standalone outbound upload without captions or local paths"
   assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/%252Froot%25.txt">%2Froot%.txt</a></p>'), undefined);
   assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/..%252Fsecret%25.txt">..%2Fsecret%.txt</a></p>'), undefined);
   assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/%255Chome%25ZZ.txt">%5Chome%ZZ.txt</a></p>'), undefined);
+  assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/file.txt?source=/home/runner/file.txt">/user_uploads/x/file.txt?source=/home/runner/file.txt</a></p>'), undefined);
+  assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/file.txt#/home/runner/file.txt">/user_uploads/x/file.txt#/home/runner/file.txt</a></p>'), undefined);
+  assert.equal(extractExactUploadUrl("/user_uploads/x/file.txt?source=%252Fhome%252Frunner"), undefined);
+  assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/%ZZ.txt">%ZZ.txt</a></p>'), undefined);
+  assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/100%.txt">100%.txt</a></p>'), undefined);
   assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/file.txt">unrequested prose</a></p>'), undefined);
   assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/My%20File.txt">My File.txt</a></p>'), "/user_uploads/x/My%20File.txt");
   assert.equal(extractExactUploadUrl('<p><a href="/user_uploads/x/file.txt">/user_uploads/x/file.txt</a></p>'), "/user_uploads/x/file.txt");

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { EventEmitter, once } from "node:events";
-import { readFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
-import { buildApiUrl, countMessageDeletionFailures, EventQueue, Gateway, isBotMessage, isChildRunning, isExactPoll, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, lifecycleSummary, normalizeScenarioError, redactError, resolveUploadUrl, signalProcessTree, validateEnvironment, waitForProcessTreeExit } from "./run.mjs";
+import { assertMessageRemainsExact, buildApiUrl, countCompletedChildTranscripts, countMessageDeletionFailures, EventQueue, Gateway, isBotMessage, isChildRunning, isExactPoll, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, lifecycleSummary, normalizeScenarioError, redactError, resolveUploadUrl, signalProcessTree, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
 
 const validEnv = {
   ZULIP_URL: "https://zulip.example.test/path",
@@ -13,6 +15,7 @@ const validEnv = {
   ZULIP_SMOKE_BOT_API_KEY: "bot-key",
   ZULIP_SMOKE_STREAM: "smoke",
   SMOKE_TESTED_SHA: "a".repeat(40),
+  OPENCLAW_STATE_DIR: "/tmp/openclaw-smoke-state",
 };
 
 test("validates protected configuration while preserving base paths", () => {
@@ -85,6 +88,55 @@ test("compares downloaded upload contents as exact UTF-8 bytes", () => {
   assert.equal(isExactUtf8(Uint8Array.from([...exact, 0x0a]), "marker"), false);
 });
 
+test("requires an edited message to remain readable with exact content", async () => {
+  const calls = [];
+  const client = { request: async (path) => {
+    calls.push({ path, at: Date.now() });
+    return { message: { content: "<p>after</p>" } };
+  } };
+  await assertMessageRemainsExact(client, "42", "after", 10);
+  assert.equal(calls.length, 2);
+  assert.equal(calls[1].at - calls[0].at >= 9, true);
+  await assert.rejects(
+    assertMessageRemainsExact({ request: async () => ({ message: { content: "wrong" } }) }, "42", "after", 0),
+    /not readable/,
+  );
+});
+
+test("writes exact gateway-generation evidence with private permissions", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "zulip-smoke-generation-"));
+  const path = join(stateDir, "generation");
+  try {
+    await writeGatewayGeneration(path, "abc123");
+    assert.equal(await readFile(path, "utf8"), "abc123");
+    const { mode } = await stat(path);
+    assert.equal(mode & 0o777, 0o600);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("requires the exact child result in an assistant transcript message", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "zulip-smoke-transcript-"));
+  const sessionsDir = join(stateDir, "agents", "main", "sessions");
+  const marker = "unique-child-result";
+  await mkdir(sessionsDir, { recursive: true });
+  try {
+    await writeFile(join(sessionsDir, "parent.jsonl"), `${JSON.stringify({ message: { role: "assistant", content: [
+      { type: "toolCall", arguments: { task: `reply ${marker}` } },
+    ] } })}\n`);
+    assert.equal(await countCompletedChildTranscripts(stateDir, marker), 0);
+    await writeFile(join(sessionsDir, "child.jsonl"), [
+      JSON.stringify({ message: { role: "user", content: `[Subagent Task] reply ${marker}` } }),
+      "malformed",
+      JSON.stringify({ message: { role: "assistant", content: [{ type: "text", text: marker }] } }),
+    ].join("\n"));
+    assert.equal(await countCompletedChildTranscripts(stateDir, marker), 1);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
 test("counts message cleanup failures without skipping later deletions", async () => {
   const attempted = [];
   const client = { request: async (path) => {
@@ -98,7 +150,7 @@ test("counts message cleanup failures without skipping later deletions", async (
 test("requires lifecycle and subagent reactions to be removed", () => {
   const base = { type: "reaction", message_id: 42, user_id: 7, emoji_name: "robot", emoji_code: "1f916", reaction_type: "unicode_emoji" };
   assert.deepEqual(lifecycleSummary([{ ...base, op: "add" }, { ...base, op: "remove" }], "42"), {
-    added: [{ ...base, op: "add" }], allRemoved: true, sawSubagent: true,
+    added: [{ ...base, op: "add" }], allRemoved: true, sawSubagent: true, subagentCount: 1,
   });
   assert.equal(lifecycleSummary([{ ...base, op: "add" }, { ...base, op: "remove" }, { ...base, op: "add" }], "42").allRemoved, false);
   assert.equal(lifecycleSummary([{ ...base, op: "add" }, { ...base, user_id: 8, op: "add" }, { ...base, op: "remove" }], "42").allRemoved, false);
@@ -197,6 +249,7 @@ test("terminates the complete detached process group", { skip: process.platform 
 
 test("workflow is manual, protected, pinned, and bounded", async () => {
   const workflow = await readFile(new URL("../../.github/workflows/zulip-live-smoke.yml", import.meta.url), "utf8");
+  const agentProtocol = await readFile(new URL("./agent-workspace/AGENTS.md", import.meta.url), "utf8");
   assert.match(workflow, /workflow_dispatch:/);
   assert.doesNotMatch(workflow, /pull_request:|\n\s+push:/);
   assert.match(workflow, /environment: zulip-live-smoke/);
@@ -224,5 +277,8 @@ test("workflow is manual, protected, pinned, and bounded", async () => {
   assert.match(workflow, /Protected smoke config must disable stream mention gating/);
   assert.match(workflow, /Protected smoke config must use the robot subagent reaction/);
   assert.match(workflow, /reserves robot and tada reactions for exact evidence/);
+  assert.match(agentProtocol, /verify\nthat exact result/);
+  assert.match(agentProtocol, /\.smoke-gateway-generation/);
+  assert.match(agentProtocol, /at least four\nseconds/);
   for (const use of workflow.matchAll(/uses:\s+([^\s]+)/g)) assert.match(use[1], /@[0-9a-f]{40}$/);
 });


### PR DESCRIPTION
## Summary

- add a manual protected Zulip live-smoke workflow with a main-reachability trust gate
- exercise DM, stream/topic, typing/lifecycle, reaction, edit/delete, upload/download, poll/interactive, and durable replay/dedup scenarios
- add bounded cancellation, process-group restart verification with generation-bound replay proof and server-timestamp delay evidence, reentrancy-safe event polling, exact child-transcript, reaction-order, native-poll, canonical-upload, and edit-visibility evidence, reserved evidence reactions, enforced no-mention stream delivery, step-scoped secrets, failure-visible cleanup, offline verification, and release evidence documentation

## Verification

- Node 22.23.1: `pnpm run test:live-smoke:offline` (36 passed)
- Node 22.23.1: `pnpm run build`
- Node 22.23.1: `pnpm test` (209 Vitest + 36 offline smoke tests passed)
- independent exact-SHA review approved with no findings

## Rollout note

Implements #24, but does not close it. The issue must remain open until the `zulip-live-smoke` protected environment is provisioned and the first successful run URL and tested SHA are recorded.
