### PR TITLE
fix(zulip): bind subagent reactions to route aliases

### DIFF
--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -1198,6 +1198,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     const subagentReaction = resolveZulipReactionSpec(statusReactionConfig.subagent);
     const subagentContext = registerZulipSubagentReactionContext({
       requesterSessionKey: String(ctxPayload.SessionKey ?? sessionKey),
+      requesterSessionKeyAliases: [sessionKey],
       show: () => addReactionSafe(subagentReaction),
       hide: () => removeReactionSafe(subagentReaction),
     });

--- a/src/zulip/subagent-reactions.test.ts
+++ b/src/zulip/subagent-reactions.test.ts
@@ -34,6 +34,47 @@ describe("Zulip subagent reaction correlation", () => {
     expect(hide).toHaveBeenCalledTimes(1);
   });
 
+  it("uses an exact routed session alias after the async turn context ends", async () => {
+    const show = vi.fn(async () => {});
+    const hide = vi.fn(async () => {});
+    const context = registerZulipSubagentReactionContext({
+      requesterSessionKey: "agent:main:main",
+      requesterSessionKeyAliases: ["agent:main:zulip:default:direct:user11@example.com"],
+      show,
+      hide,
+    });
+
+    await handleZulipSubagentSpawned(
+      { runId: "routed-run", requester: { channel: "zulip" } },
+      { requesterSessionKey: "agent:main:zulip:default:direct:user11@example.com" },
+    );
+    await context.finish();
+
+    expect(show).toHaveBeenCalledTimes(1);
+    expect(hide).not.toHaveBeenCalled();
+
+    await handleZulipSubagentEnded({ runId: "routed-run" }, {});
+    expect(hide).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes every exact session alias when a context finishes", async () => {
+    const show = vi.fn(async () => {});
+    const context = registerZulipSubagentReactionContext({
+      requesterSessionKey: "agent:main:main",
+      requesterSessionKeyAliases: ["routed-requester"],
+      show,
+      hide: vi.fn(async () => {}),
+    });
+
+    await context.finish();
+    await handleZulipSubagentSpawned(
+      { runId: "late-run", requester: { channel: "zulip" } },
+      { requesterSessionKey: "routed-requester" },
+    );
+
+    expect(show).not.toHaveBeenCalled();
+  });
+
   it("uses the active Zulip async context when the hook route key differs", async () => {
     const show = vi.fn(async () => {});
     const hide = vi.fn(async () => {});

--- a/src/zulip/subagent-reactions.ts
+++ b/src/zulip/subagent-reactions.ts
@@ -2,7 +2,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import type { OpenClawPluginApi } from "../sdk.js";
 
 type ReactionContext = {
-  requesterSessionKey: string;
+  requesterSessionKeys: readonly string[];
   activeRunIds: Set<string>;
   indicatorDesired: boolean;
   indicatorShown: boolean;
@@ -80,8 +80,17 @@ function closeContext(context: ReactionContext): void {
   context.resolveClosed();
 }
 
+function removeCurrentSessionBindings(context: ReactionContext): void {
+  for (const requesterSessionKey of context.requesterSessionKeys) {
+    if (currentContextBySession.get(requesterSessionKey) === context) {
+      currentContextBySession.delete(requesterSessionKey);
+    }
+  }
+}
+
 export function registerZulipSubagentReactionContext(params: {
   requesterSessionKey: string;
+  requesterSessionKeyAliases?: readonly string[];
   show: () => Promise<void>;
   hide: () => Promise<void>;
 }): {
@@ -90,12 +99,16 @@ export function registerZulipSubagentReactionContext(params: {
   cancel: () => Promise<void>;
   closed: Promise<void>;
 } {
+  const requesterSessionKeys = Array.from(new Set([
+    params.requesterSessionKey,
+    ...(params.requesterSessionKeyAliases ?? []),
+  ].map((value) => value.trim()).filter(Boolean)));
   let resolveClosed!: () => void;
   const closed = new Promise<void>((resolve) => {
     resolveClosed = resolve;
   });
   const context: ReactionContext = {
-    requesterSessionKey: params.requesterSessionKey,
+    requesterSessionKeys,
     activeRunIds: new Set(),
     indicatorDesired: false,
     indicatorShown: false,
@@ -106,7 +119,9 @@ export function registerZulipSubagentReactionContext(params: {
     show: params.show,
     hide: params.hide,
   };
-  currentContextBySession.set(params.requesterSessionKey, context);
+  for (const requesterSessionKey of requesterSessionKeys) {
+    currentContextBySession.set(requesterSessionKey, context);
+  }
   activeContexts.add(context);
 
   return {
@@ -117,9 +132,7 @@ export function registerZulipSubagentReactionContext(params: {
         return;
       }
       context.terminal = true;
-      if (currentContextBySession.get(context.requesterSessionKey) === context) {
-        currentContextBySession.delete(context.requesterSessionKey);
-      }
+      removeCurrentSessionBindings(context);
       if (context.activeRunIds.size === 0) {
         await updateIndicator(context, false);
         closeContext(context);
@@ -127,9 +140,7 @@ export function registerZulipSubagentReactionContext(params: {
     },
     cancel: async () => {
       context.terminal = true;
-      if (currentContextBySession.get(context.requesterSessionKey) === context) {
-        currentContextBySession.delete(context.requesterSessionKey);
-      }
+      removeCurrentSessionBindings(context);
       for (const runId of Array.from(context.activeRunIds)) {
         if (bindingByRunId.get(runId)?.context === context) {
           removeRunBinding(runId);


### PR DESCRIPTION
The live subagent hook can arrive after the async-local turn context ends. The monitor has both OpenClaw normalized and routed conversation session keys, but previously registered only the normalized key.

Register both exact keys as deterministic aliases, deduplicate them, and remove each alias only when it still points to the finishing context. This preserves overlapping-turn safety without sole-active-context guessing.

Verification: 274 Vitest tests, 50 offline smoke tests, TypeScript build, and diff checks passed. Independently reviewed and approved at exact SHA dec733d3a4708db0122b5c04d00bea86d61ac9af.

Follow-up for #24.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Zulip subagent reaction session-key lookup and monitor registration; behavior is covered by new unit tests with no auth or data-path changes.
> 
> **Overview**
> Fixes Zulip subagent indicator reactions when spawn hooks fire **after** the inbound async turn ends and carry the **routed** `requesterSessionKey` instead of the normalized key from the turn context.
> 
> `registerZulipSubagentReactionContext` now accepts optional **`requesterSessionKeyAliases`**, registers the same reaction context under every deduplicated key, and on `finish`/`cancel` clears each map entry only if it still points at that context (so overlapping turns stay isolated). The monitor passes the routed `sessionKey` as an alias alongside `ctxPayload.SessionKey`.
> 
> New Vitest cases cover alias-based spawn/ended correlation after `finish()` and ensure finished contexts do not accept late spawns on stale alias keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dec733d3a4708db0122b5c04d00bea86d61ac9af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->