### PR TITLE
chore(zulip): expose safe lifecycle smoke diagnostics

### DIFF
--- a/.github/workflows/zulip-live-smoke.yml
+++ b/.github/workflows/zulip-live-smoke.yml
@@ -131,6 +131,7 @@ jobs:
           OPENCLAW_CONFIG_PATH: ${{ runner.temp }}/openclaw-smoke/openclaw.json
           OPENCLAW_STATE_DIR: ${{ runner.temp }}/openclaw-smoke/state
           SMOKE_GATEWAY_PORT: '18789'
+          ZULIP_SUBAGENT_DIAGNOSTICS: '1'
         run: node scripts/live-smoke/run.mjs
       - name: Record release evidence
         if: always()

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -508,6 +508,49 @@ export class EventQueue {
   }
 }
 
+const zulipSubagentDiagnosticSchemas = Object.freeze({
+  context_registered: { key_count: 8, active_contexts: 100 },
+  spawn_rejected_channel: { active_contexts: 100 },
+  spawn_rejected_run: { has_run_id: "boolean", duplicate_run: "boolean" },
+  spawn_correlated: {
+    channel_zulip: "boolean",
+    channel_missing: "boolean",
+    async_match: "boolean",
+    exact_match: "boolean",
+    selected: "boolean",
+    active_contexts: 100,
+  },
+  spawn_rejected_context: { has_context: "boolean", terminal: "boolean" },
+  indicator_shown: {},
+  run_ended: { binding_found: "boolean" },
+  reaction_add_succeeded: {},
+  reaction_add_failed: {},
+  reaction_remove_succeeded: {},
+  reaction_remove_failed: {},
+});
+
+export function parseZulipSubagentDiagnostic(line) {
+  if (Buffer.byteLength(line, "utf8") > 512 || !line.startsWith("ZULIP_SUBAGENT_DIAGNOSTIC ")) return undefined;
+  const tokens = line.split(" ");
+  const eventToken = tokens[1]?.match(/^event=([a-z_]+)$/);
+  if (tokens[0] !== "ZULIP_SUBAGENT_DIAGNOSTIC" || !eventToken) return undefined;
+  const schema = zulipSubagentDiagnosticSchemas[eventToken[1]];
+  if (!schema || tokens.length !== Object.keys(schema).length + 2) return undefined;
+  const observed = new Set();
+  for (const token of tokens.slice(2)) {
+    const field = token.match(/^([a-z_]+)=(true|false|[0-9]+)$/);
+    if (!field || observed.has(field[1]) || !Object.hasOwn(schema, field[1])) return undefined;
+    const domain = schema[field[1]];
+    if (domain === "boolean") {
+      if (field[2] !== "true" && field[2] !== "false") return undefined;
+    } else if (!/^[0-9]+$/.test(field[2]) || Number(field[2]) > domain) {
+      return undefined;
+    }
+    observed.add(field[1]);
+  }
+  return observed.size === Object.keys(schema).length ? line : undefined;
+}
+
 export class Gateway {
   constructor(port, {
     termTimeoutMs = 10000,
@@ -530,14 +573,54 @@ export class Gateway {
     this.spawnImpl = spawnImpl;
     this.wait = wait;
     this.now = now;
+    this.diagnostics = [];
+    this.diagnosticStreamGeneration = 0;
+    this.diagnosticStreamState = this.createDiagnosticStreamState();
+  }
+  createDiagnosticStreamState() {
+    return { remainder: "", discardingOversizedLine: false };
+  }
+  attachDiagnosticStream(child) {
+    const generation = ++this.diagnosticStreamGeneration;
+    const state = this.createDiagnosticStreamState();
+    this.diagnosticStreamState = state;
+    child.stderr?.on?.("data", (chunk) => {
+      if (this.diagnosticStreamGeneration === generation) this.captureDiagnostics(chunk, state);
+    });
+  }
+  captureDiagnostics(chunk, state = this.diagnosticStreamState) {
+    const text = String(chunk);
+    let cursor = 0;
+    while (cursor < text.length) {
+      const newline = text.indexOf("\n", cursor);
+      const segment = text.slice(cursor, newline < 0 ? text.length : newline);
+      if (!state.discardingOversizedLine) {
+        const candidate = state.remainder + segment;
+        if (Buffer.byteLength(candidate, "utf8") > 512) {
+          state.remainder = "";
+          state.discardingOversizedLine = newline < 0;
+        } else if (newline < 0) {
+          state.remainder = candidate;
+        } else {
+          const diagnostic = parseZulipSubagentDiagnostic(candidate);
+          if (diagnostic && this.diagnostics.length < 200) this.diagnostics.push(diagnostic);
+          state.remainder = "";
+        }
+      } else if (newline >= 0) {
+        state.discardingOversizedLine = false;
+      }
+      if (newline < 0) break;
+      cursor = newline + 1;
+    }
   }
   async start(signal) {
     signal?.throwIfAborted();
     if (this.process && isProcessTreeRunning(this.process)) throw new Error("Runner-local OpenClaw gateway is already running");
     this.process = this.spawnImpl("pnpm", ["exec", "openclaw", "gateway", "run", "--bind", "loopback", "--port", this.port, "--auth", "none", "--compact"], {
-      cwd: process.cwd(), env: process.env, stdio: ["ignore", "ignore", "ignore"], detached: process.platform !== "win32",
+      cwd: process.cwd(), env: process.env, stdio: ["ignore", "ignore", "pipe"], detached: process.platform !== "win32",
     });
     const child = this.process;
+    this.attachDiagnosticStream(child);
     const deadline = this.now() + 30000;
     while (this.now() < deadline) {
       signal?.throwIfAborted();
@@ -892,6 +975,9 @@ async function main() {
       await countMessageDeletionFailures(actor, messageIds.actor);
     await queue.close().catch(() => {});
     for (const item of report) console.log(`${item.ok ? "PASS" : "FAIL"} ${item.name} (${item.ms}ms)${item.error ? `: ${item.error}` : ""}`);
+    if (runError && gateway.diagnostics.length) {
+      for (const diagnostic of gateway.diagnostics) console.error(diagnostic);
+    }
     console.log(`Evidence: tested commit ${env.SMOKE_TESTED_SHA}; run identifier ${runId}`);
     console.log(`Cleanup: message deletion failures=${cleanupFailures}; Zulip exposes no public API for deleting uploaded files.`);
     if (cleanupFailures > 0) {

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -6,7 +6,7 @@ import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { assertFinalPrivateTypingStop, assertMessageRemainsExact, authenticatedUserId, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, drainEventQueueUntilQuiet, eventOccursBefore, EventQueue, extractExactUploadUrl, Gateway, hasFinalPrivateTypingStop, hasProvableMinimumMessageDelay, inspectChildTranscripts, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactPollMessage, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, isUsageCountedTranscriptName, lifecycleSummary, normalizeScenarioError, probeRunnerLocalGatewayHealth, redactError, resolveUploadUrl, signalProcessTree, subagentCompletedBeforeReply, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
+import { assertFinalPrivateTypingStop, assertMessageRemainsExact, authenticatedUserId, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, drainEventQueueUntilQuiet, eventOccursBefore, EventQueue, extractExactUploadUrl, Gateway, hasFinalPrivateTypingStop, hasProvableMinimumMessageDelay, inspectChildTranscripts, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactPollMessage, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, isUsageCountedTranscriptName, lifecycleSummary, normalizeScenarioError, parseZulipSubagentDiagnostic, probeRunnerLocalGatewayHealth, redactError, resolveUploadUrl, signalProcessTree, subagentCompletedBeforeReply, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
 
 const ACTOR_USER_ID = "42";
 const BOT_USER_ID = "91";
@@ -473,6 +473,67 @@ test("coalesces concurrent event polls", async () => {
   resolveRequest({ events: [{ id: 1, type: "message" }] });
   await Promise.all([first, second]);
   assert.equal(queue.events.length, 1);
+});
+
+test("captures only bounded allowlisted gateway lifecycle diagnostics", () => {
+  const gateway = new Gateway(18789);
+  gateway.captureDiagnostics("ordinary log with https://secret.example\n");
+  gateway.captureDiagnostics("prefix ZULIP_SUBAGENT_DIAGNOSTIC event=indicator_shown\n");
+  gateway.captureDiagnostics("ZULIP_SUBAGENT_DIAGNOSTIC event=unknown token=ABC123\n");
+  gateway.captureDiagnostics("ZULIP_SUBAGENT_DIAGNOSTIC event=run_ended secret=ABC123\n");
+  gateway.captureDiagnostics("ZULIP_SUBAGENT_DIAGNOSTIC event=run_ended binding_found=ABC123\n");
+  gateway.captureDiagnostics("ZULIP_SUBAGENT_DIAGNOSTIC event=indicator_");
+  gateway.captureDiagnostics("shown\n");
+  for (let index = 0; index < 250; index += 1) {
+    gateway.captureDiagnostics("ZULIP_SUBAGENT_DIAGNOSTIC event=reaction_add_succeeded\n");
+  }
+
+  assert.equal(gateway.diagnostics[0], "ZULIP_SUBAGENT_DIAGNOSTIC event=indicator_shown");
+  assert.equal(gateway.diagnostics.length, 200);
+  assert.equal(gateway.diagnostics.some((line) => line.includes("secret")), false);
+});
+
+test("keeps oversized complete and unterminated diagnostic lines memory-bounded", () => {
+  const gateway = new Gateway(18789);
+  gateway.captureDiagnostics(`${"x".repeat(2048)}\nZULIP_SUBAGENT_DIAGNOSTIC event=indicator_shown\n`);
+  gateway.captureDiagnostics("y".repeat(400));
+  gateway.captureDiagnostics("y".repeat(400));
+  assert.equal(Buffer.byteLength(gateway.diagnosticStreamState.remainder, "utf8") <= 512, true);
+  assert.equal(gateway.diagnosticStreamState.discardingOversizedLine, true);
+  gateway.captureDiagnostics("y".repeat(2048));
+  assert.equal(gateway.diagnosticStreamState.remainder, "");
+  gateway.captureDiagnostics("\nZULIP_SUBAGENT_DIAGNOSTIC event=run_ended binding_found=true\n");
+
+  assert.deepEqual(gateway.diagnostics, [
+    "ZULIP_SUBAGENT_DIAGNOSTIC event=indicator_shown",
+    "ZULIP_SUBAGENT_DIAGNOSTIC event=run_ended binding_found=true",
+  ]);
+});
+
+test("isolates diagnostic parser state across gateway child generations", () => {
+  const gateway = new Gateway(18789);
+  const oldChild = { stderr: new EventEmitter() };
+  const replacementChild = { stderr: new EventEmitter() };
+
+  gateway.attachDiagnosticStream(oldChild);
+  oldChild.stderr.emit("data", "ZULIP_SUBAGENT_DIAGNOSTIC event=indicator_");
+  oldChild.stderr.emit("data", "x".repeat(1024));
+  gateway.attachDiagnosticStream(replacementChild);
+  replacementChild.stderr.emit("data", "ZULIP_SUBAGENT_DIAGNOSTIC event=run_ended binding_found=true\n");
+  oldChild.stderr.emit("data", "shown\nZULIP_SUBAGENT_DIAGNOSTIC event=indicator_shown\n");
+
+  assert.deepEqual(gateway.diagnostics, [
+    "ZULIP_SUBAGENT_DIAGNOSTIC event=run_ended binding_found=true",
+  ]);
+  assert.equal(gateway.diagnosticStreamState.remainder, "");
+  assert.equal(gateway.diagnosticStreamState.discardingOversizedLine, false);
+});
+
+test("rejects unknown lifecycle diagnostic schemas and secret-shaped values", () => {
+  assert.equal(parseZulipSubagentDiagnostic("ZULIP_SUBAGENT_DIAGNOSTIC event=unknown"), undefined);
+  assert.equal(parseZulipSubagentDiagnostic("ZULIP_SUBAGENT_DIAGNOSTIC event=run_ended unknown=true"), undefined);
+  assert.equal(parseZulipSubagentDiagnostic("ZULIP_SUBAGENT_DIAGNOSTIC event=run_ended binding_found=ABC123"), undefined);
+  assert.equal(parseZulipSubagentDiagnostic("ZULIP_SUBAGENT_DIAGNOSTIC event=context_registered key_count=999 active_contexts=1"), undefined);
 });
 
 test("reconciles a placeholder update into cached message matching and cleanup attribution", async () => {

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -59,7 +59,10 @@ import {
   resolveZulipReactionSpec,
   resolveZulipStatusReactionConfig,
 } from "./status-reactions.js";
-import { registerZulipSubagentReactionContext } from "./subagent-reactions.js";
+import {
+  recordZulipSubagentDiagnostic,
+  registerZulipSubagentReactionContext,
+} from "./subagent-reactions.js";
 import {
   isZulipTopicAllowed,
   resolveZulipInboundStreamPolicy,
@@ -1032,7 +1035,9 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       }
       try {
         await addZulipReaction(client, { messageId, ...reaction });
+        recordZulipSubagentDiagnostic("reaction_add_succeeded");
       } catch (err) {
+        recordZulipSubagentDiagnostic("reaction_add_failed");
         logVerboseMessage(`zulip: failed to add reaction ${reaction.emojiName}: ${String(err)}`);
       }
     };
@@ -1068,7 +1073,9 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       }
       try {
         await removeZulipReaction(client, { messageId, ...reaction });
+        recordZulipSubagentDiagnostic("reaction_remove_succeeded");
       } catch (err) {
+        recordZulipSubagentDiagnostic("reaction_remove_failed");
         logVerboseMessage(`zulip: failed to remove reaction ${reaction.emojiName}: ${String(err)}`);
       }
     };

--- a/src/zulip/subagent-reactions.ts
+++ b/src/zulip/subagent-reactions.ts
@@ -20,6 +20,32 @@ const bindingsByChildSessionKey = new Map<string, Map<string, ReactionContext>>(
 const activeContexts = new Set<ReactionContext>();
 const reactionContextStorage = new AsyncLocalStorage<ReactionContext>();
 
+type ZulipSubagentDiagnosticEvent =
+  | "context_registered"
+  | "spawn_rejected_channel"
+  | "spawn_rejected_run"
+  | "spawn_correlated"
+  | "spawn_rejected_context"
+  | "indicator_shown"
+  | "run_ended"
+  | "reaction_add_succeeded"
+  | "reaction_add_failed"
+  | "reaction_remove_succeeded"
+  | "reaction_remove_failed";
+
+export function recordZulipSubagentDiagnostic(
+  event: ZulipSubagentDiagnosticEvent,
+  fields: Record<string, number | boolean> = {},
+): void {
+  if (process.env.ZULIP_SUBAGENT_DIAGNOSTICS !== "1") {
+    return;
+  }
+  const details = Object.entries(fields)
+    .map(([key, value]) => `${key}=${String(value)}`)
+    .join(" ");
+  process.stderr.write(`ZULIP_SUBAGENT_DIAGNOSTIC event=${event}${details ? ` ${details}` : ""}\n`);
+}
+
 function updateIndicator(context: ReactionContext, visible: boolean): Promise<void> {
   context.indicatorDesired = visible;
   const applyDesiredState = async () => {
@@ -123,6 +149,10 @@ export function registerZulipSubagentReactionContext(params: {
     currentContextBySession.set(requesterSessionKey, context);
   }
   activeContexts.add(context);
+  recordZulipSubagentDiagnostic("context_registered", {
+    key_count: requesterSessionKeys.length,
+    active_contexts: activeContexts.size,
+  });
 
   return {
     run: (callback) => reactionContextStorage.run(context, callback),
@@ -158,17 +188,35 @@ export async function handleZulipSubagentSpawned(
 ): Promise<void> {
   const requesterChannel = event.requester?.channel;
   if (requesterChannel && requesterChannel !== "zulip") {
+    recordZulipSubagentDiagnostic("spawn_rejected_channel", { active_contexts: activeContexts.size });
     return;
   }
   const runId = resolveRunId(event, ctx);
   const childSessionKey = resolveChildSessionKey(event, ctx);
   const requesterSessionKey = ctx.requesterSessionKey?.trim() ?? "";
   if (!runId || bindingByRunId.has(runId)) {
+    recordZulipSubagentDiagnostic("spawn_rejected_run", {
+      has_run_id: Boolean(runId),
+      duplicate_run: Boolean(runId && bindingByRunId.has(runId)),
+    });
     return;
   }
   const asyncContext = requesterChannel === "zulip" ? reactionContextStorage.getStore() : undefined;
-  const context = asyncContext ?? currentContextBySession.get(requesterSessionKey);
+  const exactContext = currentContextBySession.get(requesterSessionKey);
+  const context = asyncContext ?? exactContext;
+  recordZulipSubagentDiagnostic("spawn_correlated", {
+    channel_zulip: requesterChannel === "zulip",
+    channel_missing: requesterChannel === undefined,
+    async_match: Boolean(asyncContext),
+    exact_match: Boolean(exactContext),
+    selected: Boolean(context),
+    active_contexts: activeContexts.size,
+  });
   if (!context || context.terminal) {
+    recordZulipSubagentDiagnostic("spawn_rejected_context", {
+      has_context: Boolean(context),
+      terminal: Boolean(context?.terminal),
+    });
     return;
   }
   bindingByRunId.set(runId, { context, childSessionKey });
@@ -180,6 +228,7 @@ export async function handleZulipSubagentSpawned(
   context.activeRunIds.add(runId);
   if (context.activeRunIds.size === 1) {
     await updateIndicator(context, true);
+    recordZulipSubagentDiagnostic("indicator_shown");
   }
 }
 
@@ -190,6 +239,7 @@ export async function handleZulipSubagentEnded(
   const runId = resolveRunId(event, ctx);
   if (runId) {
     const context = removeRunBinding(runId);
+    recordZulipSubagentDiagnostic("run_ended", { binding_found: Boolean(context) });
     if (!context) {
       return;
     }


### PR DESCRIPTION
The protected lifecycle failure is hidden because the gateway process discards stderr and OpenClaw swallows hook exceptions. Add environment-gated diagnostics with a finite event/field schema, strict line-start parsing, bounded line/count storage, and per-gateway-generation parser isolation.

The smoke runner drains gateway stderr but retains and prints only allowlisted lifecycle records on failure. Arbitrary gateway logs, unknown fields, secret-shaped values, oversized lines, and late prior-generation chunks are rejected.

Verification: 274 Vitest tests, 54 offline smoke tests, TypeScript build, and diff checks passed. Independent security review approved exact SHA f8b9e557434821a2f18f5ba9f1872d92d21949d7.

Diagnostic follow-up for #24.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to optional diagnostics and smoke tooling; production behavior is unchanged unless the env flag is set, with parsing designed to avoid retaining secrets from stderr.
> 
> **Overview**
> Adds **environment-gated, schema-bound diagnostics** for Zulip subagent reaction lifecycle so protected live smoke can surface why lifecycle scenarios fail without dumping arbitrary gateway logs.
> 
> When `ZULIP_SUBAGENT_DIAGNOSTICS=1`, the plugin writes fixed-format lines to stderr for context registration, spawn correlation/rejection, indicator show/hide paths, run end, and reaction add/remove outcomes. The live smoke **Gateway** now pipes child stderr through a strict parser (allowlisted events/fields, 512-byte line cap, 200-line store) and **prints only validated lines on scenario failure**. Protected CI enables the flag for live runs.
> 
> Offline smoke tests cover rejection of unknown events, non-boolean fields, oversized lines, and stale stderr after gateway restart.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8b9e557434821a2f18f5ba9f1872d92d21949d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->