### PR TITLE
fix(smoke): verify Zulip DM participants by user ID

### DIFF
--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -63,23 +63,24 @@ export function redactError(error) {
     .slice(0, 500);
 }
 
-export function isBotMessage(event, botEmail, marker) {
-  if (event?.type !== "message" || event.message?.sender_email !== botEmail) return false;
+export function isBotMessage(event, botUserId, marker) {
+  if (event?.type !== "message" || !sameUserId(event.message?.sender_id, botUserId)) return false;
   return isExactRenderedContent(event.message?.content, marker);
 }
 
-export function isPrivateBotEvent(event, botEmail, actorEmail) {
-  if (event?.type !== "message" || event.message?.type !== "private" || event.message?.sender_email !== botEmail) return false;
+export function isPrivateBotEvent(event, botUserId, actorUserId) {
+  if (event?.type !== "message" || event.message?.type !== "private" ||
+    !sameUserId(event.message?.sender_id, botUserId)) return false;
   const recipients = Array.isArray(event.message?.display_recipient) ? event.message.display_recipient : [];
-  return hasExactDirectParticipants(recipients, botEmail, actorEmail);
+  return hasExactDirectParticipants(recipients, botUserId, actorUserId);
 }
 
-export function isPrivateBotMessage(event, botEmail, actorEmail, marker) {
-  return isPrivateBotEvent(event, botEmail, actorEmail) && isExactRenderedContent(event.message?.content, marker);
+export function isPrivateBotMessage(event, botUserId, actorUserId, marker) {
+  return isPrivateBotEvent(event, botUserId, actorUserId) && isExactRenderedContent(event.message?.content, marker);
 }
 
-export function isDurableReplyEvent(event, botEmail, actorEmail, marker) {
-  return isPrivateBotEvent(event, botEmail, actorEmail) && String(event.message?.content ?? "").includes(marker);
+export function isDurableReplyEvent(event, botUserId, actorUserId, marker) {
+  return isPrivateBotEvent(event, botUserId, actorUserId) && String(event.message?.content ?? "").includes(marker);
 }
 
 export function eventOccursBefore(events, first, second) {
@@ -103,28 +104,29 @@ export function captureMessageIds(events, predicate, target) {
   return matches;
 }
 
-export function captureObservedSmokeBotMessageIds(events, { botEmail, actorEmail, stream, runId }, target, excluded = new Set()) {
+export function captureObservedSmokeBotMessageIds(events, { botUserId, actorUserId, stream, runId }, target, excluded = new Set()) {
   return captureMessageIds(events, (event) => {
-    if (event?.type !== "message" || event.message?.sender_email !== botEmail || excluded.has(String(event.message?.id))) return false;
-    if (isPrivateBotEvent(event, botEmail, actorEmail)) return true;
+    if (event?.type !== "message" || !sameUserId(event.message?.sender_id, botUserId) || excluded.has(String(event.message?.id))) return false;
+    if (isPrivateBotEvent(event, botUserId, actorUserId)) return true;
     const content = String(event.message?.content ?? "");
     return content.includes(runId) || (event.message?.type === "stream" &&
       event.message?.display_recipient === stream && event.message?.subject === `${runId}-topic`);
   }, target);
 }
 
-export function isPrivateTypingEvent(event, botEmail, actorEmail, op) {
+export function isPrivateTypingEvent(event, botUserId, actorUserId, op) {
   if (event?.type !== "typing" || event.op !== op) return false;
-  const senderEmail = event.sender?.email ?? event.sender_email;
-  if (senderEmail !== botEmail || (event.message_type && !["direct", "private"].includes(event.message_type))) return false;
+  const senderUserId = event.sender?.user_id ?? event.sender?.id ?? event.sender_id;
+  if (!sameUserId(senderUserId, botUserId) ||
+    (event.message_type && !["direct", "private"].includes(event.message_type))) return false;
   const recipients = Array.isArray(event.recipients) ? event.recipients : [];
-  return hasExactDirectParticipants(recipients, botEmail, actorEmail);
+  return hasExactDirectParticipants(recipients, botUserId, actorUserId);
 }
 
-export function hasFinalPrivateTypingStop(events, botEmail, actorEmail) {
+export function hasFinalPrivateTypingStop(events, botUserId, actorUserId) {
   const lifecycle = events.filter((event) =>
-    isPrivateTypingEvent(event, botEmail, actorEmail, "start") ||
-    isPrivateTypingEvent(event, botEmail, actorEmail, "stop"));
+    isPrivateTypingEvent(event, botUserId, actorUserId, "start") ||
+    isPrivateTypingEvent(event, botUserId, actorUserId, "stop"));
   return lifecycle.some((event) => event.op === "start") && lifecycle.at(-1)?.op === "stop";
 }
 
@@ -140,16 +142,38 @@ export async function drainEventQueueUntilQuiet(queue, signal, quietMs = 500, ma
   throw new Error("Event queue did not reach a stable quiet window");
 }
 
-export async function assertFinalPrivateTypingStop(queue, eventStart, botEmail, actorEmail, signal, quietMs = 500, maxMs = 5000, pollIntervalMs = 100) {
+export async function assertFinalPrivateTypingStop(queue, eventStart, botUserId, actorUserId, signal, quietMs = 500, maxMs = 5000, pollIntervalMs = 100) {
   await drainEventQueueUntilQuiet(queue, signal, quietMs, maxMs, pollIntervalMs);
-  if (!hasFinalPrivateTypingStop(queue.events.slice(eventStart), botEmail, actorEmail)) {
+  if (!hasFinalPrivateTypingStop(queue.events.slice(eventStart), botUserId, actorUserId)) {
     throw new Error("Final direct typing state was not stopped after lifecycle completion");
   }
 }
 
-function hasExactDirectParticipants(recipients, botEmail, actorEmail) {
-  const emails = new Set(recipients.map((recipient) => recipient?.email ?? recipient).filter(Boolean));
-  return emails.size === 2 && emails.has(botEmail) && emails.has(actorEmail);
+function userId(value) {
+  const normalized = String(value ?? "").trim();
+  return /^[1-9][0-9]*$/.test(normalized) ? normalized : undefined;
+}
+
+function sameUserId(actual, expected) {
+  const actualId = userId(actual);
+  const expectedId = userId(expected);
+  return actualId !== undefined && expectedId !== undefined && actualId === expectedId;
+}
+
+export function authenticatedUserId(payload, label = "Zulip identity") {
+  const id = userId(payload?.user_id ?? payload?.id);
+  if (!id) throw new Error(`${label} did not return a valid user_id`);
+  return id;
+}
+
+function hasExactDirectParticipants(recipients, botUserId, actorUserId) {
+  const expectedBotId = userId(botUserId);
+  const expectedActorId = userId(actorUserId);
+  const participantIds = recipients.map((recipient) =>
+    userId(recipient?.id ?? recipient?.user_id ?? recipient));
+  const uniqueIds = new Set(participantIds);
+  return recipients.length === 2 && participantIds.every(Boolean) && uniqueIds.size === 2 &&
+    uniqueIds.has(expectedBotId) && uniqueIds.has(expectedActorId);
 }
 
 export function isExactRenderedContent(content, expected) {
@@ -582,6 +606,11 @@ async function main() {
   const runId = `smoke-${env.SMOKE_TESTED_SHA.slice(0, 8)}-${randomBytes(5).toString("hex")}`;
   const actor = new ZulipClient(env.ZULIP_URL, env.ZULIP_SMOKE_USER_EMAIL, env.ZULIP_SMOKE_USER_API_KEY);
   const bot = new ZulipClient(env.ZULIP_URL, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_BOT_API_KEY);
+  const [actorUserId, botUserId] = await Promise.all([
+    actor.request("users/me").then((payload) => authenticatedUserId(payload, "Smoke actor")),
+    bot.request("users/me").then((payload) => authenticatedUserId(payload, "Smoke bot")),
+  ]);
+  if (actorUserId === botUserId) throw new Error("Smoke actor and bot resolved to the same Zulip user_id");
   const queue = new EventQueue(actor);
   const gateway = new Gateway(env.SMOKE_GATEWAY_PORT || 18789);
   const gatewayGenerationPath = resolve("scripts/live-smoke/agent-workspace/.smoke-gateway-generation");
@@ -621,7 +650,7 @@ async function main() {
 
     await scenario("dm-round-trip", async (signal) => {
       const marker = `${runId}:dm-ok`; await sendDm(command(`echo ${marker}`), signal);
-      const event = await queue.waitFor((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, marker), timeoutMs, "DM reply", signal);
+      const event = await queue.waitFor((e) => isPrivateBotMessage(e, botUserId, actorUserId, marker), timeoutMs, "DM reply", signal);
       messageIds.bot.add(String(event.message.id));
     });
 
@@ -629,14 +658,14 @@ async function main() {
       const marker = `${runId}:stream-ok`; const topic = `${runId}-topic`;
       const sent = await actor.request("messages", { method: "POST", body: { type: "stream", to: env.ZULIP_SMOKE_STREAM, topic, content: command(`echo ${marker}`) }, signal });
       messageIds.actor.add(String(sent.id));
-      const event = await queue.waitFor((e) => isBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, marker) && e.message?.display_recipient === env.ZULIP_SMOKE_STREAM && e.message?.subject === topic, timeoutMs, "stream/topic reply", signal);
+      const event = await queue.waitFor((e) => isBotMessage(e, botUserId, marker) && e.message?.display_recipient === env.ZULIP_SMOKE_STREAM && e.message?.subject === topic, timeoutMs, "stream/topic reply", signal);
       messageIds.bot.add(String(event.message.id));
     });
 
     await scenario("typing-and-lifecycle-reactions", async (signal) => {
       const marker = `${runId}:lifecycle-ok`; const childResult = `${runId}:child-ok`; const eventStart = queue.events.length;
       const inboundId = await sendDm(command(`lifecycle ${marker} ${childResult}`), signal);
-      const reply = await queue.waitFor((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, marker), timeoutMs, "lifecycle reply", signal);
+      const reply = await queue.waitFor((e) => isPrivateBotMessage(e, botUserId, actorUserId, marker), timeoutMs, "lifecycle reply", signal);
       messageIds.bot.add(String(reply.message.id));
       const deadline = Date.now() + timeoutMs;
       let summary;
@@ -657,9 +686,9 @@ async function main() {
       }
       await drainEventQueueUntilQuiet(queue, signal, 500, timeoutMs, 100, () =>
         lifecycleSummary(queue.events, inboundId).allRemoved &&
-        hasFinalPrivateTypingStop(queue.events.slice(eventStart), env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL));
+        hasFinalPrivateTypingStop(queue.events.slice(eventStart), botUserId, actorUserId));
       summary = lifecycleSummary(queue.events, inboundId);
-      if (!hasFinalPrivateTypingStop(queue.events.slice(eventStart), env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL)) {
+      if (!hasFinalPrivateTypingStop(queue.events.slice(eventStart), botUserId, actorUserId)) {
         throw new Error("Final direct typing state was not stopped after lifecycle completion");
       }
       if (!summary.added.length) throw new Error("No lifecycle reaction was observed on the inbound message");
@@ -675,7 +704,7 @@ async function main() {
       const marker = `${runId}:reacted`;
       const inboundId = await sendDm(command(`react 🎉 ${marker}`), signal);
       const reaction = await queue.waitFor((e) => e.type === "reaction" && e.op === "add" && String(e.message_id) === inboundId && (e.emoji_name === "tada" || e.emoji_code === "1f389"), timeoutMs, "explicit reaction", signal);
-      const reply = await queue.waitFor((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, marker), timeoutMs, "reaction acknowledgement", signal);
+      const reply = await queue.waitFor((e) => isPrivateBotMessage(e, botUserId, actorUserId, marker), timeoutMs, "reaction acknowledgement", signal);
       messageIds.bot.add(String(reply.message.id));
       if (!eventOccursBefore(queue.events, reaction, reply)) {
         throw new Error("Reaction acknowledgement arrived before the requested reaction");
@@ -685,7 +714,7 @@ async function main() {
     await scenario("edit-delete", async (signal) => {
       const before = `${runId}:before-edit`; const after = `${runId}:after-edit`;
       await sendDm(command(`edit-delete ${before} ${after}`), signal);
-      const created = await queue.waitFor((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, before), timeoutMs, "message before edit", signal);
+      const created = await queue.waitFor((e) => isPrivateBotMessage(e, botUserId, actorUserId, before), timeoutMs, "message before edit", signal);
       const id = String(created.message.id); messageIds.bot.add(id);
       await queue.waitFor((e) => e.type === "update_message" && String(e.message_id) === id && isExactRenderedContent(e.content, after), timeoutMs, "message edit", signal);
       await assertMessageRemainsExact(actor, id, after, 4000, signal);
@@ -696,10 +725,10 @@ async function main() {
     await scenario("upload-download", async (signal) => {
       const inboundMarker = `${runId}:inbound-upload`; const uri = await actor.upload(`${runId}.txt`, inboundMarker, signal);
       await sendDm(`${command(`read-upload ${inboundMarker}`)}\n[attachment](${uri})`, signal);
-      const inboundReply = await queue.waitFor((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, inboundMarker), timeoutMs, "inbound upload read", signal);
+      const inboundReply = await queue.waitFor((e) => isPrivateBotMessage(e, botUserId, actorUserId, inboundMarker), timeoutMs, "inbound upload read", signal);
       messageIds.bot.add(String(inboundReply.message.id));
       const outboundMarker = `${runId}:outbound-upload`; await sendDm(command(`send-upload ${outboundMarker}`), signal);
-      const outbound = await queue.waitFor((e) => isPrivateBotEvent(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL) &&
+      const outbound = await queue.waitFor((e) => isPrivateBotEvent(e, botUserId, actorUserId) &&
         Boolean(extractExactUploadUrl(e.message?.content)), timeoutMs, "outbound upload", signal);
       messageIds.bot.add(String(outbound.message.id));
       const uploadUrl = extractExactUploadUrl(outbound.message.content);
@@ -710,26 +739,26 @@ async function main() {
       const question = `${runId}:poll`; const optionA = `smoke-choice:${runId}:interactive-ok`; const optionB = `${runId}:beta`;
       await sendDm(command(`poll ${question} ${optionA} ${optionB}`), signal);
       const poll = await queue.waitFor((e) => {
-        if (!isPrivateBotEvent(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL)) return false;
+        if (!isPrivateBotEvent(e, botUserId, actorUserId)) return false;
         return isExactPollMessage(e.message, question, [optionA, optionB]);
       }, timeoutMs, "native poll", signal);
       messageIds.bot.add(String(poll.message.id));
       await sendDm(optionA, signal);
-      const reply = await queue.waitFor((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, `${runId}:interactive-ok`), timeoutMs, "interactive reply", signal);
+      const reply = await queue.waitFor((e) => isPrivateBotMessage(e, botUserId, actorUserId, `${runId}:interactive-ok`), timeoutMs, "interactive reply", signal);
       messageIds.bot.add(String(reply.message.id));
     });
 
     await scenario("durable-receive-completion-deduplication", async (signal) => {
       const marker = `${runId}:durable-ok`;
       const isAttributable = (event) =>
-        isDurableReplyEvent(event, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, marker);
+        isDurableReplyEvent(event, botUserId, actorUserId, marker);
       const captureReplies = () => captureMessageIds(queue.events, isAttributable, messageIds.bot);
       try {
         const oldGeneration = randomBytes(16).toString("hex");
         await writeGatewayGeneration(gatewayGenerationPath, oldGeneration);
         const inboundId = await sendDm(command(`durable ${marker}`), signal);
         const commandEvent = await queue.waitFor((e) => e.type === "message" &&
-          String(e.message?.id) === inboundId && e.message?.sender_email === env.ZULIP_SMOKE_USER_EMAIL,
+          String(e.message?.id) === inboundId && sameUserId(e.message?.sender_id, actorUserId),
         timeoutMs, "durable command event", signal);
         await queue.waitFor((e) => e.type === "reaction" && e.op === "add" && String(e.message_id) === inboundId, timeoutMs, "durable accept signal", signal);
         if (captureReplies().length) {
@@ -743,7 +772,7 @@ async function main() {
         const reply = await queue.waitFor((e) => {
           if (!isAttributable(e)) return false;
           captureReplies();
-          if (!isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, replacementReply)) {
+          if (!isPrivateBotMessage(e, botUserId, actorUserId, replacementReply)) {
             throw new Error("Durable reply did not contain the replacement gateway generation");
           }
           if (!hasProvableMinimumMessageDelay(commandEvent, e, 15)) {
@@ -755,7 +784,7 @@ async function main() {
         const settleDeadline = Date.now() + 10000;
         while (Date.now() < settleDeadline) { await queue.poll(signal); await delay(500, undefined, { signal }); }
         const replies = captureReplies();
-        const validReplies = replies.filter((e) => isPrivateBotMessage(e, env.ZULIP_SMOKE_BOT_EMAIL, env.ZULIP_SMOKE_USER_EMAIL, replacementReply));
+        const validReplies = replies.filter((e) => isPrivateBotMessage(e, botUserId, actorUserId, replacementReply));
         if (replies.length !== 1 || validReplies.length !== 1) {
           throw new Error(`Durable receive produced ${replies.length} attributable replies (${validReplies.length} valid); expected exactly one valid replacement reply`);
         }
@@ -770,8 +799,8 @@ async function main() {
     await unlink(gatewayGenerationPath).catch(() => {});
     await queue.poll().catch(() => {});
     captureObservedSmokeBotMessageIds(queue.events, {
-      botEmail: env.ZULIP_SMOKE_BOT_EMAIL,
-      actorEmail: env.ZULIP_SMOKE_USER_EMAIL,
+      botUserId,
+      actorUserId,
       stream: env.ZULIP_SMOKE_STREAM,
       runId,
     }, messageIds.bot, deletedBotMessageIds);

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -6,7 +6,10 @@ import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { assertFinalPrivateTypingStop, assertMessageRemainsExact, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, drainEventQueueUntilQuiet, eventOccursBefore, EventQueue, extractExactUploadUrl, Gateway, hasFinalPrivateTypingStop, hasProvableMinimumMessageDelay, inspectChildTranscripts, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactPollMessage, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, isUsageCountedTranscriptName, lifecycleSummary, normalizeScenarioError, probeRunnerLocalGatewayHealth, redactError, resolveUploadUrl, signalProcessTree, subagentCompletedBeforeReply, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
+import { assertFinalPrivateTypingStop, assertMessageRemainsExact, authenticatedUserId, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, drainEventQueueUntilQuiet, eventOccursBefore, EventQueue, extractExactUploadUrl, Gateway, hasFinalPrivateTypingStop, hasProvableMinimumMessageDelay, inspectChildTranscripts, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactPollMessage, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, isUsageCountedTranscriptName, lifecycleSummary, normalizeScenarioError, probeRunnerLocalGatewayHealth, redactError, resolveUploadUrl, signalProcessTree, subagentCompletedBeforeReply, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
+
+const ACTOR_USER_ID = "42";
+const BOT_USER_ID = "91";
 
 const validEnv = {
   ZULIP_URL: "https://zulip.example.test/path",
@@ -44,51 +47,65 @@ test("redacts URLs and authorization values", () => {
 });
 
 test("matches only marked messages from the configured bot", () => {
-  const event = { type: "message", message: { sender_email: "bot@example.test", content: "marker" } };
-  assert.equal(isBotMessage(event, "bot@example.test", "marker"), true);
-  assert.equal(isBotMessage({ ...event, message: { ...event.message, content: "<p>marker</p>" } }, "bot@example.test", "marker"), true);
-  assert.equal(isBotMessage({ ...event, message: { ...event.message, content: "prefix marker" } }, "bot@example.test", "marker"), false);
-  assert.equal(isBotMessage(event, "other@example.test", "marker"), false);
+  const event = { type: "message", message: { sender_id: Number(BOT_USER_ID), content: "marker" } };
+  assert.equal(isBotMessage(event, BOT_USER_ID, "marker"), true);
+  assert.equal(isBotMessage({ ...event, message: { ...event.message, content: "<p>marker</p>" } }, BOT_USER_ID, "marker"), true);
+  assert.equal(isBotMessage({ ...event, message: { ...event.message, content: "prefix marker" } }, BOT_USER_ID, "marker"), false);
+  assert.equal(isBotMessage(event, "92", "marker"), false);
+  assert.equal(isBotMessage({ type: "message", message: { content: "marker" } }, undefined, "marker"), false);
 });
 
-test("requires private bot replies with the expected participants", () => {
-  const event = { type: "message", message: { type: "private", sender_email: "bot@example.test", content: "marker", display_recipient: [
-    { email: "bot@example.test" }, { email: "user@example.test" },
+test("requires private bot replies with the exact user IDs despite differing login emails", () => {
+  const event = { type: "message", message: { type: "private", sender_id: Number(BOT_USER_ID), sender_email: "bot-event@example.test", content: "marker", display_recipient: [
+    { id: Number(BOT_USER_ID), email: "bot-event@example.test" },
+    { id: Number(ACTOR_USER_ID), email: "actor-event@example.test" },
   ] } };
-  assert.equal(isPrivateBotMessage(event, "bot@example.test", "user@example.test", "marker"), true);
-  assert.equal(isPrivateBotMessage({ ...event, message: { ...event.message, type: "stream" } }, "bot@example.test", "user@example.test", "marker"), false);
-  assert.equal(isPrivateBotMessage({ ...event, message: { ...event.message, display_recipient: [{ email: "bot@example.test" }] } }, "bot@example.test", "user@example.test", "marker"), false);
-  assert.equal(isPrivateBotMessage({ ...event, message: { ...event.message, display_recipient: [...event.message.display_recipient, { email: "third@example.test" }] } }, "bot@example.test", "user@example.test", "marker"), false);
+  assert.equal(isPrivateBotMessage(event, BOT_USER_ID, ACTOR_USER_ID, "marker"), true);
+  assert.equal(isPrivateBotMessage({ ...event, message: { ...event.message, sender_id: undefined } }, undefined, ACTOR_USER_ID, "marker"), false);
+  assert.equal(isPrivateBotMessage({ ...event, message: { ...event.message, type: "stream" } }, BOT_USER_ID, ACTOR_USER_ID, "marker"), false);
+  assert.equal(isPrivateBotMessage({ ...event, message: { ...event.message, display_recipient: [{ id: Number(BOT_USER_ID) }] } }, BOT_USER_ID, ACTOR_USER_ID, "marker"), false);
+  assert.equal(isPrivateBotMessage({ ...event, message: { ...event.message, display_recipient: [...event.message.display_recipient, { id: 7 }] } }, BOT_USER_ID, ACTOR_USER_ID, "marker"), false);
   const uploadEvent = { ...event, message: { ...event.message, content: "[file](/user_uploads/a.txt)" } };
-  assert.equal(isPrivateBotEvent(uploadEvent, "bot@example.test", "user@example.test"), true);
-  assert.equal(isPrivateBotEvent({ ...uploadEvent, message: { ...uploadEvent.message, type: "stream" } }, "bot@example.test", "user@example.test"), false);
+  assert.equal(isPrivateBotEvent(uploadEvent, BOT_USER_ID, ACTOR_USER_ID), true);
+  assert.equal(isPrivateBotEvent({ ...uploadEvent, message: { ...uploadEvent.message, type: "stream" } }, BOT_USER_ID, ACTOR_USER_ID), false);
 });
 
-test("matches private typing events from the configured bot", () => {
-  const event = { type: "typing", op: "start", message_type: "direct", sender: { email: "bot@example.test" }, recipients: [
-    { email: "bot@example.test" }, { email: "user@example.test" },
+test("matches private typing by user ID across supported sender payload shapes", () => {
+  const event = { type: "typing", op: "start", message_type: "direct", sender: { user_id: Number(BOT_USER_ID), email: "bot-event@example.test" }, recipients: [
+    { user_id: Number(BOT_USER_ID), email: "bot-event@example.test" },
+    { user_id: Number(ACTOR_USER_ID), email: "actor-event@example.test" },
   ] };
-  assert.equal(isPrivateTypingEvent(event, "bot@example.test", "user@example.test", "start"), true);
-  assert.equal(isPrivateTypingEvent({ ...event, op: "stop" }, "bot@example.test", "user@example.test", "start"), false);
-  assert.equal(isPrivateTypingEvent({ ...event, sender: { email: "other@example.test" } }, "bot@example.test", "user@example.test", "start"), false);
-  assert.equal(isPrivateTypingEvent({ ...event, recipients: [...event.recipients, { email: "third@example.test" }] }, "bot@example.test", "user@example.test", "start"), false);
+  assert.equal(isPrivateTypingEvent(event, BOT_USER_ID, ACTOR_USER_ID, "start"), true);
+  assert.equal(isPrivateTypingEvent({ ...event, sender: { id: Number(BOT_USER_ID) } }, BOT_USER_ID, ACTOR_USER_ID, "start"), true);
+  assert.equal(isPrivateTypingEvent({ ...event, sender: undefined, sender_id: Number(BOT_USER_ID) }, BOT_USER_ID, ACTOR_USER_ID, "start"), true);
+  assert.equal(isPrivateTypingEvent({ ...event, op: "stop" }, BOT_USER_ID, ACTOR_USER_ID, "start"), false);
+  assert.equal(isPrivateTypingEvent({ ...event, sender: { user_id: 92 } }, BOT_USER_ID, ACTOR_USER_ID, "start"), false);
+  assert.equal(isPrivateTypingEvent({ ...event, sender: undefined }, undefined, ACTOR_USER_ID, "start"), false);
+  assert.equal(isPrivateTypingEvent({ ...event, recipients: [...event.recipients, { id: 7 }] }, BOT_USER_ID, ACTOR_USER_ID, "start"), false);
+});
+
+test("extracts authenticated Zulip user IDs and rejects malformed identity responses", () => {
+  assert.equal(authenticatedUserId({ user_id: 42 }, "Smoke actor"), ACTOR_USER_ID);
+  assert.equal(authenticatedUserId({ id: "91" }, "Smoke bot"), BOT_USER_ID);
+  assert.throws(() => authenticatedUserId({ user_id: "actor@example.test" }, "Smoke actor"),
+    /Smoke actor did not return a valid user_id/);
 });
 
 test("requires the final matching typing event to stop", () => {
-  const base = { type: "typing", message_type: "direct", sender: { email: "bot@example.test" }, recipients: [
-    { email: "bot@example.test" }, { email: "user@example.test" },
+  const base = { type: "typing", message_type: "direct", sender: { user_id: Number(BOT_USER_ID) }, recipients: [
+    { id: Number(BOT_USER_ID) }, { id: Number(ACTOR_USER_ID) },
   ] };
   const start = { ...base, op: "start" };
   const stop = { ...base, op: "stop" };
-  assert.equal(hasFinalPrivateTypingStop([start, stop], "bot@example.test", "user@example.test"), true);
-  assert.equal(hasFinalPrivateTypingStop([start, stop, start], "bot@example.test", "user@example.test"), false);
-  assert.equal(hasFinalPrivateTypingStop([stop], "bot@example.test", "user@example.test"), false);
-  assert.equal(hasFinalPrivateTypingStop([start, stop, { ...start, sender: { email: "other@example.test" } }], "bot@example.test", "user@example.test"), true);
+  assert.equal(hasFinalPrivateTypingStop([start, stop], BOT_USER_ID, ACTOR_USER_ID), true);
+  assert.equal(hasFinalPrivateTypingStop([start, stop, start], BOT_USER_ID, ACTOR_USER_ID), false);
+  assert.equal(hasFinalPrivateTypingStop([stop], BOT_USER_ID, ACTOR_USER_ID), false);
+  assert.equal(hasFinalPrivateTypingStop([start, stop, { ...start, sender: { user_id: 92 } }], BOT_USER_ID, ACTOR_USER_ID), true);
 });
 
 test("rechecks the final typing state after draining later events", async () => {
-  const base = { type: "typing", message_type: "direct", sender: { email: "bot@example.test" }, recipients: [
-    { email: "bot@example.test" }, { email: "user@example.test" },
+  const base = { type: "typing", message_type: "direct", sender: { user_id: Number(BOT_USER_ID) }, recipients: [
+    { id: Number(BOT_USER_ID) }, { id: Number(ACTOR_USER_ID) },
   ] };
   const start = { ...base, op: "start" };
   const stop = { ...base, op: "stop" };
@@ -102,7 +119,7 @@ test("rechecks the final typing state after draining later events", async () => 
     },
   };
   await assert.rejects(
-    assertFinalPrivateTypingStop(queue, 0, "bot@example.test", "user@example.test", undefined, 10, 100, 0),
+    assertFinalPrivateTypingStop(queue, 0, BOT_USER_ID, ACTOR_USER_ID, undefined, 10, 100, 0),
     /Final direct typing state was not stopped/,
   );
 });
@@ -167,8 +184,8 @@ test("waits through the locked default terminal hold until lifecycle cleanup", a
 
 test("does not settle when a late typing start follows the earlier stop", async () => {
   const reaction = { type: "reaction", message_id: 42, user_id: 7, reaction_type: "unicode_emoji", emoji_name: "robot", emoji_code: "1f916" };
-  const typing = { type: "typing", message_type: "direct", sender: { email: "bot@example.test" }, recipients: [
-    { email: "bot@example.test" }, { email: "user@example.test" },
+  const typing = { type: "typing", message_type: "direct", sender: { user_id: Number(BOT_USER_ID) }, recipients: [
+    { id: Number(BOT_USER_ID) }, { id: Number(ACTOR_USER_ID) },
   ] };
   const events = [{ ...reaction, op: "add" }, { ...reaction, op: "remove" }, { ...typing, op: "start" }, { ...typing, op: "stop" }];
   const started = Date.now();
@@ -185,11 +202,11 @@ test("does not settle when a late typing start follows the earlier stop", async 
   await assert.rejects(
     drainEventQueueUntilQuiet(queue, undefined, 30, 100, 5, () =>
       lifecycleSummary(queue.events, "42").allRemoved &&
-      hasFinalPrivateTypingStop(queue.events, "bot@example.test", "user@example.test")),
+      hasFinalPrivateTypingStop(queue.events, BOT_USER_ID, ACTOR_USER_ID)),
     /stable quiet window/,
   );
   assert.equal(lateStartSent, true);
-  assert.equal(hasFinalPrivateTypingStop(queue.events, "bot@example.test", "user@example.test"), false);
+  assert.equal(hasFinalPrivateTypingStop(queue.events, BOT_USER_ID, ACTOR_USER_ID), false);
 });
 
 test("matches complete raw or Zulip-rendered content", () => {
@@ -201,13 +218,13 @@ test("matches complete raw or Zulip-rendered content", () => {
 });
 
 test("attributes every configured-bot DM containing the unique durable marker", () => {
-  const base = { type: "message", message: { type: "private", sender_email: "bot@example.test", display_recipient: [
-    { email: "bot@example.test" }, { email: "user@example.test" },
+  const base = { type: "message", message: { type: "private", sender_id: Number(BOT_USER_ID), display_recipient: [
+    { id: Number(BOT_USER_ID) }, { id: Number(ACTOR_USER_ID) },
   ] } };
   for (const content of ["durable-marker", "durable-marker:old", "<p>durable-marker:wrong</p>", "prefix durable-marker suffix"]) {
-    assert.equal(isDurableReplyEvent({ ...base, message: { ...base.message, content } }, "bot@example.test", "user@example.test", "durable-marker"), true);
+    assert.equal(isDurableReplyEvent({ ...base, message: { ...base.message, content } }, BOT_USER_ID, ACTOR_USER_ID, "durable-marker"), true);
   }
-  assert.equal(isDurableReplyEvent({ ...base, message: { ...base.message, sender_email: "other@example.test", content: "durable-marker" } }, "bot@example.test", "user@example.test", "durable-marker"), false);
+  assert.equal(isDurableReplyEvent({ ...base, message: { ...base.message, sender_id: 92, content: "durable-marker" } }, BOT_USER_ID, ACTOR_USER_ID, "durable-marker"), false);
 });
 
 test("requires the explicit reaction event to precede its acknowledgement", () => {
@@ -238,21 +255,21 @@ test("captures every attributable reply id before an early failure", () => {
 });
 
 test("captures every observed in-run bot message while excluding already deleted messages", () => {
-  const dm = (id, content, sender = "bot@example.test") => ({ type: "message", message: {
-    id, type: "private", sender_email: sender, content, display_recipient: [
-      { email: "bot@example.test" }, { email: "user@example.test" },
+  const dm = (id, content, senderId = Number(BOT_USER_ID)) => ({ type: "message", message: {
+    id, type: "private", sender_id: senderId, content, display_recipient: [
+      { id: Number(BOT_USER_ID) }, { id: Number(ACTOR_USER_ID) },
     ],
   } });
   const events = [
     dm(1, "malformed extra output"),
     dm(2, "already deleted"),
-    dm(3, "other sender", "other@example.test"),
-    { type: "message", message: { id: 4, type: "stream", sender_email: "bot@example.test", content: "wrong", display_recipient: "smoke", subject: "run-id-topic" } },
-    { type: "message", message: { id: 5, type: "stream", sender_email: "bot@example.test", content: "run-id marker", display_recipient: "other", subject: "other" } },
+    dm(3, "other sender", 92),
+    { type: "message", message: { id: 4, type: "stream", sender_id: Number(BOT_USER_ID), content: "wrong", display_recipient: "smoke", subject: "run-id-topic" } },
+    { type: "message", message: { id: 5, type: "stream", sender_id: Number(BOT_USER_ID), content: "run-id marker", display_recipient: "other", subject: "other" } },
   ];
   const ids = new Set();
   const matches = captureObservedSmokeBotMessageIds(events, {
-    botEmail: "bot@example.test", actorEmail: "user@example.test", stream: "smoke", runId: "run-id",
+    botUserId: BOT_USER_ID, actorUserId: ACTOR_USER_ID, stream: "smoke", runId: "run-id",
   }, ids, new Set(["2"]));
   assert.equal(matches.length, 3);
   assert.deepEqual([...ids], ["1", "4", "5"]);


### PR DESCRIPTION
## Summary

- authenticate both protected smoke identities through `users/me`
- attribute message and typing events by stable Zulip user IDs instead of visibility-dependent emails
- require exact two-party DM membership and fail closed on malformed identities
- preserve existing private login credentials and add no new secret

## Verification

- 270 Vitest tests passed
- 40 offline live-smoke tests passed
- TypeScript build passed
- independent exact-SHA review approved `0a766c0ed4a234c63d8a68987d5fa7d0bf26cd6d`

Supports #24. Live evidence: run 33352618179 produced the exact bot reply, but the prior email-based participant predicate rejected it because the actor login and event identities differ.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to live-smoke scripts and offline tests; production Zulip integration behavior is unchanged.
> 
> **Overview**
> Live smoke now resolves the actor and bot through `users/me` and matches messages, DMs, and typing events by **stable Zulip user IDs** instead of emails, so scenarios still pass when event payloads use different addresses than the configured login emails.
> 
> **Helpers added/updated:** `authenticatedUserId`, `sameUserId`, and stricter two-party DM checks on recipient `id`/`user_id`. Startup **fails closed** if identities are invalid or actor and bot share the same `user_id`. Offline tests were rewritten around ID-based fixtures, including cases where event emails differ from env credentials.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a766c0ed4a234c63d8a68987d5fa7d0bf26cd6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->