### PR TITLE
chore(zulip): classify live reaction evidence

### DIFF
--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -279,6 +279,21 @@ export function lifecycleSummary(events, inboundMessageId) {
   };
 }
 
+export function lifecycleEvidenceCounts(events, inboundMessageId) {
+  const relevant = events.filter((event) =>
+    event?.type === "reaction" && String(event.message_id) === String(inboundMessageId));
+  return {
+    total: relevant.length,
+    add: relevant.filter((event) => event.op === "add").length,
+    remove: relevant.filter((event) => event.op === "remove").length,
+    otherOp: relevant.filter((event) => event.op !== "add" && event.op !== "remove").length,
+    withName: relevant.filter((event) => typeof event.emoji_name === "string").length,
+    withCode: relevant.filter((event) => typeof event.emoji_code === "string").length,
+    robotName: relevant.filter((event) => event.emoji_name === "robot").length,
+    robotCode: relevant.filter((event) => String(event.emoji_code ?? "").toLowerCase() === "1f916").length,
+  };
+}
+
 export function subagentCompletedBeforeReply(events, inboundMessageId, replyEvent) {
   const replyIndex = events.indexOf(replyEvent);
   if (replyIndex < 0) return false;
@@ -784,6 +799,7 @@ async function main() {
   const deletedBotMessageIds = new Set();
   const report = [];
   let runError;
+  let lifecycleInboundId;
   const sendDm = async (content, signal) => {
     const result = await actor.request("messages", { method: "POST", body: { type: "private", to: JSON.stringify([env.ZULIP_SMOKE_BOT_EMAIL]), content }, signal });
     messageIds.actor.add(String(result.id)); return String(result.id);
@@ -831,6 +847,7 @@ async function main() {
     await scenario("typing-and-lifecycle-reactions", async (signal) => {
       const marker = `${runId}:lifecycle-ok`; const childResult = `${runId}:child-ok`; const eventStart = queue.events.length;
       const inboundId = await sendDm(command(`lifecycle ${marker} ${childResult}`), signal);
+      lifecycleInboundId = inboundId;
       const reply = await queue.waitFor((e) => isPrivateBotMessage(e, botUserId, actorUserId, marker), timeoutMs, "lifecycle reply", signal);
       messageIds.bot.add(String(reply.message.id));
       const deadline = Date.now() + timeoutMs;
@@ -975,6 +992,10 @@ async function main() {
       await countMessageDeletionFailures(actor, messageIds.actor);
     await queue.close().catch(() => {});
     for (const item of report) console.log(`${item.ok ? "PASS" : "FAIL"} ${item.name} (${item.ms}ms)${item.error ? `: ${item.error}` : ""}`);
+    if (runError && lifecycleInboundId) {
+      const evidence = lifecycleEvidenceCounts(queue.events, lifecycleInboundId);
+      console.error(`Lifecycle reaction evidence counts: total=${evidence.total} add=${evidence.add} remove=${evidence.remove} other_op=${evidence.otherOp} with_name=${evidence.withName} with_code=${evidence.withCode} robot_name=${evidence.robotName} robot_code=${evidence.robotCode}`);
+    }
     if (runError && gateway.diagnostics.length) {
       for (const diagnostic of gateway.diagnostics) console.error(diagnostic);
     }

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -6,7 +6,7 @@ import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { assertFinalPrivateTypingStop, assertMessageRemainsExact, authenticatedUserId, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, drainEventQueueUntilQuiet, eventOccursBefore, EventQueue, extractExactUploadUrl, Gateway, hasFinalPrivateTypingStop, hasProvableMinimumMessageDelay, inspectChildTranscripts, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactPollMessage, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, isUsageCountedTranscriptName, lifecycleSummary, normalizeScenarioError, parseZulipSubagentDiagnostic, probeRunnerLocalGatewayHealth, redactError, resolveUploadUrl, signalProcessTree, subagentCompletedBeforeReply, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
+import { assertFinalPrivateTypingStop, assertMessageRemainsExact, authenticatedUserId, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, drainEventQueueUntilQuiet, eventOccursBefore, EventQueue, extractExactUploadUrl, Gateway, hasFinalPrivateTypingStop, hasProvableMinimumMessageDelay, inspectChildTranscripts, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactPollMessage, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, isUsageCountedTranscriptName, lifecycleEvidenceCounts, lifecycleSummary, normalizeScenarioError, parseZulipSubagentDiagnostic, probeRunnerLocalGatewayHealth, redactError, resolveUploadUrl, signalProcessTree, subagentCompletedBeforeReply, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
 
 const ACTOR_USER_ID = "42";
 const BOT_USER_ID = "91";
@@ -398,6 +398,26 @@ test("requires lifecycle and subagent reactions to be removed", () => {
   assert.equal(lifecycleSummary([{ ...base, op: "add" }, { ...base, user_id: 8, op: "add" }, { ...base, op: "remove" }], "42").allRemoved, false);
   const terminal = { ...base, emoji_name: "white_check_mark", emoji_code: "2705", op: "add" };
   assert.equal(lifecycleSummary([{ ...base, op: "add" }, { ...base, op: "remove" }, terminal], "42").allRemoved, false);
+});
+
+test("reports only fixed numeric lifecycle evidence classifications", () => {
+  const events = [
+    { type: "reaction", message_id: 42, op: "add", emoji_name: "eyes", emoji_code: "1f440" },
+    { type: "reaction", message_id: 42, op: "add", emoji_name: "robot", emoji_code: "1F916" },
+    { type: "reaction", message_id: 42, op: "remove", emoji_name: "robot", emoji_code: "1f916" },
+    { type: "reaction", message_id: 42, op: "unexpected" },
+    { type: "reaction", message_id: 99, op: "add", emoji_name: "robot", emoji_code: "1f916" },
+  ];
+  assert.deepEqual(lifecycleEvidenceCounts(events, "42"), {
+    total: 4,
+    add: 2,
+    remove: 1,
+    otherOp: 1,
+    withName: 3,
+    withCode: 3,
+    robotName: 2,
+    robotCode: 2,
+  });
 });
 
 test("requires subagent lifecycle completion before the parent reply", () => {


### PR DESCRIPTION
Add a failure-only, count-only classification for lifecycle reaction events scoped to the exact inbound smoke message. This distinguishes missing events from operation or robot name/code shape mismatches without logging payload values, IDs, names, or arbitrary strings.

Verification: 274 Vitest tests, 55 offline smoke tests, TypeScript build, and diff checks passed. Independently approved at exact SHA 08af077e4345cdb183ef4f94c276309834cc2069.

Diagnostic follow-up for #24.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to live-smoke diagnostics and tests; success paths and Zulip bot behavior are unchanged.
> 
> **Overview**
> Adds **`lifecycleEvidenceCounts`** to the live smoke runner: it tallies reaction events for one inbound message (add/remove/other ops, emoji name/code presence, robot emoji matches) without logging raw event payloads.
> 
> When a smoke run fails after the **typing-and-lifecycle-reactions** scenario, the runner remembers that scenario’s inbound message id and prints a single **count-only** `Lifecycle reaction evidence counts` line to stderr so flakes can be split into “no reactions” vs “wrong op/shape” vs “robot mismatch.”
> 
> Offline smoke tests lock the fixed numeric buckets (including case-insensitive robot `emoji_code`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08af077e4345cdb183ef4f94c276309834cc2069. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->