### PR TITLE
fix(zulip): correlate routed subagent reactions

### DIFF
--- a/src/zulip/subagent-reactions.test.ts
+++ b/src/zulip/subagent-reactions.test.ts
@@ -11,7 +11,7 @@ describe("Zulip subagent reaction correlation", () => {
     await clearZulipSubagentReactionContexts();
   });
 
-  it("tracks concurrent OpenClaw sessions_spawn children through public hook events", async () => {
+  it("uses the exact requester session fallback outside async turn context", async () => {
     const show = vi.fn(async () => {});
     const hide = vi.fn(async () => {});
     const context = registerZulipSubagentReactionContext({ requesterSessionKey: "requester", show, hide });
@@ -32,6 +32,64 @@ describe("Zulip subagent reaction correlation", () => {
 
     await handleZulipSubagentEnded({ runId: "run-2" }, {});
     expect(hide).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the active Zulip async context when the hook route key differs", async () => {
+    const show = vi.fn(async () => {});
+    const hide = vi.fn(async () => {});
+    const context = registerZulipSubagentReactionContext({
+      requesterSessionKey: "agent:main:main",
+      show,
+      hide,
+    });
+
+    await context.run(() =>
+      handleZulipSubagentSpawned(
+        {
+          runId: "routed-run",
+          childSessionKey: "routed-child",
+          requester: { channel: "zulip" },
+        },
+        { requesterSessionKey: "agent:main:zulip:default:direct:user11@example.com" },
+      ));
+
+    expect(show).toHaveBeenCalledTimes(1);
+    await handleZulipSubagentEnded({ runId: "routed-run" }, {});
+    expect(hide).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps mismatched Zulip async contexts isolated across concurrent turns", async () => {
+    const first = { show: vi.fn(async () => {}), hide: vi.fn(async () => {}) };
+    const second = { show: vi.fn(async () => {}), hide: vi.fn(async () => {}) };
+    const firstContext = registerZulipSubagentReactionContext({
+      requesterSessionKey: "agent:first:main",
+      ...first,
+    });
+    const secondContext = registerZulipSubagentReactionContext({
+      requesterSessionKey: "agent:second:main",
+      ...second,
+    });
+
+    await Promise.all([
+      firstContext.run(() =>
+        handleZulipSubagentSpawned(
+          { runId: "first-run", requester: { channel: "zulip" } },
+          { requesterSessionKey: "agent:main:zulip:default:direct:first@example.com" },
+        )),
+      secondContext.run(() =>
+        handleZulipSubagentSpawned(
+          { runId: "second-run", requester: { channel: "zulip" } },
+          { requesterSessionKey: "agent:main:zulip:default:direct:second@example.com" },
+        )),
+    ]);
+
+    expect(first.show).toHaveBeenCalledTimes(1);
+    expect(second.show).toHaveBeenCalledTimes(1);
+    await handleZulipSubagentEnded({ runId: "first-run" }, {});
+    expect(first.hide).toHaveBeenCalledTimes(1);
+    expect(second.hide).not.toHaveBeenCalled();
+    await handleZulipSubagentEnded({ runId: "second-run" }, {});
+    expect(second.hide).toHaveBeenCalledTimes(1);
   });
 
   it("binds run completion to the exact inbound context active at spawn time", async () => {
@@ -194,15 +252,16 @@ describe("Zulip subagent reaction correlation", () => {
     expect(hide).toHaveBeenCalledTimes(1);
   });
 
-  it("does not create child-session fallback bindings for non-Zulip spawns", async () => {
+  it("ignores non-Zulip spawns even inside an active Zulip async context", async () => {
     const show = vi.fn(async () => {});
     const hide = vi.fn(async () => {});
-    registerZulipSubagentReactionContext({ requesterSessionKey: "requester", show, hide });
+    const context = registerZulipSubagentReactionContext({ requesterSessionKey: "requester", show, hide });
 
-    await handleZulipSubagentSpawned(
-      { runId: "discord-run", childSessionKey: "discord-child", requester: { channel: "discord" } },
-      { requesterSessionKey: "requester" },
-    );
+    await context.run(() =>
+      handleZulipSubagentSpawned(
+        { runId: "discord-run", childSessionKey: "discord-child", requester: { channel: "discord" } },
+        { requesterSessionKey: "requester" },
+      ));
     await handleZulipSubagentEnded(
       { targetSessionKey: "discord-child" },
       { childSessionKey: "discord-child" },

--- a/src/zulip/subagent-reactions.ts
+++ b/src/zulip/subagent-reactions.ts
@@ -145,20 +145,18 @@ export async function handleZulipSubagentSpawned(
   event: { runId: string; childSessionKey?: string; requester?: { channel?: string } },
   ctx: { runId?: string; childSessionKey?: string; requesterSessionKey?: string },
 ): Promise<void> {
-  if (event.requester?.channel && event.requester.channel !== "zulip") {
+  const requesterChannel = event.requester?.channel;
+  if (requesterChannel && requesterChannel !== "zulip") {
     return;
   }
   const runId = resolveRunId(event, ctx);
   const childSessionKey = resolveChildSessionKey(event, ctx);
   const requesterSessionKey = ctx.requesterSessionKey?.trim() ?? "";
-  if (!runId || !requesterSessionKey || bindingByRunId.has(runId)) {
+  if (!runId || bindingByRunId.has(runId)) {
     return;
   }
-  const asyncContext = reactionContextStorage.getStore();
-  const context =
-    asyncContext?.requesterSessionKey === requesterSessionKey
-      ? asyncContext
-      : currentContextBySession.get(requesterSessionKey);
+  const asyncContext = requesterChannel === "zulip" ? reactionContextStorage.getStore() : undefined;
+  const context = asyncContext ?? currentContextBySession.get(requesterSessionKey);
   if (!context || context.terminal) {
     return;
   }


### PR DESCRIPTION
Fixes the live-smoke lifecycle failure where Zulip-routed subagent hooks used a rewritten requester session key and lost the active dispatch context.

The hook now prioritizes the active async-local Zulip turn context, rejects explicit non-Zulip events, and retains exact requester-session fallback outside an active turn.

Verification: 272 Vitest tests, 50 offline live-smoke tests, TypeScript build, and diff checks passed. Independently reviewed and approved at exact SHA 856bf3a5a227e10cded71fdfc1c8929c6651fccd.

Follow-up for #24.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes subagent spawn-to-reaction binding logic for concurrent Zulip turns; wrong correlation could show or hide indicators on the wrong message, but scope is limited to Zulip reaction UX.
> 
> **Overview**
> **Fixes Zulip subagent reaction indicators** when spawn hooks carry a **routed `requesterSessionKey`** that no longer matches the session registered for the active inbound turn.
> 
> `handleZulipSubagentSpawned` now **prefers the active async-local Zulip turn context** for explicit Zulip events, then falls back to `currentContextBySession` by the hook’s requester key. It no longer requires the async store’s `requesterSessionKey` to match the hook context, and spawn binding no longer bails when `requesterSessionKey` is empty as long as a run id and reaction context exist. **Non-Zulip requester channels** still exit early and **do not** use the Zulip async store, including when a Zulip turn is active.
> 
> Tests were renamed/extended to cover **requester-session fallback outside a turn**, **routed keys inside `context.run`**, **concurrent isolated async contexts**, and **Discord spawns ignored inside an active Zulip context**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 856bf3a5a227e10cded71fdfc1c8929c6651fccd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->