### PR TITLE
fix(smoke): reconcile edited Zulip message evidence

### DIFF
--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -476,29 +476,34 @@ export class EventQueue {
     if (this.queueId) await this.client.request("events", { method: "DELETE", params: { queue_id: this.queueId } }).catch(() => {});
   }
   reconcileMessageUpdate(event) {
-    const messageIds = new Set(
-      [event.message_id, event.message?.id, ...(Array.isArray(event.message_ids) ? event.message_ids : [])]
-        .filter((id) => id !== undefined && id !== null)
-        .map(String),
-    );
-    const fields = [
-      "content",
-      "subject",
-      "topic_links",
-      "last_edit_timestamp",
-      "edit_timestamp",
-      "reactions",
-      "flags",
-    ];
-    for (const messageId of messageIds) {
-      const cachedEvent = this.messageEventsById.get(messageId);
-      if (!cachedEvent?.message) continue;
-      for (const source of [event.message, event]) {
-        if (!source || typeof source !== "object") continue;
-        for (const field of fields) {
-          if (Object.hasOwn(source, field)) cachedEvent.message[field] = source[field];
-        }
+    const nestedMessage = event.message && typeof event.message === "object" ? event.message : undefined;
+    const primaryMessageId = event.message_id ?? nestedMessage?.id;
+    const primaryMessage = primaryMessageId === undefined || primaryMessageId === null
+      ? undefined
+      : this.messageEventsById.get(String(primaryMessageId))?.message;
+    if (primaryMessage) {
+      const renderedContent = Object.hasOwn(event, "rendered_content")
+        ? event.rendered_content
+        : nestedMessage && Object.hasOwn(nestedMessage, "rendered_content")
+          ? nestedMessage.rendered_content
+          : nestedMessage && Object.hasOwn(nestedMessage, "content")
+            ? nestedMessage.content
+            : Object.hasOwn(event, "content")
+              ? event.content
+              : undefined;
+      if (renderedContent !== undefined) primaryMessage.content = renderedContent;
+      for (const field of ["flags", "edit_timestamp", "last_edit_timestamp", "is_me_message"]) {
+        if (nestedMessage && Object.hasOwn(nestedMessage, field)) primaryMessage[field] = nestedMessage[field];
+        if (Object.hasOwn(event, field)) primaryMessage[field] = event[field];
       }
+    }
+
+    for (const messageId of Array.isArray(event.message_ids) ? event.message_ids : []) {
+      const cachedMessage = this.messageEventsById.get(String(messageId))?.message;
+      if (!cachedMessage) continue;
+      if (Object.hasOwn(event, "subject")) cachedMessage.subject = event.subject;
+      if (Object.hasOwn(event, "topic_links")) cachedMessage.topic_links = event.topic_links;
+      if (Object.hasOwn(event, "new_stream_id")) cachedMessage.stream_id = event.new_stream_id;
     }
   }
 }

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -427,7 +427,13 @@ class ZulipClient {
 }
 
 export class EventQueue {
-  constructor(client) { this.client = client; this.events = []; this.lastEventId = -1; this.pollPromise = undefined; }
+  constructor(client) {
+    this.client = client;
+    this.events = [];
+    this.lastEventId = -1;
+    this.pollPromise = undefined;
+    this.messageEventsById = new Map();
+  }
   async open() {
     const result = await this.client.request("register", { method: "POST", body: {
       event_types: JSON.stringify(["message", "typing", "reaction", "update_message", "delete_message"]),
@@ -443,7 +449,13 @@ export class EventQueue {
     }, signal }).then((result) => {
       for (const event of result.events ?? []) {
         this.lastEventId = Math.max(this.lastEventId, event.id ?? this.lastEventId);
-        if (event.type !== "heartbeat") this.events.push(event);
+        if (event.type === "heartbeat") continue;
+        if (event.type === "message" && event.message?.id !== undefined) {
+          this.messageEventsById.set(String(event.message.id), event);
+        } else if (event.type === "update_message") {
+          this.reconcileMessageUpdate(event);
+        }
+        this.events.push(event);
       }
       return result.events ?? [];
     }).finally(() => { this.pollPromise = undefined; });
@@ -462,6 +474,32 @@ export class EventQueue {
   }
   async close() {
     if (this.queueId) await this.client.request("events", { method: "DELETE", params: { queue_id: this.queueId } }).catch(() => {});
+  }
+  reconcileMessageUpdate(event) {
+    const messageIds = new Set(
+      [event.message_id, event.message?.id, ...(Array.isArray(event.message_ids) ? event.message_ids : [])]
+        .filter((id) => id !== undefined && id !== null)
+        .map(String),
+    );
+    const fields = [
+      "content",
+      "subject",
+      "topic_links",
+      "last_edit_timestamp",
+      "edit_timestamp",
+      "reactions",
+      "flags",
+    ];
+    for (const messageId of messageIds) {
+      const cachedEvent = this.messageEventsById.get(messageId);
+      if (!cachedEvent?.message) continue;
+      for (const source of [event.message, event]) {
+        if (!source || typeof source !== "object") continue;
+        for (const field of fields) {
+          if (Object.hasOwn(source, field)) cachedEvent.message[field] = source[field];
+        }
+      }
+    }
   }
 }
 

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -487,7 +487,8 @@ test("reconciles a placeholder update into cached message matching and cleanup a
     id: 2,
     type: "update_message",
     message_id: 100,
-    content: "<p>final-marker</p>",
+    content: "final-marker",
+    rendered_content: "<p>final-marker</p>",
     edit_timestamp: 1_750_000_001,
   };
   const batches = [[messageEvent], [updateEvent]];
@@ -535,6 +536,60 @@ test("does not mutate a cached message for an unrelated update", async () => {
   assert.deepEqual(queue.events, [messageEvent, updateEvent]);
 });
 
+test("scopes an official propagated update across cached messages", async () => {
+  const primaryEvent = { id: 1, type: "message", message: {
+    id: 100,
+    content: "<p>primary before</p>",
+    subject: "old-topic",
+    topic_links: [],
+    stream_id: 5,
+  } };
+  const secondaryEvent = { id: 2, type: "message", message: {
+    id: 101,
+    content: "<p>secondary before</p>",
+    subject: "old-topic",
+    topic_links: [],
+    stream_id: 5,
+  } };
+  const topicLinks = [{ text: "docs", url: "https://example.com/docs" }];
+  const updateEvent = {
+    id: 3,
+    type: "update_message",
+    message_id: 100,
+    message_ids: [100, 101],
+    content: "**primary after**",
+    rendered_content: "<p><strong>primary after</strong></p>",
+    flags: ["read"],
+    edit_timestamp: 1_750_000_002,
+    is_me_message: false,
+    stream_id: 5,
+    stream_name: "Old channel",
+    new_stream_id: 9,
+    subject: "new-topic",
+    topic_links: topicLinks,
+    propagate_mode: "change_all",
+  };
+  const queue = new EventQueue({
+    request: async () => ({ events: [primaryEvent, secondaryEvent, updateEvent] }),
+  });
+
+  await queue.poll();
+
+  assert.equal(primaryEvent.message.content, "<p><strong>primary after</strong></p>");
+  assert.deepEqual(primaryEvent.message.flags, ["read"]);
+  assert.equal(primaryEvent.message.edit_timestamp, 1_750_000_002);
+  assert.equal(primaryEvent.message.is_me_message, false);
+  assert.equal(secondaryEvent.message.content, "<p>secondary before</p>");
+  assert.equal(Object.hasOwn(secondaryEvent.message, "flags"), false);
+  assert.equal(Object.hasOwn(secondaryEvent.message, "edit_timestamp"), false);
+  for (const event of [primaryEvent, secondaryEvent]) {
+    assert.equal(event.message.subject, "new-topic");
+    assert.equal(event.message.topic_links, topicLinks);
+    assert.equal(event.message.stream_id, 9);
+  }
+  assert.equal(queue.events[2], updateEvent);
+});
+
 test("preserves raw update and delete evidence after reconciling an edit", async () => {
   const messageEvent = { id: 1, type: "message", message: {
     id: 100,
@@ -545,7 +600,9 @@ test("preserves raw update and delete evidence after reconciling an edit", async
     id: 2,
     type: "update_message",
     message_id: 100,
-    content: "<p>after-edit</p>",
+    message_ids: [100],
+    content: "after-edit",
+    rendered_content: "<p>after-edit</p>",
     subject: "new-topic",
   };
   const deleteEvent = { id: 3, type: "delete_message", message_ids: [100] };

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -475,6 +475,93 @@ test("coalesces concurrent event polls", async () => {
   assert.equal(queue.events.length, 1);
 });
 
+test("reconciles a placeholder update into cached message matching and cleanup attribution", async () => {
+  const messageEvent = { id: 1, type: "message", message: {
+    id: 100,
+    type: "private",
+    sender_id: Number(BOT_USER_ID),
+    display_recipient: [{ id: Number(BOT_USER_ID) }, { id: Number(ACTOR_USER_ID) }],
+    content: "<p>Thinking…</p>",
+  } };
+  const updateEvent = {
+    id: 2,
+    type: "update_message",
+    message_id: 100,
+    content: "<p>final-marker</p>",
+    edit_timestamp: 1_750_000_001,
+  };
+  const batches = [[messageEvent], [updateEvent]];
+  const queue = new EventQueue({ request: async () => ({ events: batches.shift() ?? [] }) });
+
+  await queue.poll();
+  assert.equal(messageEvent.message.content, "<p>Thinking…</p>");
+  await queue.poll();
+  const matched = await queue.waitFor(
+    (event) => isPrivateBotMessage(event, BOT_USER_ID, ACTOR_USER_ID, "final-marker"),
+    1,
+    "updated DM",
+  );
+
+  assert.equal(matched, messageEvent);
+  assert.equal(messageEvent.message.content, "<p>final-marker</p>");
+  assert.equal(messageEvent.message.edit_timestamp, 1_750_000_001);
+  assert.equal(queue.events[1], updateEvent);
+  const cleanupIds = new Set();
+  captureObservedSmokeBotMessageIds(queue.events, {
+    botUserId: BOT_USER_ID,
+    actorUserId: ACTOR_USER_ID,
+    stream: "smoke",
+    runId: "run-id",
+  }, cleanupIds);
+  assert.deepEqual([...cleanupIds], ["100"]);
+});
+
+test("does not mutate a cached message for an unrelated update", async () => {
+  const messageEvent = { id: 1, type: "message", message: {
+    id: 100,
+    content: "<p>Thinking…</p>",
+  } };
+  const updateEvent = {
+    id: 2,
+    type: "update_message",
+    message_id: 999,
+    content: "<p>unrelated final</p>",
+  };
+  const queue = new EventQueue({ request: async () => ({ events: [messageEvent, updateEvent] }) });
+
+  await queue.poll();
+
+  assert.equal(messageEvent.message.content, "<p>Thinking…</p>");
+  assert.deepEqual(queue.events, [messageEvent, updateEvent]);
+});
+
+test("preserves raw update and delete evidence after reconciling an edit", async () => {
+  const messageEvent = { id: 1, type: "message", message: {
+    id: 100,
+    content: "<p>before-edit</p>",
+    subject: "old-topic",
+  } };
+  const updateEvent = {
+    id: 2,
+    type: "update_message",
+    message_id: 100,
+    content: "<p>after-edit</p>",
+    subject: "new-topic",
+  };
+  const deleteEvent = { id: 3, type: "delete_message", message_ids: [100] };
+  const queue = new EventQueue({
+    request: async () => ({ events: [messageEvent, updateEvent, deleteEvent] }),
+  });
+
+  await queue.poll();
+
+  assert.equal(messageEvent.message.content, "<p>after-edit</p>");
+  assert.equal(messageEvent.message.subject, "new-topic");
+  assert.equal(queue.events.find((event) => event.type === "update_message"), updateEvent);
+  assert.equal(queue.events.find((event) => event.type === "delete_message"), deleteEvent);
+  assert.equal(queue.events.length, 3);
+});
+
 test("waits for gateway exit after escalating to SIGKILL", async () => {
   const child = new EventEmitter();
   child.exitCode = null;


### PR DESCRIPTION
## Summary

- reconcile Zulip `update_message` events into cached message snapshots by ID
- use rendered content only for the primary edited message
- propagate topic/channel moves across affected message IDs without leaking content or personal fields
- preserve raw update/delete events and cleanup attribution

## Verification

- 270 Vitest tests passed
- 50 offline live-smoke tests passed
- TypeScript build passed
- independent exact-SHA review approved `f9eab98617a67c34a90ac826334d4dc64479c1e4`

Supports #24 and live placeholder proof for #22. With `thinkingPlaceholder` enabled, the visible final reply arrives as an edit to the original placeholder; the prior harness inspected only the stale creation snapshot.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the live-smoke test harness in `scripts/live-smoke/` and do not affect production runtime paths.
> 
> **Overview**
> The live-smoke **EventQueue** now keeps a per-message-id cache and **reconciles** incoming `update_message` events into the original `message` event objects, so `waitFor` / content matchers see the edited body (e.g. placeholder → final reply) instead of a stale snapshot.
> 
> **Primary** edits update rendered content and fields like `flags` and `edit_timestamp` on the matched message only; **propagated** updates apply shared metadata (`subject`, `topic_links`, `new_stream_id`) across `message_ids` without copying body or per-message fields to siblings. Raw `update_message` and `delete_message` events stay on the queue for evidence and cleanup attribution.
> 
> Four offline tests cover placeholder reconciliation, unrelated updates, propagated topic/channel moves, and preserved update/delete events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9eab98617a67c34a90ac826334d4dc64479c1e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->