### PR TITLE
fix(smoke): wait for gateway channel startup

### DIFF
--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -466,32 +466,67 @@ export class EventQueue {
 }
 
 export class Gateway {
-  constructor(port, { termTimeoutMs = 10000, killTimeoutMs = 5000, healthProbe, healthProbeTimeoutMs = 2000 } = {}) {
+  constructor(port, {
+    termTimeoutMs = 10000,
+    killTimeoutMs = 5000,
+    healthProbe,
+    healthProbeTimeoutMs = 2000,
+    startupSettleMs = 5000,
+    startupSettlePollMs = 250,
+    spawnImpl = spawn,
+    wait = (ms, signal) => delay(ms, undefined, { signal }),
+    now = () => Date.now(),
+  } = {}) {
     this.port = String(port);
     this.termTimeoutMs = termTimeoutMs;
     this.killTimeoutMs = killTimeoutMs;
     this.healthProbe = healthProbe;
     this.healthProbeTimeoutMs = healthProbeTimeoutMs;
+    this.startupSettleMs = startupSettleMs;
+    this.startupSettlePollMs = startupSettlePollMs;
+    this.spawnImpl = spawnImpl;
+    this.wait = wait;
+    this.now = now;
   }
   async start(signal) {
     signal?.throwIfAborted();
     if (this.process && isProcessTreeRunning(this.process)) throw new Error("Runner-local OpenClaw gateway is already running");
-    this.process = spawn("pnpm", ["exec", "openclaw", "gateway", "run", "--bind", "loopback", "--port", this.port, "--auth", "none", "--compact"], {
+    this.process = this.spawnImpl("pnpm", ["exec", "openclaw", "gateway", "run", "--bind", "loopback", "--port", this.port, "--auth", "none", "--compact"], {
       cwd: process.cwd(), env: process.env, stdio: ["ignore", "ignore", "ignore"], detached: process.platform !== "win32",
     });
     const child = this.process;
-    const deadline = Date.now() + 30000;
-    while (Date.now() < deadline) {
+    const deadline = this.now() + 30000;
+    while (this.now() < deadline) {
       signal?.throwIfAborted();
       if (!isChildRunning(child)) throw new Error("Runner-local OpenClaw gateway exited during startup");
       if (await this.isHealthy()) {
-        await delay(500, undefined, { signal });
+        await this.wait(500, signal);
         if (!isChildRunning(child)) throw new Error("Runner-local OpenClaw gateway exited during startup");
-        if (await this.isHealthy()) return;
+        if (await this.isHealthy()) {
+          await this.waitForStartupStability(child, signal);
+          return;
+        }
       }
-      await delay(1000, undefined, { signal });
+      await this.wait(1000, signal);
     }
     throw new Error("Runner-local OpenClaw gateway did not become healthy within 30s");
+  }
+  async waitForStartupStability(child, signal) {
+    const deadline = this.now() + this.startupSettleMs;
+    while (this.now() < deadline) {
+      signal?.throwIfAborted();
+      if (!isChildRunning(child)) {
+        throw new Error("Runner-local OpenClaw gateway exited during startup stabilization");
+      }
+      await this.wait(Math.min(this.startupSettlePollMs, deadline - this.now()), signal);
+    }
+    signal?.throwIfAborted();
+    if (!isChildRunning(child)) {
+      throw new Error("Runner-local OpenClaw gateway exited during startup stabilization");
+    }
+    if (!await this.isHealthy()) {
+      throw new Error("Runner-local OpenClaw gateway became unhealthy during startup stabilization");
+    }
   }
   async isHealthy() {
     if (this.healthProbe) return this.healthProbe();

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -524,7 +524,12 @@ export class Gateway {
     if (!isChildRunning(child)) {
       throw new Error("Runner-local OpenClaw gateway exited during startup stabilization");
     }
-    if (!await this.isHealthy()) {
+    const healthy = await this.isHealthy();
+    signal?.throwIfAborted();
+    if (!isChildRunning(child)) {
+      throw new Error("Runner-local OpenClaw gateway exited during final startup health probe");
+    }
+    if (!healthy) {
       throw new Error("Runner-local OpenClaw gateway became unhealthy during startup stabilization");
     }
   }

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -492,6 +492,79 @@ test("waits for gateway exit after escalating to SIGKILL", async () => {
   assert.equal(gateway.process, undefined);
 });
 
+test("does not begin scenario traffic until gateway startup stabilization finishes", async () => {
+  const child = { exitCode: null, signalCode: null };
+  let clock = 0;
+  let releaseStabilization;
+  let stabilizationStarted;
+  const stabilization = new Promise((resolve) => { releaseStabilization = resolve; });
+  const enteredStabilization = new Promise((resolve) => { stabilizationStarted = resolve; });
+  const waits = [];
+  const gateway = new Gateway(18789, {
+    healthProbe: async () => true,
+    startupSettleMs: 250,
+    spawnImpl: () => child,
+    now: () => clock,
+    wait: async (ms, signal) => {
+      waits.push(ms);
+      signal?.throwIfAborted();
+      if (ms === 250) {
+        stabilizationStarted();
+        await stabilization;
+      }
+      clock += ms;
+      signal?.throwIfAborted();
+    },
+  });
+  let scenarioSendStarted = false;
+  const scenario = gateway.start().then(() => { scenarioSendStarted = true; });
+
+  await enteredStabilization;
+  assert.equal(scenarioSendStarted, false);
+  releaseStabilization();
+  await scenario;
+
+  assert.equal(scenarioSendStarted, true);
+  assert.deepEqual(waits, [500, 250]);
+});
+
+test("fails startup if the gateway exits during stabilization", async () => {
+  const child = { exitCode: null, signalCode: null };
+  let clock = 0;
+  const gateway = new Gateway(18789, {
+    healthProbe: async () => true,
+    startupSettleMs: 250,
+    spawnImpl: () => child,
+    now: () => clock,
+    wait: async (ms) => {
+      clock += ms;
+      if (ms === 250) child.exitCode = 1;
+    },
+  });
+
+  await assert.rejects(gateway.start(), /gateway exited during startup stabilization/);
+});
+
+test("aborts gateway startup during stabilization", async () => {
+  const child = { exitCode: null, signalCode: null };
+  const controller = new AbortController();
+  const abortReason = new Error("cancel startup");
+  let clock = 0;
+  const gateway = new Gateway(18789, {
+    healthProbe: async () => true,
+    startupSettleMs: 250,
+    spawnImpl: () => child,
+    now: () => clock,
+    wait: async (ms, signal) => {
+      clock += ms;
+      if (ms === 250) controller.abort(abortReason);
+      signal?.throwIfAborted();
+    },
+  });
+
+  await assert.rejects(gateway.start(controller.signal), (error) => error === abortReason);
+});
+
 test("accepts only HTTP 200 from the runner-local health endpoint without auth", async () => {
   const requests = [];
   const server = createServer((request, response) => {

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -565,6 +565,67 @@ test("aborts gateway startup during stabilization", async () => {
   await assert.rejects(gateway.start(controller.signal), (error) => error === abortReason);
 });
 
+function createDeferredFinalHealthGateway() {
+  const child = { exitCode: null, signalCode: null };
+  let clock = 0;
+  let healthProbeCount = 0;
+  let markFinalProbeStarted;
+  let resolveFinalProbe;
+  const finalProbeStarted = new Promise((resolve) => { markFinalProbeStarted = resolve; });
+  const finalProbe = new Promise((resolve) => { resolveFinalProbe = resolve; });
+  const gateway = new Gateway(18789, {
+    healthProbe: async () => {
+      healthProbeCount += 1;
+      if (healthProbeCount < 3) return true;
+      markFinalProbeStarted();
+      return finalProbe;
+    },
+    startupSettleMs: 250,
+    spawnImpl: () => child,
+    now: () => clock,
+    wait: async (ms, signal) => {
+      signal?.throwIfAborted();
+      clock += ms;
+    },
+  });
+  return { child, finalProbeStarted, gateway, resolveFinalProbe };
+}
+
+test("aborts startup when cancellation arrives during the final health probe", async () => {
+  const controller = new AbortController();
+  const abortReason = new Error("cancel final probe");
+  const { finalProbeStarted, gateway, resolveFinalProbe } = createDeferredFinalHealthGateway();
+  const startup = gateway.start(controller.signal);
+
+  await finalProbeStarted;
+  controller.abort(abortReason);
+  resolveFinalProbe(true);
+
+  await assert.rejects(startup, (error) => error === abortReason);
+});
+
+test("fails startup when the gateway exits during the final health probe", async () => {
+  const { child, finalProbeStarted, gateway, resolveFinalProbe } =
+    createDeferredFinalHealthGateway();
+  const startup = gateway.start();
+
+  await finalProbeStarted;
+  child.exitCode = 1;
+  resolveFinalProbe(true);
+
+  await assert.rejects(startup, /gateway exited during final startup health probe/);
+});
+
+test("fails startup when the deferred final health probe is false", async () => {
+  const { finalProbeStarted, gateway, resolveFinalProbe } = createDeferredFinalHealthGateway();
+  const startup = gateway.start();
+
+  await finalProbeStarted;
+  resolveFinalProbe(false);
+
+  await assert.rejects(startup, /gateway became unhealthy during startup stabilization/);
+});
+
 test("accepts only HTTP 200 from the runner-local health endpoint without auth", async () => {
   const requests = [];
   const server = createServer((request, response) => {


### PR DESCRIPTION
## Summary

- hold live scenarios behind a bounded five-second post-health stabilization barrier
- monitor gateway process exit and abort throughout the barrier
- require a final health check with post-probe abort and liveness validation
- add deterministic startup-race regressions without sending duplicate readiness traffic

## Verification

- 270 Vitest tests passed
- 46 offline live-smoke tests passed
- TypeScript build passed
- independent exact-SHA review approved `e7d5d27379ae59e820a9a47b6ab4dc308df7ea5a`

Supports #24. Protected runs proved `/healthz` can become ready before the Zulip channel event queue is registered, allowing the first DM to fall into that gap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to live-smoke gateway startup timing and test harness injection; production smoke runs add up to ~5s wait after health checks.
> 
> **Overview**
> Live smoke was sending Zulip traffic as soon as `/healthz` looked healthy, but the gateway can report healthy before the Zulip channel is fully wired—so the first DM could miss the event queue.
> 
> **`Gateway.start()`** now runs a **post-health stabilization phase** (default **5s**, polled every **250ms**) before it resolves. During that window it keeps checking that the child process is still alive, honors **abort signals**, and ends with a **final health probe**; startup fails with explicit errors if the process exits or health drops.
> 
> The constructor accepts **`startupSettleMs`**, **`startupSettlePollMs`**, and injectable **`spawnImpl`**, **`wait`**, and **`now`** so offline tests can simulate races without real delays or duplicate readiness traffic. New tests cover “scenarios don’t run until stabilization finishes,” exit/abort during stabilization, and cancellation or failure on the deferred final health check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7d5d27379ae59e820a9a47b6ab4dc308df7ea5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->