### PR TITLE
fix(ci): use HTTP health probe for live smoke gateway

### DIFF
--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -3,6 +3,7 @@
 import { spawn } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { chmod, readdir, readFile, unlink, writeFile } from "node:fs/promises";
+import { request as httpRequest } from "node:http";
 import { resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { pathToFileURL } from "node:url";
@@ -441,12 +442,11 @@ export class EventQueue {
 }
 
 export class Gateway {
-  constructor(port, { termTimeoutMs = 10000, killTimeoutMs = 5000, healthProbe, healthProbeSpawn = spawn, healthProbeTimeoutMs = 5000 } = {}) {
+  constructor(port, { termTimeoutMs = 10000, killTimeoutMs = 5000, healthProbe, healthProbeTimeoutMs = 2000 } = {}) {
     this.port = String(port);
     this.termTimeoutMs = termTimeoutMs;
     this.killTimeoutMs = killTimeoutMs;
     this.healthProbe = healthProbe;
-    this.healthProbeSpawn = healthProbeSpawn;
     this.healthProbeTimeoutMs = healthProbeTimeoutMs;
   }
   async start(signal) {
@@ -471,27 +471,7 @@ export class Gateway {
   }
   async isHealthy() {
     if (this.healthProbe) return this.healthProbe();
-    return new Promise((resolve) => {
-      const probe = this.healthProbeSpawn("pnpm", ["exec", "openclaw", "gateway", "health", "--port", this.port, "--timeout", "2000"], {
-        stdio: "ignore", env: process.env, detached: process.platform !== "win32",
-      });
-      let settled = false;
-      let timeout;
-      const finish = (value) => {
-        if (!settled) {
-          settled = true;
-          clearTimeout(timeout);
-          resolve(value);
-        }
-      };
-      probe.once("error", () => finish(false));
-      probe.once("exit", (code) => finish(code === 0));
-      timeout = setTimeout(() => {
-        try { signalProcessTree(probe, "SIGKILL"); } catch {}
-        finish(false);
-      }, this.healthProbeTimeoutMs);
-      timeout.unref?.();
-    });
+    return probeRunnerLocalGatewayHealth(this.port, this.healthProbeTimeoutMs);
   }
   async waitUntilUnhealthy(timeoutMs) {
     const deadline = Date.now() + timeoutMs;
@@ -523,6 +503,37 @@ export class Gateway {
     if (this.process === child) this.process = undefined;
   }
   async restart(signal) { await this.stop(); signal?.throwIfAborted(); await this.start(signal); }
+}
+
+export function probeRunnerLocalGatewayHealth(port, timeoutMs = 2000) {
+  return new Promise((resolve) => {
+    const probe = httpRequest({
+      hostname: "127.0.0.1",
+      port,
+      path: "/healthz",
+      method: "GET",
+      agent: false,
+    });
+    let response;
+    let timeout;
+    let settled = false;
+    const finish = (value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      response?.destroy();
+      probe.destroy();
+      resolve(value);
+    };
+    probe.once("response", (incoming) => {
+      response = incoming;
+      finish(incoming.statusCode === 200);
+    });
+    probe.once("error", () => finish(false));
+    timeout = setTimeout(() => finish(false), timeoutMs);
+    timeout.unref?.();
+    probe.end();
+  });
 }
 
 export function isChildRunning(child) {

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -2,10 +2,11 @@ import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { EventEmitter, once } from "node:events";
 import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { assertFinalPrivateTypingStop, assertMessageRemainsExact, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, drainEventQueueUntilQuiet, eventOccursBefore, EventQueue, extractExactUploadUrl, Gateway, hasFinalPrivateTypingStop, hasProvableMinimumMessageDelay, inspectChildTranscripts, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactPollMessage, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, isUsageCountedTranscriptName, lifecycleSummary, normalizeScenarioError, redactError, resolveUploadUrl, signalProcessTree, subagentCompletedBeforeReply, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
+import { assertFinalPrivateTypingStop, assertMessageRemainsExact, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, drainEventQueueUntilQuiet, eventOccursBefore, EventQueue, extractExactUploadUrl, Gateway, hasFinalPrivateTypingStop, hasProvableMinimumMessageDelay, inspectChildTranscripts, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactPollMessage, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, isUsageCountedTranscriptName, lifecycleSummary, normalizeScenarioError, probeRunnerLocalGatewayHealth, redactError, resolveUploadUrl, signalProcessTree, subagentCompletedBeforeReply, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
 
 const validEnv = {
   ZULIP_URL: "https://zulip.example.test/path",
@@ -474,22 +475,49 @@ test("waits for gateway exit after escalating to SIGKILL", async () => {
   assert.equal(gateway.process, undefined);
 });
 
-test("kills a health probe that exceeds its process deadline", async () => {
-  const probe = new EventEmitter();
-  probe.exitCode = null;
-  probe.signalCode = null;
-  probe.kill = (signal) => {
-    probe.signalCode = signal;
-    setImmediate(() => probe.emit("exit", null, signal));
-    return true;
-  };
-  const gateway = new Gateway(18789, { healthProbeSpawn: () => probe, healthProbeTimeoutMs: 5 });
-  const keepAlive = setInterval(() => {}, 1000);
+test("accepts only HTTP 200 from the runner-local health endpoint without auth", async () => {
+  const requests = [];
+  const server = createServer((request, response) => {
+    requests.push({ method: request.method, url: request.url, authorization: request.headers.authorization });
+    response.writeHead(request.url === "/healthz" ? 200 : 404).end();
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
   try {
-    assert.equal(await gateway.isHealthy(), false);
-    assert.equal(probe.signalCode, "SIGKILL");
+    const address = server.address();
+    assert.equal(await probeRunnerLocalGatewayHealth(address.port, 1000), true);
+    assert.deepEqual(requests, [{ method: "GET", url: "/healthz", authorization: undefined }]);
   } finally {
-    clearInterval(keepAlive);
+    await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  }
+});
+
+test("rejects redirects and other non-200 health responses", async () => {
+  const server = createServer((_request, response) => response.writeHead(302, { location: "/healthy" }).end());
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    assert.equal(await new Gateway(server.address().port).isHealthy(), false);
+  } finally {
+    await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  }
+});
+
+test("fails closed when the runner-local health connection is refused", async () => {
+  const server = createServer();
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  assert.equal(await probeRunnerLocalGatewayHealth(port, 1000), false);
+});
+
+test("aborts a runner-local health request that exceeds its deadline", async () => {
+  const server = createServer(() => {});
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const started = Date.now();
+    assert.equal(await probeRunnerLocalGatewayHealth(server.address().port, 20), false);
+    assert.equal(Date.now() - started < 500, true);
+  } finally {
+    await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
   }
 });
 


### PR DESCRIPTION
Summary:

- Replace the runner-local OpenClaw CLI health RPC probe with a bounded loopback HTTP GET to /healthz.
- Accept only HTTP 200; reject redirects and non-200 responses.
- Destroy request/response resources on success, error, and timeout.
- Add offline coverage for success, redirect, refusal, timeout, and socket cleanup.

Why:

The first protected live runs proved the gateway started, connected Zulip, and served /healthz, but OpenClaw 2026.7.1 gateway health exits 1 on an auth-none gateway because the CLI lacks paired read-scope device credentials. That made the harness falsely report a startup timeout.

Verification:

- 268 Vitest tests passed
- 39 offline live-smoke tests passed
- TypeScript build passed
- git diff --check passed
- Independent exact-SHA review approved 21e1696c95ca3305e17e0c93fda5ca055410fc59 with no findings

Closes the remaining harness blocker for issue #24.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to CI live-smoke harness health detection and offline tests; no production auth or runtime paths are modified.
> 
> **Overview**
> The live smoke harness **replaces the OpenClaw CLI gateway health check** with a **loopback HTTP GET to `/healthz`**, so startup health no longer depends on CLI device credentials that fail when the runner starts the gateway with `--auth none`.
> 
> `Gateway.isHealthy()` now calls exported **`probeRunnerLocalGatewayHealth`**, which treats **only HTTP 200** as healthy, **fails closed** on errors/refused connections, and **destroys** the request/response on success, error, or timeout. The **`healthProbeSpawn`** option and default **5s** probe timeout are removed; the default HTTP probe timeout is **2s**.
> 
> Offline tests swap the old “kill stuck CLI probe” case for coverage of **200 on `/healthz` without auth**, **302/non-200 rejection**, **connection refused**, and **bounded timeout**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21e1696c95ca3305e17e0c93fda5ca055410fc59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->