### PR TITLE
feat(zulip): add per-stream inbound policy overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+- **Per-stream inbound policy**: Add deterministic name/ID `streamOverrides` for inbound activation, mention requirements, and allowed/excluded topics while preserving legacy `streams`, `topics`, and `streamTopics` behavior.
+- **Early inbound filtering**: Resolve stream policy before durable acceptance, attachment downloads, reactions, typing, routing, or agent dispatch. Outbound access remains independent.
+
 ## 2026.5.26
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -124,6 +124,18 @@ Add the plugin id to `plugins.allow` in `~/.openclaw/openclaw.json`:
         "42": ["bot help"]
       },
 
+      // Optional inbound-only policy overrides. ASCII decimal keys select
+      // stream IDs; every other key selects a normalized stream name.
+      "streamOverrides": {
+        "general": {
+          "enabled": true,
+          "requireMention": false,
+          "allowedTopics": ["support", "bot help"],
+          "excludedTopics": ["private"]
+        },
+        "42": { "enabled": false }
+      },
+
       // Default topic for outbound messages with no explicit topic
       "defaultTopic": "bot replies",
 
@@ -184,6 +196,39 @@ Then restart the Gateway:
 ```sh
 openclaw gateway restart
 ```
+
+### Per-stream inbound policy and migration
+
+Existing configurations do not need changes. `streams`, `topics`, and
+`streamTopics` keep their previous behavior. `streams` remains the legacy
+inbound allowlist, while `streamTopics` further restricts the account-level
+`topics` allowlist.
+
+`streamOverrides` adds field-by-field inbound overrides with this precedence:
+
+1. Account defaults (`requireMention`/`chatmode` and `topics`).
+2. Legacy `streams` activation and the additional `streamTopics` restriction.
+3. A matching normalized stream-name override.
+4. A matching decimal stream-ID override.
+
+An omitted field inherits the lower-precedence value. An explicit
+`enabled: true` may activate a stream outside `streams`; `enabled: false`
+disables inbound handling. `allowedTopics` replaces lower-precedence allowed
+topic filters when set. Empty `allowedTopics`, or one containing `"*"`, allows
+all topics. `excludedTopics` is applied afterward, so exclusions win;
+`["*"]` excludes every topic.
+
+Names are trimmed and matched case-insensitively against the authoritative
+name on the Zulip message. Keys containing only ASCII digits are always IDs;
+leading zeroes are canonicalized, so `"017"` selects ID 17. Values such as
+`"1e3"`, `"0x11"`, and `"+17"` are names, never coerced IDs. Duplicate keys
+after normalization are rejected. ID rules are the safest choice across
+stream renames. A replayed message never uses its historical name when current
+stream metadata is unavailable.
+
+These rules govern inbound activation only. Outbound send, read, search, and
+administrative actions remain available according to their existing access
+controls.
 
 ### Lifecycle reactions
 
@@ -249,6 +294,7 @@ Common setups that intentionally produce no visible stream reply:
 - `groupPolicy: "allowlist"` requires the sender to match `groupAllowFrom`; if the sender is not allowed, the message is ignored.
 - `chatmode: "oncall"` or `requireMention: true` means the bot only replies when it is mentioned.
 - `topics` or `streamTopics` filters only allow matching topics; messages in other topics are ignored.
+- A matching `streamOverrides` rule can disable the stream, change its mention requirement, or allow/exclude topics.
 
 For the simplest “reply in monitored streams” setup, use `groupPolicy: "open"` with the stream listed in `streams`, then add mention or topic filters only after the basic path works.
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -70,6 +70,16 @@
               "errorHoldMs": { "type": "integer", "minimum": 0 }
             }
           },
+          "zulipStreamRule": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "enabled": { "type": "boolean" },
+              "requireMention": { "type": "boolean" },
+              "allowedTopics": { "type": "array", "items": { "type": "string" } },
+              "excludedTopics": { "type": "array", "items": { "type": "string" } }
+            }
+          },
           "zulipAccount": {
             "type": "object",
             "additionalProperties": true,
@@ -96,6 +106,10 @@
               "streamTopics": {
                 "type": "object",
                 "additionalProperties": { "type": "array", "items": { "type": "string" } }
+              },
+              "streamOverrides": {
+                "type": "object",
+                "additionalProperties": { "$ref": "#/$defs/zulipStreamRule" }
               },
               "defaultTopic": { "type": "string" },
               "chatmode": { "type": "string", "enum": ["oncall", "onmessage", "onchar"] },
@@ -162,6 +176,10 @@
           "streamTopics": {
             "type": "object",
             "additionalProperties": { "type": "array", "items": { "type": "string" } }
+          },
+          "streamOverrides": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#/$defs/zulipStreamRule" }
           },
           "defaultTopic": { "type": "string" },
           "chatmode": { "type": "string", "enum": ["oncall", "onmessage", "onchar"] },
@@ -231,6 +249,11 @@
         "streamTopics": {
           "label": "Per-Stream Topic Filters",
           "placeholder": "{\"general\":[\"support\"]}"
+        },
+        "streamOverrides": {
+          "label": "Per-Stream Inbound Overrides",
+          "description": "Inbound-only rules keyed by trimmed, case-insensitive stream name or an ASCII decimal stream ID. ID rules take precedence over name rules.",
+          "placeholder": "{\"general\":{\"enabled\":true,\"requireMention\":false,\"allowedTopics\":[\"support\"]}}"
         },
         "defaultTopic": {
           "label": "Default Topic",

--- a/src/config-schema.test.ts
+++ b/src/config-schema.test.ts
@@ -3,6 +3,38 @@ import { describe, expect, it } from "vitest";
 import { zulipChannelConfigSchema } from "./config-schema.js";
 
 describe("Zulip lifecycle reaction config", () => {
+  it("accepts strict per-stream inbound policy fields", () => {
+    const result = zulipChannelConfigSchema.runtime.safeParse({
+      streamOverrides: {
+        General: {
+          enabled: false,
+          requireMention: true,
+          allowedTopics: ["support"],
+          excludedTopics: ["private"],
+        },
+        "42": { enabled: true },
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects unknown per-stream inbound policy fields", () => {
+    expect(
+      zulipChannelConfigSchema.runtime.safeParse({
+        streamOverrides: { general: { outboundEnabled: false } },
+      }).success,
+    ).toBe(false);
+  });
+
+  it.each([
+    { " ": { enabled: true } },
+    { General: { enabled: true }, " general ": { enabled: false } },
+    { "17": { enabled: true }, "017": { enabled: false } },
+  ])("rejects empty or canonically duplicate stream selectors", (streamOverrides) => {
+    expect(zulipChannelConfigSchema.runtime.safeParse({ streamOverrides }).success).toBe(false);
+  });
+
   it("accepts lifecycle emoji, timing, and subagent overrides", () => {
     const result = zulipChannelConfigSchema.runtime.safeParse({
       reactions: {
@@ -83,6 +115,32 @@ describe("Zulip lifecycle reaction config", () => {
     for (const value of ["+", "-", ":+:", ":-:", ":+1", "+1:", "white space", "🦄"]) {
       expect(accepts(value)).toBe(false);
     }
+  });
+
+  it("keeps manifest stream override fields aligned with runtime validation", () => {
+    const manifest = JSON.parse(
+      fs.readFileSync(new URL("../openclaw.plugin.json", import.meta.url), "utf8"),
+    ) as {
+      channelConfigs: {
+        zulip: {
+          schema: {
+            $defs: { zulipAccount: { properties: Record<string, unknown> }; zulipStreamRule: { properties: Record<string, unknown> } };
+            properties: Record<string, unknown>;
+          };
+          uiHints: Record<string, unknown>;
+        };
+      };
+    };
+    const channelConfig = manifest.channelConfigs.zulip;
+    expect(Object.keys(channelConfig.schema.$defs.zulipStreamRule.properties).sort()).toEqual([
+      "allowedTopics",
+      "enabled",
+      "excludedTopics",
+      "requireMention",
+    ]);
+    expect(channelConfig.schema.properties).toHaveProperty("streamOverrides");
+    expect(channelConfig.schema.$defs.zulipAccount.properties).toHaveProperty("streamOverrides");
+    expect(channelConfig.uiHints).toHaveProperty("streamOverrides");
   });
 
   it("rejects arbitrary Unicode reaction values", () => {

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -2,6 +2,10 @@ import { z } from "zod";
 import { buildJsonChannelConfigSchema } from "openclaw/plugin-sdk/channel-config-schema";
 import { buildOptionalSecretInputSchema } from "openclaw/plugin-sdk/secret-input";
 import { isSupportedZulipReactionValue } from "./zulip/status-reactions.js";
+import {
+  normalizeZulipStreamIdSelector,
+  normalizeZulipStreamName,
+} from "./zulip/stream-policy.js";
 
 // Inlined from openclaw/plugin-sdk to avoid module resolution issues
 // when installed via npm to ~/.openclaw/extensions/. These are stable
@@ -51,6 +55,44 @@ const StatusReactionTimingSchema = z
     errorHoldMs: z.number().int().nonnegative().optional(),
   })
   .strict();
+const ZulipStreamRuleSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    requireMention: z.boolean().optional(),
+    allowedTopics: z.array(z.string()).optional(),
+    excludedTopics: z.array(z.string()).optional(),
+  })
+  .strict();
+const ZulipStreamOverridesSchema = z
+  .record(z.string(), ZulipStreamRuleSchema)
+  .superRefine((overrides, ctx) => {
+    const selectors = new Map<string, string>();
+    for (const key of Object.keys(overrides)) {
+      const normalizedId = normalizeZulipStreamIdSelector(key);
+      const normalizedName = normalizeZulipStreamName(key);
+      if (!normalizedName) {
+        ctx.addIssue({
+          code: "custom",
+          path: [key],
+          message: "Stream override selectors cannot be empty",
+        });
+        continue;
+      }
+      const selector = normalizedId !== undefined
+        ? `id:${normalizedId}`
+        : `name:${normalizedName}`;
+      const existing = selectors.get(selector);
+      if (existing !== undefined) {
+        ctx.addIssue({
+          code: "custom",
+          path: [key],
+          message: `Stream override selector duplicates ${JSON.stringify(existing)} after normalization`,
+        });
+      } else {
+        selectors.set(selector, key);
+      }
+    }
+  });
 
 const OptionalSecretInputSchema = buildOptionalSecretInputSchema();
 
@@ -101,6 +143,7 @@ const ZulipAccountSchemaBase = z
     streams: z.array(z.string()).optional(),
     topics: z.array(z.string()).optional(),
     streamTopics: z.record(z.string(), z.array(z.string())).optional(),
+    streamOverrides: ZulipStreamOverridesSchema.optional(),
     defaultTopic: z.string().optional(),
     chatmode: z.enum(["oncall", "onmessage", "onchar"]).optional(),
     oncharPrefixes: z.array(z.string()).optional(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,17 @@ type BlockStreamingCoalesceConfig = {
 export type ZulipChatMode = "oncall" | "onmessage" | "onchar";
 export type ZulipAgentReactionGuidance = "off" | "minimal" | "extensive";
 
+export type ZulipStreamRule = {
+  /** Enable or disable inbound processing for the selected stream. */
+  enabled?: boolean;
+  /** Override the account-level mention requirement for this stream. */
+  requireMention?: boolean;
+  /** Allow only these topics. Empty or "*" means all topics. */
+  allowedTopics?: string[];
+  /** Reject these topics. "*" rejects every topic. */
+  excludedTopics?: string[];
+};
+
 export type ZulipAccountConfig = {
   /** Optional display name for this account (used in CLI/UI lists). */
   name?: string;
@@ -50,6 +61,8 @@ export type ZulipAccountConfig = {
   topics?: string[];
   /** Restrict monitored topics per stream name or stream id. Case-insensitive after trimming. */
   streamTopics?: Record<string, string[]>;
+  /** Per-stream inbound policy overrides keyed by normalized stream name or decimal stream id. */
+  streamOverrides?: Record<string, ZulipStreamRule>;
   /**
    * Controls when channel messages trigger replies.
    * - "oncall": only respond when mentioned

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -357,6 +357,7 @@ describe("monitorZulipProvider", () => {
     fetchZulipStreamMock.mockClear();
     state.addZulipReaction.mockReset().mockResolvedValue(undefined);
     state.removeZulipReaction.mockReset().mockResolvedValue(undefined);
+    typingCallbacksMock.mockClear();
   });
 
   it("wires typing idle cleanup into the reply dispatcher", async () => {
@@ -1221,6 +1222,177 @@ describe("monitorZulipProvider", () => {
 
     expect(state.core.channel.inbound.buildContext).toHaveBeenCalledTimes(1);
     expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops disabled stream overrides before durable acceptance or observable inbound work", async () => {
+    enableDurableInboundJournal();
+    state.account.config = {
+      ...state.account.config,
+      streams: ["*"],
+      streamOverrides: { debbie: { enabled: false } },
+      reactions: { enabled: true },
+    };
+    state.extractedUploadUrls = ["https://zlp.pubnerd.app/user_uploads/2/aa/report.pdf"];
+    state.pollResponses = [{
+      result: "success",
+      events: [{ id: 1, type: "message", message: makeChannelMessage(1210) }],
+    }];
+
+    await runMonitorOnce();
+
+    expect(extractZulipUploadUrlsMock).not.toHaveBeenCalled();
+    expect(downloadZulipUploadMock).not.toHaveBeenCalled();
+    expect(state.addZulipReaction).not.toHaveBeenCalled();
+    expect(typingCallbacksMock).not.toHaveBeenCalled();
+    expect(state.core.channel.activity.record).not.toHaveBeenCalled();
+    expect(state.core.channel.inbound.buildContext).not.toHaveBeenCalled();
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    for (const store of state.durableStores.values()) {
+      await expect(store.entries()).resolves.toEqual([]);
+    }
+  });
+
+  it("drops mention-gated stream messages before durable acceptance or attachment work", async () => {
+    enableDurableInboundJournal();
+    state.account.requireMention = false;
+    state.account.config = {
+      ...state.account.config,
+      streamOverrides: { "4": { requireMention: true } },
+      reactions: { enabled: true },
+    };
+    state.core.channel.groups.resolveRequireMention.mockImplementation(
+      ({ requireMentionOverride }: { requireMentionOverride?: boolean }) =>
+        requireMentionOverride ?? false,
+    );
+    state.extractedUploadUrls = ["https://zlp.pubnerd.app/user_uploads/2/aa/report.pdf"];
+    state.pollResponses = [{
+      result: "success",
+      events: [{ id: 1, type: "message", message: makeChannelMessage(1213) }],
+    }];
+
+    await runMonitorOnce();
+
+    expect(extractZulipUploadUrlsMock).not.toHaveBeenCalled();
+    expect(downloadZulipUploadMock).not.toHaveBeenCalled();
+    expect(state.core.channel.media.saveMediaBuffer).not.toHaveBeenCalled();
+    expect(state.addZulipReaction).not.toHaveBeenCalled();
+    expect(typingCallbacksMock).not.toHaveBeenCalled();
+    expect(state.core.channel.activity.record).not.toHaveBeenCalled();
+    expect(state.core.channel.routing.resolveAgentRoute).not.toHaveBeenCalled();
+    expect(state.core.channel.inbound.buildContext).not.toHaveBeenCalled();
+    expect(state.core.channel.session.updateLastRoute).not.toHaveBeenCalled();
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    for (const store of state.durableStores.values()) {
+      await expect(store.entries()).resolves.toEqual([]);
+    }
+  });
+
+  it("broadens initial and replacement queues when overrides can enable other streams", async () => {
+    state.account.streams = ["debbie"];
+    state.account.config = {
+      ...state.account.config,
+      streams: ["debbie"],
+      streamOverrides: { random: { enabled: true } },
+    };
+    state.pollResponses = [
+      { result: "error", code: "BAD_EVENT_QUEUE_ID", msg: "expired" },
+      { result: "success", events: [] },
+    ];
+
+    await runMonitorOnce();
+
+    expect(registerZulipQueueMock).toHaveBeenCalledTimes(2);
+    for (const call of registerZulipQueueMock.mock.calls) {
+      expect(call[1]).toEqual({ eventTypes: ["message"], streams: ["*"] });
+    }
+  });
+
+  it("lets an id override win over a normalized name override for mention and topics", async () => {
+    state.account.requireMention = true;
+    state.account.config = {
+      ...state.account.config,
+      streams: ["other"],
+      topics: ["blocked-by-account-default"],
+      streamOverrides: {
+        " DEBBIE ": { enabled: true, requireMention: true, allowedTopics: ["wrong-topic"] },
+        "4": { requireMention: false, allowedTopics: ["zulip-plugin-pr"] },
+      },
+    };
+    state.core.channel.groups.resolveRequireMention.mockImplementation(
+      ({ requireMentionOverride }: { requireMentionOverride?: boolean }) =>
+        requireMentionOverride ?? true,
+    );
+    state.pollResponses = [{
+      result: "success",
+      events: [{ id: 1, type: "message", message: makeChannelMessage(1211) }],
+    }];
+
+    await runMonitorOnce();
+
+    expect(state.core.channel.groups.resolveRequireMention).toHaveBeenCalledWith(
+      expect.objectContaining({ requireMentionOverride: false }),
+    );
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the event's authoritative stream name after a cached stream rename", async () => {
+    state.streamSubscriptions = [{
+      stream_id: 4,
+      name: "old-name",
+      invite_only: false,
+    }];
+    state.account.config = {
+      ...state.account.config,
+      streamOverrides: {
+        "old-name": { enabled: false },
+        "new-name": { enabled: true },
+      },
+    };
+    state.pollResponses = [{
+      result: "success",
+      events: [{
+        id: 1,
+        type: "message",
+        message: { ...makeChannelMessage(1212), display_recipient: "new-name" },
+      }],
+    }];
+
+    await runMonitorOnce();
+
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not use a replayed message's stale stream name when metadata is unavailable", async () => {
+    enableDurableInboundJournal();
+    state.streamSubscriptions = [];
+    state.streamLookups.set("4", new Error("stream metadata unavailable"));
+    state.account.config = {
+      ...state.account.config,
+      streams: ["other"],
+      streamOverrides: { debbie: { enabled: true } },
+    };
+    const {
+      createZulipDurableInboundMessageId,
+      createZulipDurableInboundReceiveJournal,
+      serializeZulipDurableInboundMessage,
+    } = await import("./durable-receive.js");
+    const message = makeChannelMessage(1214);
+    const durableId = createZulipDurableInboundMessageId({
+      accountId: state.account.accountId,
+      messageId: String(message.id),
+    });
+    const journal = createZulipDurableInboundReceiveJournal(state.account.accountId);
+    await journal.accept(durableId, {
+      message: serializeZulipDurableInboundMessage(message),
+      receivedAt: Date.now(),
+    });
+
+    await runMonitorOnce();
+
+    await expect(journal.pending()).resolves.toEqual([]);
+    expect(fetchZulipStreamMock).toHaveBeenCalledWith(state.client, "4");
+    expect(state.core.channel.inbound.buildContext).not.toHaveBeenCalled();
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
   });
 
   it("ignores duplicate inbound message ids on repeat processing", async () => {

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -119,6 +119,8 @@ const state = vi.hoisted(() => {
     durableStores: new Map<string, ReturnType<typeof createMemoryKeyedStore>>(),
     pollResponses: [] as Array<Record<string, unknown>>,
     pairingAllowFrom: [] as string[],
+    pairingUpsertError: undefined as Error | undefined,
+    upsertPairingRequest: vi.fn(async () => ({ code: "123456", created: false })),
     streamSubscriptions: [] as Array<Record<string, unknown>>,
     streamLookups: new Map<string, Record<string, unknown> | Error>(),
     downloadedUploads: [] as Array<{ buffer: Buffer; contentType: string; filename: string }>,
@@ -230,7 +232,7 @@ const typingCallbacksMock = vi.fn(() => ({
 
 vi.mock("../sdk.js", () => ({
   createChannelPairingController: vi.fn(() => ({
-    upsertPairingRequest: vi.fn(async () => ({ code: "123456", created: false })),
+    upsertPairingRequest: state.upsertPairingRequest,
     readStoreForDmPolicy: vi.fn(async () => state.pairingAllowFrom),
   })),
 }));
@@ -327,6 +329,14 @@ describe("monitorZulipProvider", () => {
     state.core.channel.inbound.buildContext.mockImplementation(buildChannelInboundEventContext);
     state.durableStores = new Map();
     state.pairingAllowFrom = [];
+    state.pairingUpsertError = undefined;
+    state.upsertPairingRequest.mockReset().mockImplementation(async () => {
+      if (state.pairingUpsertError) {
+        throw state.pairingUpsertError;
+      }
+      return { code: "123456", created: false };
+    });
+    state.account.streams = ["debbie"];
     state.account.config = {
       dmPolicy: "open",
       groupPolicy: "open",
@@ -1307,6 +1317,22 @@ describe("monitorZulipProvider", () => {
     }
   });
 
+  it("keeps a narrow queue when an enabled override is already covered by legacy streams", async () => {
+    state.account.streams = ["general"];
+    state.account.config = {
+      ...state.account.config,
+      streams: ["general"],
+      streamOverrides: { GENERAL: { enabled: true } },
+    };
+
+    await runMonitorOnce();
+
+    expect(registerZulipQueueMock).toHaveBeenCalledWith(
+      state.client,
+      { eventTypes: ["message"], streams: ["general"] },
+    );
+  });
+
   it("lets an id override win over a normalized name override for mention and topics", async () => {
     state.account.requireMention = true;
     state.account.config = {
@@ -1360,6 +1386,89 @@ describe("monitorZulipProvider", () => {
     await runMonitorOnce();
 
     expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains the last good stream metadata snapshot when a later seed fails", async () => {
+    state.streamSubscriptions = [{
+      stream_id: 4,
+      name: "retained-name",
+      invite_only: false,
+    }];
+    await runMonitorOnce();
+
+    fetchZulipSubscriptionsMock.mockRejectedValueOnce(new Error("temporary subscription failure"));
+    state.account.streams = ["retained-name"];
+    state.account.config = {
+      ...state.account.config,
+      streams: ["retained-name"],
+    };
+    state.pollResponses = [{
+      result: "success",
+      events: [{
+        id: 1,
+        type: "message",
+        message: { ...makeChannelMessage(1216), display_recipient: null },
+      }],
+    }];
+
+    await runMonitorOnce();
+
+    expect(fetchZulipStreamMock).not.toHaveBeenCalled();
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("durably retries a pairing ingress failure without journaling known policy drops", async () => {
+    enableDurableInboundJournal();
+    state.account.config = {
+      ...state.account.config,
+      dmPolicy: "pairing",
+      streams: ["*"],
+      streamOverrides: { debbie: { enabled: false } },
+    };
+    state.pairingUpsertError = new Error("synthetic pairing persistence failure");
+    const filteredMessage = makeChannelMessage(1217);
+    state.pollResponses = [{
+      result: "success",
+      events: [{ id: 1, type: "message", message: filteredMessage }],
+    }];
+
+    await runMonitorOnce();
+
+    for (const store of state.durableStores.values()) {
+      await expect(store.entries()).resolves.toEqual([]);
+    }
+
+    state.account.config.streamOverrides = { debbie: { enabled: true } };
+    const message = makePrivateMessage(1218);
+    state.pollResponses = [{
+      result: "success",
+      events: [{ id: 2, type: "message", message }],
+    }];
+    await runMonitorOnce();
+
+    const {
+      createZulipDurableInboundMessageId,
+      createZulipDurableInboundReceiveJournal,
+    } = await import("./durable-receive.js");
+    const durableId = createZulipDurableInboundMessageId({
+      accountId: state.account.accountId,
+      messageId: String(message.id),
+    });
+    const journal = createZulipDurableInboundReceiveJournal(state.account.accountId);
+    await expect(journal.pending()).resolves.toEqual([
+      expect.objectContaining({
+        id: durableId,
+        lastError: "Error: synthetic pairing persistence failure",
+      }),
+    ]);
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+
+    state.pairingUpsertError = undefined;
+    await runMonitorOnce();
+
+    await expect(journal.pending()).resolves.toEqual([]);
+    expect(state.upsertPairingRequest).toHaveBeenCalledTimes(2);
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
   });
 
   it("keeps a legacy-allowlisted replay pending when authoritative stream metadata is unavailable", async () => {

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -1362,14 +1362,13 @@ describe("monitorZulipProvider", () => {
     expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
   });
 
-  it("does not use a replayed message's stale stream name when metadata is unavailable", async () => {
+  it("keeps a legacy-allowlisted replay pending when authoritative stream metadata is unavailable", async () => {
     enableDurableInboundJournal();
     state.streamSubscriptions = [];
     state.streamLookups.set("4", new Error("stream metadata unavailable"));
     state.account.config = {
       ...state.account.config,
-      streams: ["other"],
-      streamOverrides: { debbie: { enabled: true } },
+      streams: ["debbie"],
     };
     const {
       createZulipDurableInboundMessageId,
@@ -1389,8 +1388,50 @@ describe("monitorZulipProvider", () => {
 
     await runMonitorOnce();
 
-    await expect(journal.pending()).resolves.toEqual([]);
+    const pending = await journal.pending();
+    expect(pending).toHaveLength(1);
+    expect(pending[0]).toMatchObject({
+      lastError: "Zulip stream metadata unavailable during durable replay",
+    });
     expect(fetchZulipStreamMock).toHaveBeenCalledWith(state.client, "4");
+    expect(state.core.channel.inbound.buildContext).not.toHaveBeenCalled();
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+  });
+
+  it("keeps a replay pending rather than bypassing a name disable when metadata is unavailable", async () => {
+    enableDurableInboundJournal();
+    state.streamSubscriptions = [];
+    state.streamLookups.set("4", new Error("stream metadata unavailable"));
+    state.account.config = {
+      ...state.account.config,
+      streams: ["*"],
+      streamOverrides: { debbie: { enabled: false } },
+    };
+    const {
+      createZulipDurableInboundMessageId,
+      createZulipDurableInboundReceiveJournal,
+      serializeZulipDurableInboundMessage,
+    } = await import("./durable-receive.js");
+    const message = makeChannelMessage(1215);
+    const durableId = createZulipDurableInboundMessageId({
+      accountId: state.account.accountId,
+      messageId: String(message.id),
+    });
+    const journal = createZulipDurableInboundReceiveJournal(state.account.accountId);
+    await journal.accept(durableId, {
+      message: serializeZulipDurableInboundMessage(message),
+      receivedAt: Date.now(),
+    });
+
+    await runMonitorOnce();
+
+    const pending = await journal.pending();
+    expect(pending).toHaveLength(1);
+    expect(pending[0]).toMatchObject({
+      lastError: "Zulip stream metadata unavailable during durable replay",
+    });
+    expect(state.addZulipReaction).not.toHaveBeenCalled();
+    expect(state.core.channel.activity.record).not.toHaveBeenCalled();
     expect(state.core.channel.inbound.buildContext).not.toHaveBeenCalled();
     expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
   });

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -343,6 +343,8 @@ describe("monitorZulipProvider", () => {
       return { code: "123456", created: false };
     });
     state.account.streams = ["debbie"];
+    state.account.requireMention = false;
+    state.account.chatmode = "normal";
     state.account.config = {
       dmPolicy: "open",
       groupPolicy: "open",
@@ -1301,6 +1303,68 @@ describe("monitorZulipProvider", () => {
     for (const store of state.durableStores.values()) {
       await expect(store.entries()).resolves.toEqual([]);
     }
+  });
+
+  it.each([
+    { label: "explicitly disabled", requireMention: false, expectedDispatches: 1, messageId: 3101 },
+    { label: "explicitly enabled", requireMention: true, expectedDispatches: 0, messageId: 3102 },
+    { label: "inherited", requireMention: undefined, expectedDispatches: 0, messageId: 3103 },
+  ])(
+    "applies onchar gating when per-stream mention policy is $label",
+    async ({ requireMention, expectedDispatches, messageId }) => {
+      state.account.chatmode = "onchar";
+      state.account.config = {
+        ...state.account.config,
+        streamOverrides: {
+          debbie: requireMention === undefined ? {} : { requireMention },
+        },
+      };
+      state.core.channel.groups.resolveRequireMention.mockImplementation(
+        ({ requireMentionOverride }: { requireMentionOverride?: boolean }) =>
+          requireMentionOverride ?? false,
+      );
+      state.pollResponses = [{
+        result: "success",
+        events: [{ id: 1, type: "message", message: makeChannelMessage(messageId) }],
+      }];
+
+      await runMonitorOnce();
+
+      expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher)
+        .toHaveBeenCalledTimes(expectedDispatches);
+    },
+  );
+
+  it("preserves onchar gating for DMs and its authorized control-command bypass", async () => {
+    state.account.chatmode = "onchar";
+    state.account.config = {
+      ...state.account.config,
+      dmPolicy: "pairing",
+    };
+    state.pairingAllowFrom = ["user8@zlp.pubnerd.app"];
+    state.pollResponses = [{
+      result: "success",
+      events: [{ id: 1, type: "message", message: makePrivateMessage(3104) }],
+    }];
+
+    await runMonitorOnce();
+
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+
+    state.core.channel.commands.shouldHandleTextCommands.mockReturnValue(true);
+    state.core.channel.text.hasControlCommand.mockReturnValue(true);
+    state.pollResponses = [{
+      result: "success",
+      events: [{
+        id: 2,
+        type: "message",
+        message: { ...makeChannelMessage(3105), content: "/status" },
+      }],
+    }];
+
+    await runMonitorOnce();
+
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
   });
 
   it("broadens initial and replacement queues when overrides can enable other streams", async () => {

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -175,6 +175,12 @@ const fetchZulipStreamMock = vi.fn(async (_client: unknown, streamId: string) =>
   if (result) {
     return result;
   }
+  const subscription = state.streamSubscriptions.find(
+    (entry) => String(entry.stream_id ?? entry.id ?? "") === String(streamId),
+  );
+  if (subscription) {
+    return subscription;
+  }
   throw new Error(`unexpected stream metadata lookup: ${streamId}`);
 });
 
@@ -1414,6 +1420,94 @@ describe("monitorZulipProvider", () => {
     await runMonitorOnce();
 
     expect(fetchZulipStreamMock).not.toHaveBeenCalled();
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    {
+      label: "the fresh lookup fails",
+      lookup: new Error("temporary stream lookup failure"),
+    },
+    {
+      label: "the fresh lookup has a blank name",
+      lookup: { id: 4, name: "   ", invite_only: false },
+    },
+  ])("keeps replay pending with stale cached metadata when $label", async ({ lookup }) => {
+    state.streamSubscriptions = [{ stream_id: 4, name: "old-name", invite_only: false }];
+    await runMonitorOnce();
+
+    enableDurableInboundJournal();
+    fetchZulipSubscriptionsMock.mockRejectedValueOnce(new Error("temporary subscription failure"));
+    state.streamLookups.set("4", lookup);
+    state.account.streams = ["old-name"];
+    state.account.config = {
+      ...state.account.config,
+      streams: ["old-name"],
+    };
+    const {
+      createZulipDurableInboundMessageId,
+      createZulipDurableInboundReceiveJournal,
+      serializeZulipDurableInboundMessage,
+    } = await import("./durable-receive.js");
+    const message = makeChannelMessage(1219);
+    const durableId = createZulipDurableInboundMessageId({
+      accountId: state.account.accountId,
+      messageId: String(message.id),
+    });
+    const journal = createZulipDurableInboundReceiveJournal(state.account.accountId);
+    await journal.accept(durableId, {
+      message: serializeZulipDurableInboundMessage(message),
+      receivedAt: Date.now(),
+    });
+
+    await runMonitorOnce();
+
+    await expect(journal.pending()).resolves.toEqual([
+      expect.objectContaining({
+        id: durableId,
+        lastError: "Zulip stream metadata unavailable during durable replay",
+      }),
+    ]);
+    expect(fetchZulipStreamMock).toHaveBeenCalledWith(state.client, "4");
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+  });
+
+  it("uses a fresh renamed stream lookup for durable replay policy", async () => {
+    state.streamSubscriptions = [{ stream_id: 4, name: "old-name", invite_only: false }];
+    await runMonitorOnce();
+
+    enableDurableInboundJournal();
+    fetchZulipSubscriptionsMock.mockRejectedValueOnce(new Error("temporary subscription failure"));
+    state.streamLookups.set("4", { id: 4, name: "new-name", invite_only: false });
+    state.account.streams = ["new-name"];
+    state.account.config = {
+      ...state.account.config,
+      streams: ["new-name"],
+      streamOverrides: {
+        "old-name": { enabled: false },
+        "new-name": { enabled: true },
+      },
+    };
+    const {
+      createZulipDurableInboundMessageId,
+      createZulipDurableInboundReceiveJournal,
+      serializeZulipDurableInboundMessage,
+    } = await import("./durable-receive.js");
+    const message = makeChannelMessage(1220);
+    const durableId = createZulipDurableInboundMessageId({
+      accountId: state.account.accountId,
+      messageId: String(message.id),
+    });
+    const journal = createZulipDurableInboundReceiveJournal(state.account.accountId);
+    await journal.accept(durableId, {
+      message: serializeZulipDurableInboundMessage(message),
+      receivedAt: Date.now(),
+    });
+
+    await runMonitorOnce();
+
+    await expect(journal.pending()).resolves.toEqual([]);
+    expect(fetchZulipStreamMock).toHaveBeenCalledWith(state.client, "4");
     expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
   });
 

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -209,6 +209,30 @@ async function resolveCachedZulipStreamMetadata(params: {
   return undefined;
 }
 
+async function resolveFreshZulipStreamMetadata(params: {
+  client: ReturnType<typeof createZulipClient>;
+  accountId: string;
+  streamId: string;
+  log: (message: string) => void;
+}): Promise<ZulipStreamMetadata | undefined> {
+  const streamId = params.streamId.trim();
+  if (!streamId) {
+    return undefined;
+  }
+  try {
+    const stream = await fetchZulipStream(params.client, streamId);
+    const metadata = normalizeZulipStreamMetadata(stream);
+    if (!metadata?.name?.trim()) {
+      return undefined;
+    }
+    cacheZulipStreamMetadata(params.accountId, metadata);
+    return metadata;
+  } catch (err) {
+    params.log(`zulip: fresh stream metadata lookup failed streamId=${streamId}: ${String(err)}`);
+    return undefined;
+  }
+}
+
 function resolveRuntime(opts: MonitorZulipOpts): RuntimeEnv {
   return (
     opts.runtime ?? {
@@ -500,16 +524,24 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         ? message.display_recipient.trim()
         : "";
     let streamName = options.replay ? "" : eventStreamName;
-    if (options.replay || !streamName) {
+    if (options.replay) {
+      const metadata = await resolveFreshZulipStreamMetadata({
+        client,
+        accountId: account.accountId,
+        streamId,
+        log: logVerboseMessage,
+      });
+      if (!metadata?.name?.trim()) {
+        return RETRYABLE_STREAM_POLICY;
+      }
+      streamName = metadata.name.trim();
+    } else if (!streamName) {
       const metadata = await resolveCachedZulipStreamMetadata({
         client,
         accountId: account.accountId,
         streamId,
         log: logVerboseMessage,
       });
-      if (options.replay && !metadata?.name?.trim()) {
-        return RETRYABLE_STREAM_POLICY;
-      }
       streamName = metadata?.name?.trim() || streamName;
     } else {
       const key = streamMetadataCacheKey(account.accountId, streamId);

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -790,7 +790,9 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     const effectiveWasMentioned = wasMentioned || shouldBypassMention || oncharTriggered;
     const canDetectMention = Boolean(botUsername) || mentionRegexes.length > 0;
 
-    if (oncharEnabled && !oncharTriggered && !wasMentioned && !isControlCommand) {
+    const shouldApplyOncharGate =
+      oncharEnabled && (kind === "dm" || inboundStreamPolicy?.requireMention !== false);
+    if (shouldApplyOncharGate && !oncharTriggered && !wasMentioned && !isControlCommand) {
       return;
     }
 

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -61,6 +61,7 @@ import { registerZulipSubagentReactionContext } from "./subagent-reactions.js";
 import {
   isZulipTopicAllowed,
   resolveZulipInboundStreamPolicy,
+  zulipStreamOverridesExpandLegacySelection,
   type ResolvedZulipInboundStreamPolicy,
 } from "./stream-policy.js";
 
@@ -159,17 +160,21 @@ async function seedZulipStreamMetadataCache(params: {
   accountId: string;
   log: (message: string) => void;
 }): Promise<void> {
-  clearZulipStreamMetadataCache(params.accountId);
   try {
     const subscriptions = await fetchZulipSubscriptions(params.client, {
       includeAllPublic: true,
       includeSubscribers: true,
     });
+    const metadataSnapshot: ZulipStreamMetadata[] = [];
     for (const subscription of subscriptions) {
       const metadata = normalizeZulipStreamMetadata(subscription);
       if (metadata) {
-        cacheZulipStreamMetadata(params.accountId, metadata);
+        metadataSnapshot.push(metadata);
       }
+    }
+    clearZulipStreamMetadataCache(params.accountId);
+    for (const metadata of metadataSnapshot) {
+      cacheZulipStreamMetadata(params.accountId, metadata);
     }
   } catch (err) {
     params.log(`zulip: stream metadata seed failed: ${String(err)}`);
@@ -1284,9 +1289,10 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
 
   // Register event queue
   const streams = account.streams ?? ["*"];
-  const registrationStreams = Object.values(account.config.streamOverrides ?? {}).some(
-    (override) => override.enabled === true,
-  ) ? ["*"] : streams;
+  const registrationStreams = zulipStreamOverridesExpandLegacySelection({
+    streams: account.streams,
+    streamOverrides: account.config.streamOverrides,
+  }) ? ["*"] : streams;
   const durableInboundJournal = (() => {
     try {
       return createZulipDurableInboundReceiveJournal(account.accountId);
@@ -1376,6 +1382,14 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       if (
         durableInboundJournal &&
         durableId &&
+        options.acceptInbound &&
+        options.durableAccepted?.() !== true
+      ) {
+        await options.acceptInbound();
+      }
+      if (
+        durableInboundJournal &&
+        durableId &&
         (!options.acceptInbound || options.durableAccepted?.() === true)
       ) {
         await durableInboundJournal.release(durableId, {
@@ -1390,7 +1404,54 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     message: ZulipMessage,
     queueEventId?: number,
   ): Promise<void> => {
-    const streamDecision = await resolveInboundStreamDecision(message);
+    const messageId = String(message.id ?? "");
+    const metadata: ZulipDurableInboundMetadata | undefined =
+      queueEventId !== undefined ? { queueEventId } : undefined;
+    let durableId: string | undefined;
+    let durableAccepted = false;
+    let acceptInbound: (() => Promise<boolean>) | undefined;
+    if (durableInboundJournal && messageId) {
+      const acceptedDurableId = createZulipDurableInboundMessageId({
+        accountId: account.accountId,
+        messageId,
+      });
+      durableId = acceptedDurableId;
+      acceptInbound = async (): Promise<boolean> => {
+        try {
+          const accepted = await durableInboundJournal.accept(
+            acceptedDurableId,
+            {
+              message: serializeZulipDurableInboundMessage(message),
+              receivedAt: Date.now(),
+            },
+            {
+              ...(metadata ? { metadata } : {}),
+              receivedAt:
+                typeof message.timestamp === "number" ? message.timestamp * 1000 : Date.now(),
+            },
+          );
+          durableAccepted = accepted.kind === "accepted";
+          return durableAccepted;
+        } catch (err) {
+          runtime.log?.(`zulip: failed persisting durable inbound; delivering live: ${String(err)}`);
+          return true;
+        }
+      };
+    }
+
+    let streamDecision: InboundStreamDecision | typeof RETRYABLE_STREAM_POLICY | undefined;
+    try {
+      streamDecision = await resolveInboundStreamDecision(message);
+    } catch (err) {
+      if (acceptInbound) {
+        await acceptInbound();
+      }
+      if (durableInboundJournal && durableId && durableAccepted) {
+        await durableInboundJournal.release(durableId, { lastError: String(err) });
+      }
+      runtime.error?.(`zulip ingress policy evaluation failed: ${String(err)}`);
+      return;
+    }
     if (streamDecision === RETRYABLE_STREAM_POLICY) {
       return;
     }
@@ -1401,45 +1462,6 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       );
       return;
     }
-    if (!durableInboundJournal) {
-      await deliverDurableInboundMessage(undefined, message, undefined, { streamDecision });
-      return;
-    }
-
-    const messageId = String(message.id ?? "");
-    if (!messageId) {
-      await deliverDurableInboundMessage(undefined, message, undefined, { streamDecision });
-      return;
-    }
-
-    const durableId = createZulipDurableInboundMessageId({
-      accountId: account.accountId,
-      messageId,
-    });
-    const metadata: ZulipDurableInboundMetadata | undefined =
-      queueEventId !== undefined ? { queueEventId } : undefined;
-    let durableAccepted = false;
-    const acceptInbound = async (): Promise<boolean> => {
-      try {
-        const accepted = await durableInboundJournal.accept(
-          durableId,
-          {
-            message: serializeZulipDurableInboundMessage(message),
-            receivedAt: Date.now(),
-          },
-          {
-            ...(metadata ? { metadata } : {}),
-            receivedAt:
-              typeof message.timestamp === "number" ? message.timestamp * 1000 : Date.now(),
-          },
-        );
-        durableAccepted = accepted.kind === "accepted";
-        return durableAccepted;
-      } catch (err) {
-        runtime.log?.(`zulip: failed persisting durable inbound; delivering live: ${String(err)}`);
-        return true;
-      }
-    };
 
     await deliverDurableInboundMessage(durableId, message, metadata, {
       streamDecision,

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -344,6 +344,7 @@ async function saveZulipMediaBuffer(params: {
 
 const ABORTED_INBOUND_MESSAGE = Symbol("aborted-inbound-message");
 const RETRYABLE_INBOUND_MESSAGE = Symbol("retryable-inbound-message");
+const RETRYABLE_STREAM_POLICY = Symbol("retryable-stream-policy");
 const activeMonitorReactionCleanups = new Set<() => Promise<void>>();
 let monitorReactionShutdownStarted = false;
 
@@ -474,7 +475,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
   const resolveInboundStreamDecision = async (
     message: ZulipMessage,
     options: { replay?: boolean } = {},
-  ): Promise<InboundStreamDecision | undefined> => {
+  ): Promise<InboundStreamDecision | typeof RETRYABLE_STREAM_POLICY | undefined> => {
     if (message.type === "private") {
       return undefined;
     }
@@ -501,6 +502,9 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         streamId,
         log: logVerboseMessage,
       });
+      if (options.replay && !metadata?.name?.trim()) {
+        return RETRYABLE_STREAM_POLICY;
+      }
       streamName = metadata?.name?.trim() || streamName;
     } else {
       const key = streamMetadataCacheKey(account.accountId, streamId);
@@ -591,6 +595,9 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       const streamDecision =
         options.streamDecision ??
         await resolveInboundStreamDecision(message, { replay: options.replay });
+      if (streamDecision === RETRYABLE_STREAM_POLICY) {
+        return RETRYABLE_STREAM_POLICY;
+      }
       if (!streamDecision || !streamDecision.accepted) {
         if (streamDecision) {
           logRejectedStreamDecision(streamDecision, senderIdentity);
@@ -1354,6 +1361,14 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         }
         return;
       }
+      if (outcome === RETRYABLE_STREAM_POLICY) {
+        if (durableInboundJournal && durableId && manageDurableRecord) {
+          await durableInboundJournal.release(durableId, {
+            lastError: "Zulip stream metadata unavailable during durable replay",
+          });
+        }
+        return;
+      }
       if (manageDurableRecord) {
         await completeDurableInboundMessage(durableId, metadata);
       }
@@ -1376,6 +1391,9 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     queueEventId?: number,
   ): Promise<void> => {
     const streamDecision = await resolveInboundStreamDecision(message);
+    if (streamDecision === RETRYABLE_STREAM_POLICY) {
+      return;
+    }
     if (streamDecision && !streamDecision.accepted) {
       logRejectedStreamDecision(
         streamDecision,

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -58,6 +58,11 @@ import {
   resolveZulipStatusReactionConfig,
 } from "./status-reactions.js";
 import { registerZulipSubagentReactionContext } from "./subagent-reactions.js";
+import {
+  isZulipTopicAllowed,
+  resolveZulipInboundStreamPolicy,
+  type ResolvedZulipInboundStreamPolicy,
+} from "./stream-policy.js";
 
 export type MonitorZulipOpts = {
   apiKey?: string;
@@ -125,6 +130,15 @@ function cacheZulipStreamMetadata(accountId: string, metadata: ZulipStreamMetada
   streamMetadataCache.set(streamMetadataCacheKey(accountId, metadata.streamId), metadata);
 }
 
+function clearZulipStreamMetadataCache(accountId: string): void {
+  const prefix = `${accountId}:`;
+  for (const key of streamMetadataCache.keys()) {
+    if (key.startsWith(prefix)) {
+      streamMetadataCache.delete(key);
+    }
+  }
+}
+
 function resolveZulipStreamPrivacy(
   metadata: ZulipStreamMetadata | undefined,
 ): ZulipStreamPrivacy {
@@ -145,6 +159,7 @@ async function seedZulipStreamMetadataCache(params: {
   accountId: string;
   log: (message: string) => void;
 }): Promise<void> {
+  clearZulipStreamMetadataCache(params.accountId);
   try {
     const subscriptions = await fetchZulipSubscriptions(params.client, {
       includeAllPublic: true,
@@ -224,48 +239,6 @@ function normalizeMention(text: string, mention: string | undefined): string {
 function resolveOncharPrefixes(prefixes: string[] | undefined): string[] {
   const cleaned = prefixes?.map((entry) => entry.trim()).filter(Boolean) ?? DEFAULT_ONCHAR_PREFIXES;
   return cleaned.length > 0 ? cleaned : DEFAULT_ONCHAR_PREFIXES;
-}
-
-function normalizeTopicFilterValue(value: string): string {
-  return value.trim().toLowerCase();
-}
-
-function normalizeTopicFilterList(values?: string[]): Set<string> | undefined {
-  const normalized = (values ?? [])
-    .map(normalizeTopicFilterValue)
-    .filter(Boolean);
-  if (normalized.length === 0 || normalized.includes("*")) {
-    return undefined;
-  }
-  return new Set(normalized);
-}
-
-function shouldMonitorTopic(params: {
-  topic: string;
-  streamName?: string;
-  streamId?: string;
-  topics?: string[];
-  streamTopics?: Record<string, string[]>;
-}): boolean {
-  const topic = normalizeTopicFilterValue(params.topic);
-  const globalTopics = normalizeTopicFilterList(params.topics);
-  if (globalTopics && !globalTopics.has(topic)) {
-    return false;
-  }
-
-  const streamTopics = params.streamTopics ?? {};
-  const candidateKeys = [params.streamName, params.streamId]
-    .map((value) => value?.trim())
-    .filter((value): value is string => Boolean(value));
-  const matchingStreamFilter = Object.entries(streamTopics).find(([key]) =>
-    candidateKeys.some((candidate) => normalizeTopicFilterValue(candidate) === normalizeTopicFilterValue(key)),
-  );
-  if (!matchingStreamFilter) {
-    return true;
-  }
-
-  const allowedTopics = normalizeTopicFilterList(matchingStreamFilter[1]);
-  return !allowedTopics || allowedTopics.has(topic);
 }
 
 function stripOncharPrefix(
@@ -490,9 +463,93 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     accountId: account.accountId,
   });
 
+  type InboundStreamDecision = {
+    accepted: boolean;
+    streamId: string;
+    streamName: string;
+    topic: string;
+    policy: ResolvedZulipInboundStreamPolicy;
+  };
+
+  const resolveInboundStreamDecision = async (
+    message: ZulipMessage,
+    options: { replay?: boolean } = {},
+  ): Promise<InboundStreamDecision | undefined> => {
+    if (message.type === "private") {
+      return undefined;
+    }
+    const streamId = String(message.stream_id ?? "").trim();
+    if (!streamId) {
+      return {
+        accepted: false,
+        streamId,
+        streamName: "",
+        topic: message.subject?.trim() || defaultTopic,
+        policy: { enabled: false },
+      };
+    }
+
+    const eventStreamName =
+      typeof message.display_recipient === "string"
+        ? message.display_recipient.trim()
+        : "";
+    let streamName = options.replay ? "" : eventStreamName;
+    if (options.replay || !streamName) {
+      const metadata = await resolveCachedZulipStreamMetadata({
+        client,
+        accountId: account.accountId,
+        streamId,
+        log: logVerboseMessage,
+      });
+      streamName = metadata?.name?.trim() || streamName;
+    } else {
+      const key = streamMetadataCacheKey(account.accountId, streamId);
+      const cached = streamMetadataCache.get(key);
+      if (cached) {
+        cacheZulipStreamMetadata(account.accountId, {
+          ...cached,
+          name: streamName,
+        });
+      }
+    }
+
+    const topic = message.subject?.trim() || defaultTopic;
+    const policy = resolveZulipInboundStreamPolicy({
+      config: account.config,
+      streamName,
+      streamId,
+    });
+    return {
+      accepted: policy.enabled && isZulipTopicAllowed({ topic, policy }),
+      streamId,
+      streamName,
+      topic,
+      policy,
+    };
+  };
+
+  const logRejectedStreamDecision = (
+    decision: InboundStreamDecision,
+    senderIdentity: string,
+  ): void => {
+    logInboundDrop({
+      log: logVerboseMessage,
+      channel: "zulip",
+      reason: decision.policy.enabled
+        ? `topic filter (${decision.streamName || decision.streamId}:${decision.topic})`
+        : `stream disabled (${decision.streamName || decision.streamId})`,
+      target: senderIdentity,
+    });
+  };
+
   const handleMessage = async (
     message: ZulipMessage,
-    options: { skipRecentDedupe?: boolean } = {},
+    options: {
+      skipRecentDedupe?: boolean;
+      streamDecision?: InboundStreamDecision;
+      replay?: boolean;
+      acceptInbound?: () => Promise<boolean>;
+    } = {},
   ) => {
     if (opts.abortSignal?.aborted || monitorReactionShutdownStarted) {
       return ABORTED_INBOUND_MESSAGE;
@@ -526,78 +583,30 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     let streamId = "";
     let topic = defaultTopic;
     let channelId = "";
+    let inboundStreamPolicy: ResolvedZulipInboundStreamPolicy | undefined;
 
     if (isDM) {
       channelId = dmTargetIdentity;
     } else {
-      streamId = String(message.stream_id ?? "");
-      channelId = streamId;
-      if (typeof message.display_recipient === "string") {
-        streamName = message.display_recipient;
-      }
-      topic = message.subject?.trim() || defaultTopic;
-      if (
-        !shouldMonitorTopic({
-          topic,
-          streamName,
-          streamId,
-          topics: account.config.topics,
-          streamTopics: account.config.streamTopics,
-        })
-      ) {
-        logInboundDrop({
-          log: logVerboseMessage,
-          channel: "zulip",
-          reason: `topic filter (${streamName || streamId}:${topic})`,
-          target: senderIdentity,
-        });
+      const streamDecision =
+        options.streamDecision ??
+        await resolveInboundStreamDecision(message, { replay: options.replay });
+      if (!streamDecision || !streamDecision.accepted) {
+        if (streamDecision) {
+          logRejectedStreamDecision(streamDecision, senderIdentity);
+        }
         return;
       }
+      streamId = streamDecision.streamId;
+      channelId = streamId;
+      streamName = streamDecision.streamName;
+      topic = streamDecision.topic;
+      inboundStreamPolicy = streamDecision.policy;
     }
 
     const rawText = stripHtmlToText(message.content ?? "");
     const oncharResult = stripOncharPrefix(rawText, oncharPrefixes);
 
-    const uploadUrls = extractZulipUploadUrls(message.content ?? "", baseUrl);
-    const mediaPaths: string[] = [];
-    const mediaTypes: string[] = [];
-    const mediaUrls: string[] = [];
-    if (uploadUrls.length > 0) {
-      logVerboseMessage(
-        `zulip: discovered ${uploadUrls.length} upload${uploadUrls.length === 1 ? "" : "s"} for message ${messageId} maxBytes=${mediaMaxBytes}`,
-      );
-      for (const uploadUrl of uploadUrls) {
-        try {
-          logVerboseMessage(`zulip: downloading upload ${uploadUrl}`);
-          const downloaded = await downloadZulipUpload(
-            uploadUrl,
-            baseUrl,
-            client.authHeader,
-            mediaMaxBytes,
-          );
-          logVerboseMessage(
-            `zulip: downloaded upload filename=${downloaded.filename} type=${downloaded.contentType} bytes=${downloaded.buffer.length}`,
-          );
-          const saved = await saveZulipMediaBuffer({
-            core,
-            buffer: downloaded.buffer,
-            contentType: downloaded.contentType,
-            filename: downloaded.filename,
-            maxBytes: mediaMaxBytes,
-          });
-          if (saved) {
-            mediaPaths.push(saved.path);
-            mediaTypes.push(saved.contentType);
-            mediaUrls.push(saved.path);
-            logVerboseMessage(
-              `zulip: saved upload filename=${downloaded.filename} path=${saved.path} type=${saved.contentType}`,
-            );
-          }
-        } catch (err) {
-          logVerboseMessage(`zulip: failed to download/save upload ${uploadUrl}: ${String(err)}`);
-        }
-      }
-    }
     const oncharTriggered = oncharEnabled && oncharResult.triggered;
 
     const mentionRegexes = core.channel.mentions.buildMentionRegexes(cfg, "main");
@@ -730,7 +739,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         channel: "zulip",
         accountId: account.accountId,
         groupId: channelId,
-        requireMentionOverride: account.requireMention,
+        requireMentionOverride: inboundStreamPolicy?.requireMention ?? account.requireMention,
       });
     const shouldBypassMention =
       isControlCommand && shouldRequireMention && !wasMentioned && commandAuthorized;
@@ -751,6 +760,51 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     const bodyText = normalizeMention(bodySource, botUsername);
     if (!bodyText) {
       return;
+    }
+
+    if (options.acceptInbound && !await options.acceptInbound()) {
+      return;
+    }
+
+    const uploadUrls = extractZulipUploadUrls(message.content ?? "", baseUrl);
+    const mediaPaths: string[] = [];
+    const mediaTypes: string[] = [];
+    const mediaUrls: string[] = [];
+    if (uploadUrls.length > 0) {
+      logVerboseMessage(
+        `zulip: discovered ${uploadUrls.length} upload${uploadUrls.length === 1 ? "" : "s"} for message ${messageId} maxBytes=${mediaMaxBytes}`,
+      );
+      for (const uploadUrl of uploadUrls) {
+        try {
+          logVerboseMessage(`zulip: downloading upload ${uploadUrl}`);
+          const downloaded = await downloadZulipUpload(
+            uploadUrl,
+            baseUrl,
+            client.authHeader,
+            mediaMaxBytes,
+          );
+          logVerboseMessage(
+            `zulip: downloaded upload filename=${downloaded.filename} type=${downloaded.contentType} bytes=${downloaded.buffer.length}`,
+          );
+          const saved = await saveZulipMediaBuffer({
+            core,
+            buffer: downloaded.buffer,
+            contentType: downloaded.contentType,
+            filename: downloaded.filename,
+            maxBytes: mediaMaxBytes,
+          });
+          if (saved) {
+            mediaPaths.push(saved.path);
+            mediaTypes.push(saved.contentType);
+            mediaUrls.push(saved.path);
+            logVerboseMessage(
+              `zulip: saved upload filename=${downloaded.filename} path=${saved.path} type=${saved.contentType}`,
+            );
+          }
+        } catch (err) {
+          logVerboseMessage(`zulip: failed to download/save upload ${uploadUrl}: ${String(err)}`);
+        }
+      }
     }
 
     core.channel.activity.record({
@@ -1223,6 +1277,9 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
 
   // Register event queue
   const streams = account.streams ?? ["*"];
+  const registrationStreams = Object.values(account.config.streamOverrides ?? {}).some(
+    (override) => override.enabled === true,
+  ) ? ["*"] : streams;
   const durableInboundJournal = (() => {
     try {
       return createZulipDurableInboundReceiveJournal(account.accountId);
@@ -1233,7 +1290,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
   })();
   const queue = await registerZulipQueue(client, {
     eventTypes: ["message"],
-    streams, // Pass ["*"] to trigger all_public_streams=true in registerZulipQueue
+    streams: registrationStreams,
   });
   let queueId = queue.queueId;
   let lastEventId = queue.lastEventId;
@@ -1264,12 +1321,25 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     durableId: string | undefined,
     message: ZulipMessage,
     metadata?: ZulipDurableInboundMetadata,
-    options: { replay?: boolean } = {},
+    options: {
+      replay?: boolean;
+      streamDecision?: InboundStreamDecision;
+      acceptInbound?: () => Promise<boolean>;
+      durableAccepted?: () => boolean;
+    } = {},
   ): Promise<void> => {
     try {
-      const outcome = await handleMessage(message, { skipRecentDedupe: options.replay });
+      const outcome = await handleMessage(message, {
+        skipRecentDedupe: options.replay,
+        replay: options.replay,
+        streamDecision: options.streamDecision,
+        acceptInbound: options.acceptInbound,
+      });
+      const manageDurableRecord =
+        Boolean(durableId) &&
+        (!options.acceptInbound || options.durableAccepted?.() === true);
       if (outcome === ABORTED_INBOUND_MESSAGE) {
-        if (durableInboundJournal && durableId) {
+        if (durableInboundJournal && durableId && manageDurableRecord) {
           await durableInboundJournal.release(durableId, {
             lastError: "Zulip monitor stopped before delivery",
           });
@@ -1277,16 +1347,22 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         return;
       }
       if (outcome === RETRYABLE_INBOUND_MESSAGE) {
-        if (durableInboundJournal && durableId) {
+        if (durableInboundJournal && durableId && manageDurableRecord) {
           await durableInboundJournal.release(durableId, {
             lastError: "Zulip reply delivery failed before any visible response",
           });
         }
         return;
       }
-      await completeDurableInboundMessage(durableId, metadata);
+      if (manageDurableRecord) {
+        await completeDurableInboundMessage(durableId, metadata);
+      }
     } catch (err) {
-      if (durableInboundJournal && durableId) {
+      if (
+        durableInboundJournal &&
+        durableId &&
+        (!options.acceptInbound || options.durableAccepted?.() === true)
+      ) {
         await durableInboundJournal.release(durableId, {
           lastError: String(err),
         });
@@ -1299,14 +1375,22 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     message: ZulipMessage,
     queueEventId?: number,
   ): Promise<void> => {
+    const streamDecision = await resolveInboundStreamDecision(message);
+    if (streamDecision && !streamDecision.accepted) {
+      logRejectedStreamDecision(
+        streamDecision,
+        message.sender_email?.trim() || String(message.sender_id ?? ""),
+      );
+      return;
+    }
     if (!durableInboundJournal) {
-      await deliverDurableInboundMessage(undefined, message);
+      await deliverDurableInboundMessage(undefined, message, undefined, { streamDecision });
       return;
     }
 
     const messageId = String(message.id ?? "");
     if (!messageId) {
-      await deliverDurableInboundMessage(undefined, message);
+      await deliverDurableInboundMessage(undefined, message, undefined, { streamDecision });
       return;
     }
 
@@ -1316,29 +1400,34 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     });
     const metadata: ZulipDurableInboundMetadata | undefined =
       queueEventId !== undefined ? { queueEventId } : undefined;
-    try {
-      const accepted = await durableInboundJournal.accept(
-        durableId,
-        {
-          message: serializeZulipDurableInboundMessage(message),
-          receivedAt: Date.now(),
-        },
-        {
-          ...(metadata ? { metadata } : {}),
-          receivedAt:
-            typeof message.timestamp === "number" ? message.timestamp * 1000 : Date.now(),
-        },
-      );
-      if (accepted.kind !== "accepted") {
-        return;
+    let durableAccepted = false;
+    const acceptInbound = async (): Promise<boolean> => {
+      try {
+        const accepted = await durableInboundJournal.accept(
+          durableId,
+          {
+            message: serializeZulipDurableInboundMessage(message),
+            receivedAt: Date.now(),
+          },
+          {
+            ...(metadata ? { metadata } : {}),
+            receivedAt:
+              typeof message.timestamp === "number" ? message.timestamp * 1000 : Date.now(),
+          },
+        );
+        durableAccepted = accepted.kind === "accepted";
+        return durableAccepted;
+      } catch (err) {
+        runtime.log?.(`zulip: failed persisting durable inbound; delivering live: ${String(err)}`);
+        return true;
       }
-    } catch (err) {
-      runtime.log?.(`zulip: failed persisting durable inbound; delivering live: ${String(err)}`);
-      await deliverDurableInboundMessage(undefined, message);
-      return;
-    }
+    };
 
-    await deliverDurableInboundMessage(durableId, message, metadata);
+    await deliverDurableInboundMessage(durableId, message, metadata, {
+      streamDecision,
+      acceptInbound,
+      durableAccepted: () => durableAccepted,
+    });
   };
 
   const handleMonitorAbort = () => {
@@ -1389,7 +1478,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
             runtime.log?.("zulip: queue expired, re-registering...");
             const newQueue = await registerZulipQueue(client, {
               eventTypes: ["message"],
-              streams, // Pass ["*"] to trigger all_public_streams=true in registerZulipQueue
+              streams: registrationStreams,
             });
             queueId = newQueue.queueId;
             lastEventId = newQueue.lastEventId;
@@ -1449,7 +1538,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
           runtime.log?.("zulip: bad event queue error thrown; re-registering...");
           const newQueue = await registerZulipQueue(client, {
             eventTypes: ["message"],
-            streams,
+            streams: registrationStreams,
           });
           queueId = newQueue.queueId;
           lastEventId = newQueue.lastEventId;

--- a/src/zulip/stream-policy.test.ts
+++ b/src/zulip/stream-policy.test.ts
@@ -41,6 +41,27 @@ describe("Zulip inbound stream policy", () => {
     }).enabled).toBe(false);
   });
 
+  it("matches a decimal-looking legacy streamTopics key as a stream name", () => {
+    const policy = resolveZulipInboundStreamPolicy({
+      config: { streamTopics: { "4": ["allowed"] } },
+      streamName: "4",
+      streamId: "5",
+    });
+
+    expect(policy.additionalAllowedTopics).toEqual(["allowed"]);
+    expect(isZulipTopicAllowed({ topic: "allowed", policy })).toBe(true);
+  });
+
+  it("does not canonicalize decimal-looking legacy streamTopics ids", () => {
+    const policy = resolveZulipInboundStreamPolicy({
+      config: { streamTopics: { "017": ["allowed"] } },
+      streamName: "other",
+      streamId: "17",
+    });
+
+    expect(policy.additionalAllowedTopics).toBeUndefined();
+  });
+
   it("applies name rules and then id rules field by field", () => {
     const policy = resolveZulipInboundStreamPolicy({
       config: {

--- a/src/zulip/stream-policy.test.ts
+++ b/src/zulip/stream-policy.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import {
+  isZulipTopicAllowed,
+  normalizeZulipStreamIdSelector,
+  resolveZulipInboundStreamPolicy,
+} from "./stream-policy.js";
+
+describe("Zulip inbound stream policy", () => {
+  it("preserves legacy stream and topic filters", () => {
+    const enabled = resolveZulipInboundStreamPolicy({
+      config: { streams: [" General "], topics: ["support"], streamTopics: { GENERAL: ["triage"] } },
+      streamName: "general",
+      streamId: "17",
+    });
+    const disabled = resolveZulipInboundStreamPolicy({
+      config: { streams: ["general"] },
+      streamName: "random",
+      streamId: "18",
+    });
+
+    expect(enabled).toMatchObject({
+      enabled: true,
+      allowedTopics: ["support"],
+      additionalAllowedTopics: ["triage"],
+    });
+    expect(isZulipTopicAllowed({ topic: "support", policy: enabled })).toBe(false);
+    expect(isZulipTopicAllowed({ topic: "triage", policy: enabled })).toBe(false);
+    expect(disabled.enabled).toBe(false);
+  });
+
+  it("keeps legacy streams entries as stream names, including numeric names", () => {
+    expect(resolveZulipInboundStreamPolicy({
+      config: { streams: ["4"] },
+      streamName: "4",
+      streamId: "5",
+    }).enabled).toBe(true);
+    expect(resolveZulipInboundStreamPolicy({
+      config: { streams: ["4"] },
+      streamName: "other",
+      streamId: "4",
+    }).enabled).toBe(false);
+  });
+
+  it("applies name rules and then id rules field by field", () => {
+    const policy = resolveZulipInboundStreamPolicy({
+      config: {
+        streams: ["other"],
+        streamOverrides: {
+          " General ": { enabled: true, requireMention: true, allowedTopics: ["support"] },
+          "017": { requireMention: false, excludedTopics: ["private"] },
+        },
+      },
+      streamName: "GENERAL",
+      streamId: "17",
+    });
+
+    expect(policy).toMatchObject({
+      enabled: true,
+      requireMention: false,
+      allowedTopics: ["support"],
+      excludedTopics: ["private"],
+      matchedNameKey: " General ",
+      matchedIdKey: "017",
+    });
+  });
+
+  it("inherits a name disable when a higher-precedence id rule omits enabled", () => {
+    const policy = resolveZulipInboundStreamPolicy({
+      config: {
+        streamOverrides: {
+          general: { enabled: false },
+          "17": { requireMention: false },
+        },
+      },
+      streamName: "general",
+      streamId: "17",
+    });
+
+    expect(policy).toMatchObject({ enabled: false, requireMention: false });
+  });
+
+  it.each(["1e3", "0x11", "+17", "-17", "17.0", " 17x "])(
+    "does not coerce non-decimal selector %s into a stream id",
+    (selector) => {
+      expect(normalizeZulipStreamIdSelector(selector)).toBeUndefined();
+      const policy = resolveZulipInboundStreamPolicy({
+        config: { streamOverrides: { [selector]: { enabled: false } } },
+        streamName: "different",
+        streamId: "17",
+      });
+      expect(policy.enabled).toBe(true);
+      expect(policy.matchedIdKey).toBeUndefined();
+    },
+  );
+
+  it("stops applying an old name rule after a rename while the id rule remains stable", () => {
+    const config = {
+      streamOverrides: {
+        oldName: { enabled: false },
+        newName: { requireMention: false },
+        "42": { allowedTopics: ["ops"] },
+      },
+    };
+
+    expect(resolveZulipInboundStreamPolicy({ config, streamName: "oldName", streamId: "42" }))
+      .toMatchObject({ enabled: false, allowedTopics: ["ops"] });
+    expect(resolveZulipInboundStreamPolicy({ config, streamName: "newName", streamId: "42" }))
+      .toMatchObject({ enabled: true, requireMention: false, allowedTopics: ["ops"] });
+  });
+
+  it("treats decimal selectors only as ids while non-decimal keys remain names", () => {
+    const numericName = resolveZulipInboundStreamPolicy({
+      config: { streamOverrides: { "4": { enabled: false } } },
+      streamName: "4",
+      streamId: "5",
+    });
+    const nonDecimalName = resolveZulipInboundStreamPolicy({
+      config: { streamOverrides: { "1e3": { enabled: false } } },
+      streamName: "1E3",
+      streamId: "1000",
+    });
+
+    expect(numericName.enabled).toBe(true);
+    expect(nonDecimalName.enabled).toBe(false);
+  });
+
+  it("uses normalized allow/exclude topic semantics with exclusions winning", () => {
+    const policy = { allowedTopics: ["*"], excludedTopics: [" Private "] };
+    expect(isZulipTopicAllowed({ topic: "support", policy })).toBe(true);
+    expect(isZulipTopicAllowed({ topic: "PRIVATE", policy })).toBe(false);
+    expect(isZulipTopicAllowed({ topic: "anything", policy: { excludedTopics: ["*"] } })).toBe(false);
+    expect(isZulipTopicAllowed({ topic: "anything", policy: { allowedTopics: [] } })).toBe(true);
+  });
+});

--- a/src/zulip/stream-policy.test.ts
+++ b/src/zulip/stream-policy.test.ts
@@ -3,6 +3,7 @@ import {
   isZulipTopicAllowed,
   normalizeZulipStreamIdSelector,
   resolveZulipInboundStreamPolicy,
+  zulipStreamOverridesExpandLegacySelection,
 } from "./stream-policy.js";
 
 describe("Zulip inbound stream policy", () => {
@@ -151,5 +152,24 @@ describe("Zulip inbound stream policy", () => {
     expect(isZulipTopicAllowed({ topic: "PRIVATE", policy })).toBe(false);
     expect(isZulipTopicAllowed({ topic: "anything", policy: { excludedTopics: ["*"] } })).toBe(false);
     expect(isZulipTopicAllowed({ topic: "anything", policy: { allowedTopics: [] } })).toBe(true);
+  });
+
+  it("broadens queue selection only when enabled overrides add legacy coverage", () => {
+    expect(zulipStreamOverridesExpandLegacySelection({
+      streams: [" General "],
+      streamOverrides: { general: { enabled: true } },
+    })).toBe(false);
+    expect(zulipStreamOverridesExpandLegacySelection({
+      streams: ["general"],
+      streamOverrides: { random: { enabled: true } },
+    })).toBe(true);
+    expect(zulipStreamOverridesExpandLegacySelection({
+      streams: ["general"],
+      streamOverrides: { "17": { enabled: true } },
+    })).toBe(true);
+    expect(zulipStreamOverridesExpandLegacySelection({
+      streams: ["*"],
+      streamOverrides: { random: { enabled: true } },
+    })).toBe(false);
   });
 });

--- a/src/zulip/stream-policy.ts
+++ b/src/zulip/stream-policy.ts
@@ -23,6 +23,31 @@ export function normalizeZulipStreamIdSelector(value: string): string | undefine
   return trimmed.replace(/^0+(?=\d)/, "");
 }
 
+export function zulipStreamOverridesExpandLegacySelection(params: {
+  streams: string[] | undefined;
+  streamOverrides: Record<string, ZulipStreamRule> | undefined;
+}): boolean {
+  const streams = params.streams;
+  if (!streams || streams.length === 0 || streams.some((entry) => entry.trim() === "*")) {
+    return false;
+  }
+  const legacyNames = new Set(
+    streams
+      .map(normalizeZulipStreamName)
+      .filter((value): value is string => value !== undefined),
+  );
+  return Object.entries(params.streamOverrides ?? {}).some(([selector, override]) => {
+    if (override.enabled !== true) {
+      return false;
+    }
+    if (normalizeZulipStreamIdSelector(selector) !== undefined) {
+      return true;
+    }
+    const normalizedName = normalizeZulipStreamName(selector);
+    return normalizedName !== undefined && !legacyNames.has(normalizedName);
+  });
+}
+
 function normalizeTopic(value: string): string {
   return value.trim().toLocaleLowerCase("en-US");
 }

--- a/src/zulip/stream-policy.ts
+++ b/src/zulip/stream-policy.ts
@@ -1,0 +1,162 @@
+import type { ZulipAccountConfig, ZulipStreamRule } from "../types.js";
+
+export type ResolvedZulipInboundStreamPolicy = {
+  enabled: boolean;
+  requireMention?: boolean;
+  allowedTopics?: string[];
+  additionalAllowedTopics?: string[];
+  excludedTopics?: string[];
+  matchedNameKey?: string;
+  matchedIdKey?: string;
+};
+
+export function normalizeZulipStreamName(value: string | undefined): string | undefined {
+  const normalized = value?.trim().toLocaleLowerCase("en-US");
+  return normalized || undefined;
+}
+
+export function normalizeZulipStreamIdSelector(value: string): string | undefined {
+  const trimmed = value.trim();
+  if (!/^[0-9]+$/.test(trimmed)) {
+    return undefined;
+  }
+  return trimmed.replace(/^0+(?=\d)/, "");
+}
+
+function normalizeTopic(value: string): string {
+  return value.trim().toLocaleLowerCase("en-US");
+}
+
+function normalizeAllowedTopics(values: string[] | undefined): Set<string> | undefined {
+  const normalized = (values ?? []).map(normalizeTopic).filter(Boolean);
+  if (normalized.length === 0 || normalized.includes("*")) {
+    return undefined;
+  }
+  return new Set(normalized);
+}
+
+function normalizeExcludedTopics(values: string[] | undefined): Set<string> {
+  return new Set((values ?? []).map(normalizeTopic).filter(Boolean));
+}
+
+function findLegacyStreamTopics(params: {
+  streamTopics?: Record<string, string[]>;
+  streamName?: string;
+  streamId: string;
+}): string[] | undefined {
+  const normalizedName = normalizeZulipStreamName(params.streamName);
+  const normalizedId = normalizeZulipStreamIdSelector(params.streamId);
+  const nameMatch = normalizedName
+    ? Object.entries(params.streamTopics ?? {}).find(([key]) =>
+        normalizeZulipStreamIdSelector(key) === undefined &&
+        normalizeZulipStreamName(key) === normalizedName,
+      )
+    : undefined;
+  const idMatch = Object.entries(params.streamTopics ?? {}).find(([key]) => {
+    const selector = normalizeZulipStreamIdSelector(key);
+    return selector !== undefined && selector === normalizedId;
+  });
+  return idMatch?.[1] ?? nameMatch?.[1];
+}
+
+function findRules(params: {
+  rules?: Record<string, ZulipStreamRule>;
+  streamName?: string;
+  streamId: string;
+}): {
+  nameRule?: [string, ZulipStreamRule];
+  idRule?: [string, ZulipStreamRule];
+} {
+  const normalizedName = normalizeZulipStreamName(params.streamName);
+  const normalizedId = normalizeZulipStreamIdSelector(params.streamId);
+  let nameRule: [string, ZulipStreamRule] | undefined;
+  let idRule: [string, ZulipStreamRule] | undefined;
+
+  for (const entry of Object.entries(params.rules ?? {})) {
+    const idSelector = normalizeZulipStreamIdSelector(entry[0]);
+    if (idSelector !== undefined) {
+      if (idSelector === normalizedId) {
+        idRule = entry;
+      }
+      continue;
+    }
+    if (normalizedName && normalizeZulipStreamName(entry[0]) === normalizedName) {
+      nameRule = entry;
+    }
+  }
+  return { nameRule, idRule };
+}
+
+function legacyStreamEnabled(streams: string[] | undefined, streamName: string | undefined): boolean {
+  if (!streams || streams.length === 0 || streams.some((entry) => entry.trim() === "*")) {
+    return true;
+  }
+  const normalizedName = normalizeZulipStreamName(streamName);
+  return Boolean(normalizedName) && streams.some(
+    (entry) => normalizeZulipStreamName(entry) === normalizedName,
+  );
+}
+
+export function resolveZulipInboundStreamPolicy(params: {
+  config: ZulipAccountConfig;
+  streamName?: string;
+  streamId: string;
+}): ResolvedZulipInboundStreamPolicy {
+  const legacyAllowedTopics = findLegacyStreamTopics({
+    streamTopics: params.config.streamTopics,
+    streamName: params.streamName,
+    streamId: params.streamId,
+  });
+  const { nameRule, idRule } = findRules({
+    rules: params.config.streamOverrides,
+    streamName: params.streamName,
+    streamId: params.streamId,
+  });
+
+  const policy: ResolvedZulipInboundStreamPolicy = {
+    enabled: legacyStreamEnabled(params.config.streams, params.streamName),
+    allowedTopics: params.config.topics,
+    additionalAllowedTopics: legacyAllowedTopics,
+  };
+  for (const rule of [nameRule?.[1], idRule?.[1]]) {
+    if (!rule) {
+      continue;
+    }
+    if (rule.enabled !== undefined) {
+      policy.enabled = rule.enabled;
+    }
+    if (rule.requireMention !== undefined) {
+      policy.requireMention = rule.requireMention;
+    }
+    if (rule.allowedTopics !== undefined) {
+      policy.allowedTopics = rule.allowedTopics;
+      policy.additionalAllowedTopics = undefined;
+    }
+    if (rule.excludedTopics !== undefined) {
+      policy.excludedTopics = rule.excludedTopics;
+    }
+  }
+  policy.matchedNameKey = nameRule?.[0];
+  policy.matchedIdKey = idRule?.[0];
+  return policy;
+}
+
+export function isZulipTopicAllowed(params: {
+  topic: string;
+  policy: Pick<
+    ResolvedZulipInboundStreamPolicy,
+    "allowedTopics" | "additionalAllowedTopics" | "excludedTopics"
+  >;
+}): boolean {
+  const topic = normalizeTopic(params.topic);
+  const allowed = normalizeAllowedTopics(params.policy.allowedTopics);
+  if (allowed && !allowed.has(topic)) {
+    return false;
+  }
+  const additionalAllowed = normalizeAllowedTopics(params.policy.additionalAllowedTopics);
+  if (additionalAllowed && !additionalAllowed.has(topic)) {
+    return false;
+  }
+  const excluded = normalizeExcludedTopics(params.policy.excludedTopics);
+  return !excluded.has("*") && !excluded.has(topic);
+}

--- a/src/zulip/stream-policy.ts
+++ b/src/zulip/stream-policy.ts
@@ -44,19 +44,15 @@ function findLegacyStreamTopics(params: {
   streamName?: string;
   streamId: string;
 }): string[] | undefined {
-  const normalizedName = normalizeZulipStreamName(params.streamName);
-  const normalizedId = normalizeZulipStreamIdSelector(params.streamId);
-  const nameMatch = normalizedName
-    ? Object.entries(params.streamTopics ?? {}).find(([key]) =>
-        normalizeZulipStreamIdSelector(key) === undefined &&
-        normalizeZulipStreamName(key) === normalizedName,
-      )
-    : undefined;
-  const idMatch = Object.entries(params.streamTopics ?? {}).find(([key]) => {
-    const selector = normalizeZulipStreamIdSelector(key);
-    return selector !== undefined && selector === normalizedId;
-  });
-  return idMatch?.[1] ?? nameMatch?.[1];
+  const candidates = new Set(
+    [params.streamName, params.streamId]
+      .map(normalizeZulipStreamName)
+      .filter((value): value is string => value !== undefined),
+  );
+  return Object.entries(params.streamTopics ?? {}).find(([key]) => {
+    const normalizedKey = normalizeZulipStreamName(key);
+    return normalizedKey !== undefined && candidates.has(normalizedKey);
+  })?.[1];
 }
 
 function findRules(params: {


### PR DESCRIPTION
## Summary

- add backward-compatible per-stream inbound policy overrides for activation, mention requirements, and topic filters
- define deterministic account, legacy, normalized-name, and strict decimal-ID precedence
- apply inbound rejection before durable state, downloads, reactions, typing, routing, or agent work while leaving outbound access unchanged
- keep durable replays pending when current authoritative stream metadata is temporarily unavailable
- document migration and configuration behavior across schema, UI hints, examples, and changelog

## Verification

- Node 22.23.1: `pnpm run build`
- Node 22.23.1: `pnpm test` (248 passed)
- package dry-run passed
- independent review approved `a15e538115825e195d01a13892638a9740a655c6` with no findings

Closes #26.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core Zulip inbound path and durable-replay semantics; behavior is heavily tested and backward-compatible, but misconfigured overrides could silently drop or unexpectedly accept stream traffic.
> 
> **Overview**
> Adds **`streamOverrides`** so each Zulip stream can override inbound-only rules (`enabled`, `requireMention`, `allowedTopics`, `excludedTopics`) keyed by normalized name or strict ASCII decimal stream ID, with layered precedence over existing `streams`, `topics`, and `streamTopics`. Legacy configs stay valid; outbound behavior is unchanged.
> 
> **Ingress pipeline:** Stream policy is resolved and rejected messages are dropped **before** durable journal acceptance, attachment downloads, reactions, typing, routing, or agent dispatch. Per-stream `requireMention` feeds mention and onchar gating; durable **replay** uses a fresh stream lookup and leaves journal entries pending when authoritative metadata is missing instead of applying stale name-based disables.
> 
> **Infrastructure:** New `stream-policy` module plus Zod/manifest validation (duplicate selector rejection). Event queue registration widens to all public streams when an override enables a stream outside the legacy `streams` list. README, changelog, and UI hints document migration and selector rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a15e538115825e195d01a13892638a9740a655c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->