### PR TITLE
fix(zulip): reconcile reaction event user shapes

### DIFF
--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -261,15 +261,12 @@ export function lifecycleSummary(events, inboundMessageId) {
     event?.type === "reaction" && String(event.message_id) === String(inboundMessageId),
   );
   const added = [];
-  const active = new Set();
+  const active = new Map();
   for (const event of relevant) {
-    const key = reactionKey(event);
     if (event.op === "add") {
       added.push(event);
-      active.add(key);
-    } else if (event.op === "remove") {
-      active.delete(key);
     }
+    applyReactionEvent(active, event);
   }
   return {
     added,
@@ -297,15 +294,13 @@ export function lifecycleEvidenceCounts(events, inboundMessageId) {
 export function subagentCompletedBeforeReply(events, inboundMessageId, replyEvent) {
   const replyIndex = events.indexOf(replyEvent);
   if (replyIndex < 0) return false;
-  const active = new Set();
+  const active = new Map();
   let sawSubagent = false;
   for (const event of events.slice(0, replyIndex)) {
     if (event?.type !== "reaction" || String(event.message_id) !== String(inboundMessageId) ||
         (event.emoji_name !== "robot" && event.emoji_code !== "1f916")) continue;
     sawSubagent = true;
-    const key = reactionKey(event);
-    if (event.op === "add") active.add(key);
-    else if (event.op === "remove") active.delete(key);
+    applyReactionEvent(active, event);
   }
   return sawSubagent && active.size === 0;
 }
@@ -368,8 +363,18 @@ export function normalizeScenarioError(signal, error) {
 }
 
 function reactionKey(event) {
-  const user = event.user_id ?? event.user?.user_id ?? event.user?.email ?? event.user?.full_name ?? "";
-  return `${user}:${event.emoji_name ?? ""}:${event.emoji_code ?? ""}:${event.reaction_type ?? ""}`;
+  return `${event.emoji_name ?? ""}:${event.emoji_code ?? ""}:${event.reaction_type ?? ""}`;
+}
+
+function applyReactionEvent(active, event) {
+  const key = reactionKey(event);
+  if (event.op === "add") {
+    active.set(key, (active.get(key) ?? 0) + 1);
+  } else if (event.op === "remove") {
+    const remaining = (active.get(key) ?? 0) - 1;
+    if (remaining > 0) active.set(key, remaining);
+    else active.delete(key);
+  }
 }
 
 function assistantMessageTexts(value) {

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -396,6 +396,10 @@ test("requires lifecycle and subagent reactions to be removed", () => {
   });
   assert.equal(lifecycleSummary([{ ...base, op: "add" }, { ...base, op: "remove" }, { ...base, op: "add" }], "42").allRemoved, false);
   assert.equal(lifecycleSummary([{ ...base, op: "add" }, { ...base, user_id: 8, op: "add" }, { ...base, op: "remove" }], "42").allRemoved, false);
+  assert.equal(lifecycleSummary([
+    { ...base, op: "add" },
+    { ...base, user_id: undefined, user: { id: 7 }, op: "remove" },
+  ], "42").allRemoved, true);
   const terminal = { ...base, emoji_name: "white_check_mark", emoji_code: "2705", op: "add" };
   assert.equal(lifecycleSummary([{ ...base, op: "add" }, { ...base, op: "remove" }, terminal], "42").allRemoved, false);
 });
@@ -424,6 +428,11 @@ test("requires subagent lifecycle completion before the parent reply", () => {
   const reaction = (id, op) => ({ type: "reaction", message_id: "42", user_id: 7, emoji_name: "robot", emoji_code: "1f916", reaction_type: "unicode_emoji", op, id });
   const reply = { type: "message", id: 3 };
   assert.equal(subagentCompletedBeforeReply([reaction(1, "add"), reaction(2, "remove"), reply], "42", reply), true);
+  assert.equal(subagentCompletedBeforeReply([
+    reaction(1, "add"),
+    { ...reaction(2, "remove"), user_id: undefined, user: { id: 7 } },
+    reply,
+  ], "42", reply), true);
   assert.equal(subagentCompletedBeforeReply([reaction(1, "add"), reply, reaction(3, "remove")], "42", reply), false);
 });
 


### PR DESCRIPTION
The protected run observed all five reaction adds and five removes, including the robot pair, while Zulip reported successful robot API calls. The harness still timed out because it included user payload shape in reaction identity, and Zulip varies that embedded shape between add and remove events.

Reconcile the unique smoke message by emoji identity with counted multiplicity. Duplicate same-emoji adds still require matching removals, and existing add/robot/order assertions remain intact.

Verification: 274 Vitest tests, 55 offline smoke tests, TypeScript build, and diff checks passed. Independently approved at exact SHA 1e98eea2b1cbf75bdaebd37f08d6814459796df1.

Fixes the live evidence blocker for #24.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only the live-smoke harness’s reaction parsing; production Zulip bot behavior is untouched.
> 
> **Overview**
> **Live smoke reaction lifecycle checks no longer key reactions by user fields**, because Zulip can send different user shapes on add vs remove (e.g. `user_id` vs nested `user.id`). Identity is now **emoji name, code, and reaction type** only.
> 
> **Active reactions are tracked with a refcount** (`Map` + `applyReactionEvent`) instead of a set, so multiple adds of the same emoji still need matching removes. `lifecycleSummary` and `subagentCompletedBeforeReply` share that helper.
> 
> Offline tests add cases where a remove omits `user_id` but carries `user: { id }`, asserting cleanup and subagent-before-reply still pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e98eea2b1cbf75bdaebd37f08d6814459796df1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->