### PR TITLE
fix(zulip): preserve DMs with configured streams

### DIFF
--- a/src/zulip/client.test.ts
+++ b/src/zulip/client.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   addZulipReaction,
   createZulipClient,
+  registerZulipQueue,
   removeZulipReaction,
   zulipRequestWithRetry,
   type ZulipRequestLogger,
@@ -13,6 +14,38 @@ function jsonResponse(body: unknown, init?: ResponseInit): Response {
     headers: { "content-type": "application/json", ...(init?.headers ?? {}) },
   });
 }
+
+describe("registerZulipQueue", () => {
+  it("does not narrow a single configured stream out of direct-message events", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({
+        result: "success",
+        queue_id: "queue-1",
+        last_event_id: 17,
+      }),
+    );
+    const client = createZulipClient({
+      baseUrl: "https://zulip.example.test/",
+      email: "bot@example.test",
+      apiKey: "secret",
+      fetchImpl,
+    });
+
+    await expect(
+      registerZulipQueue(client, {
+        eventTypes: ["message"],
+        streams: ["debbie"],
+      }),
+    ).resolves.toEqual({ queueId: "queue-1", lastEventId: 17 });
+
+    const [url, init] = fetchImpl.mock.calls[0] ?? [];
+    const body = new URLSearchParams(String(init?.body));
+    expect(url).toBe("https://zulip.example.test/api/v1/register");
+    expect(body.get("event_types")).toBe('["message"]');
+    expect(body.get("all_public_streams")).toBe("true");
+    expect(body.has("narrow")).toBe(false);
+  });
+});
 
 describe("zulipRequestWithRetry", () => {
   it("requests identity encoding so Zulip responses are not parsed while still gzipped", async () => {

--- a/src/zulip/client.ts
+++ b/src/zulip/client.ts
@@ -394,16 +394,9 @@ export async function registerZulipQueue(
   const eventTypes = params.eventTypes ?? ["message"];
   body.set("event_types", JSON.stringify(eventTypes));
   body.set("event_queue_longpoll_timeout_seconds", "90");
-  // Zulip ANDs narrow terms, so multiple ["stream","x"] filters match nothing.
-  // For single stream, use narrow. For multiple streams or "*", use all_public_streams
-  // and filter client-side. Uses array format [op, operand] per Zulip API v11+.
-  if (params.streams && params.streams.length === 1 && !params.streams.includes("*")) {
-    const narrow = [["stream", params.streams[0]]];
-    body.set("narrow", JSON.stringify(narrow));
-  } else {
-    // For multiple streams or "*", get all public stream messages and filter client-side
-    body.set("all_public_streams", "true");
-  }
+  // A stream narrow excludes direct messages. Receive DMs plus subscribed/private and
+  // public stream messages, then enforce configured stream and topic policy client-side.
+  body.set("all_public_streams", "true");
 
   const payload = await client.request<
     ZulipApiResponse & { queue_id?: string; last_event_id?: number }

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -1562,6 +1562,39 @@ describe("monitorZulipProvider", () => {
     expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
   });
 
+  it("does not pace rejected public-stream traffic ahead of an eligible DM", async () => {
+    state.account.config = {
+      ...state.account.config,
+      streams: ["debbie"],
+    };
+    const unrelatedEvents = Array.from({ length: 20 }, (_, index) => ({
+      id: index + 1,
+      type: "message",
+      message: {
+        ...makeChannelMessage(4000 + index),
+        stream_id: 100 + index,
+        display_recipient: `unrelated-${index}`,
+      },
+    }));
+    state.pollResponses = [{
+      result: "success",
+      events: [
+        ...unrelatedEvents,
+        { id: 21, type: "message", message: makePrivateMessage(4020) },
+      ],
+    }];
+
+    await runMonitorOnce();
+
+    expect(fetchZulipStreamMock).not.toHaveBeenCalled();
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(state.core.channel.inbound.buildContext).toHaveReturnedWith(
+      expect.objectContaining({ ChatType: "direct" }),
+    );
+  });
+
   it("processes stream messages inside configured topic filters with case and whitespace normalization", async () => {
     state.account.config = {
       ...state.account.config,

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -1766,7 +1766,7 @@ describe("monitorZulipProvider", () => {
     }
   });
 
-  it("keeps a narrow queue when an enabled override is already covered by legacy streams", async () => {
+  it("keeps configured registration streams when an enabled override is already covered", async () => {
     state.account.streams = ["general"];
     state.account.config = {
       ...state.account.config,

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -509,6 +509,12 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     topic: string;
     policy: ResolvedZulipInboundStreamPolicy;
   };
+  type InboundStreamResolution =
+    | {
+      ok: true;
+      decision: InboundStreamDecision | typeof RETRYABLE_STREAM_POLICY | undefined;
+    }
+    | { ok: false; error: unknown };
 
   const resolveInboundStreamDecision = async (
     message: ZulipMessage,
@@ -1655,6 +1661,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
   const processMessage = async (
     message: ZulipMessage,
     queueEventId?: number,
+    streamResolution?: InboundStreamResolution,
   ): Promise<void> => {
     const messageId = String(message.id ?? "");
     const metadata: ZulipDurableInboundMetadata | undefined =
@@ -1693,7 +1700,12 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
 
     let streamDecision: InboundStreamDecision | typeof RETRYABLE_STREAM_POLICY | undefined;
     try {
-      streamDecision = await resolveInboundStreamDecision(message);
+      if (streamResolution?.ok === false) {
+        throw streamResolution.error;
+      }
+      streamDecision = streamResolution?.ok
+        ? streamResolution.decision
+        : await resolveInboundStreamDecision(message);
     } catch (err) {
       if (acceptInbound) {
         await acceptInbound();
@@ -1809,15 +1821,39 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
           }
 
           if (event.type === "message" && event.message) {
+            let streamResolution: InboundStreamResolution;
+            try {
+              streamResolution = {
+                ok: true,
+                decision: await resolveInboundStreamDecision(event.message),
+              };
+            } catch (error) {
+              streamResolution = { ok: false, error };
+            }
+            if (streamResolution.ok) {
+              const streamDecision = streamResolution.decision;
+              if (streamDecision === RETRYABLE_STREAM_POLICY) {
+                continue;
+              }
+              if (streamDecision && !streamDecision.accepted) {
+                logRejectedStreamDecision(
+                  streamDecision,
+                  event.message.sender_email?.trim() || String(event.message.sender_id ?? ""),
+                );
+                continue;
+              }
+            }
             // Start processing without awaiting (fire-and-forget with error handling)
-            const messageTask = processMessage(event.message, validEventId).catch((err) => {
-              runtime.error?.(`zulip: message processing failed: ${String(err)}`);
-            });
+            const messageTask = processMessage(event.message, validEventId, streamResolution).catch(
+              (err) => {
+                runtime.error?.(`zulip: message processing failed: ${String(err)}`);
+              },
+            );
             activeMessageTasks.add(messageTask);
             void messageTask.finally(() => {
               activeMessageTasks.delete(messageTask);
             });
-            // Small delay between starting each message for natural pacing
+            // Small delay between starting each eligible message for natural pacing
             await delay(200, opts.abortSignal);
           }
         }


### PR DESCRIPTION
## Summary

- register without a stream narrow so direct messages remain visible when exactly one stream is configured
- retain client-side stream/topic/sender policy enforcement before durable acceptance and side effects
- bypass eligible-message pacing for rejected broad-queue traffic
- add registration and traffic-pressure regressions

## Verification

- 270 Vitest tests passed
- 39 offline live-smoke tests passed
- TypeScript build passed
- independent exact-SHA review approved `f405172e781be8643e592a0d93283412fd0db99d`

Supports #24.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes event-queue registration and inbound filtering/pacing in the Zulip monitor, which can alter which messages are received and how quickly DMs are processed.
> 
> **Overview**
> Fixes a case where configuring **exactly one** stream caused the Zulip event queue to register with a **stream narrow**, which **drops direct messages**. `registerZulipQueue` now always uses `all_public_streams` (no `narrow`); stream/topic/sender rules still run in the monitor before durable acceptance or replies.
> 
> The poll loop **evaluates stream policy up front** for each message event, **skips** rejected public-stream traffic **without** the inter-message pacing delay, and passes that resolution into `processMessage` so eligible DMs are not delayed behind many filtered stream events.
> 
> Adds regression tests for registration body shape and for DM handling when a batch contains many out-of-policy stream messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f405172e781be8643e592a0d93283412fd0db99d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->