### PR TITLE
fix(zulip): reconcile reaction event type shapes

### DIFF
--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -363,7 +363,7 @@ export function normalizeScenarioError(signal, error) {
 }
 
 function reactionKey(event) {
-  return `${event.emoji_name ?? ""}:${event.emoji_code ?? ""}:${event.reaction_type ?? ""}`;
+  return `${event.emoji_name ?? ""}:${event.emoji_code ?? ""}`;
 }
 
 function applyReactionEvent(active, event) {

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -398,7 +398,13 @@ test("requires lifecycle and subagent reactions to be removed", () => {
   assert.equal(lifecycleSummary([{ ...base, op: "add" }, { ...base, user_id: 8, op: "add" }, { ...base, op: "remove" }], "42").allRemoved, false);
   assert.equal(lifecycleSummary([
     { ...base, op: "add" },
-    { ...base, user_id: undefined, user: { id: 7 }, op: "remove" },
+    {
+      ...base,
+      user_id: undefined,
+      user: { id: 7 },
+      reaction_type: undefined,
+      op: "remove",
+    },
   ], "42").allRemoved, true);
   const terminal = { ...base, emoji_name: "white_check_mark", emoji_code: "2705", op: "add" };
   assert.equal(lifecycleSummary([{ ...base, op: "add" }, { ...base, op: "remove" }, terminal], "42").allRemoved, false);
@@ -430,7 +436,12 @@ test("requires subagent lifecycle completion before the parent reply", () => {
   assert.equal(subagentCompletedBeforeReply([reaction(1, "add"), reaction(2, "remove"), reply], "42", reply), true);
   assert.equal(subagentCompletedBeforeReply([
     reaction(1, "add"),
-    { ...reaction(2, "remove"), user_id: undefined, user: { id: 7 } },
+    {
+      ...reaction(2, "remove"),
+      user_id: undefined,
+      user: { id: 7 },
+      reaction_type: undefined,
+    },
     reply,
   ], "42", reply), true);
   assert.equal(subagentCompletedBeforeReply([reaction(1, "add"), reply, reaction(3, "remove")], "42", reply), false);


### PR DESCRIPTION
The protected run still observed all five adds and five removes after removing user data from reaction identity. Both robot events had the expected name and code, leaving reaction_type as the unstable envelope field across add/remove operations.

Use Zulip emoji name+code as stable identity while preserving counted multiplicity, exact message scoping, and ordering assertions.

Verification: 274 Vitest tests, 55 offline smoke tests, TypeScript build, and diff checks passed. Independently approved at exact SHA 7875719b24d8d7166a59dede421e8fc20204861d.

Fixes the remaining lifecycle evidence blocker for #24.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to live-smoke reaction bookkeeping and tests; no production Zulip integration or auth paths are touched.
> 
> **Overview**
> **Live smoke reaction tracking** now keys active reactions by **emoji name and code only**, dropping `reaction_type` from `reactionKey`. That lets add/remove pairs match when Zulip omits or changes `reaction_type` on remove events, so `lifecycleSummary` and `subagentCompletedBeforeReply` still reach `allRemoved` and correct ordering without treating mismatched envelopes as separate reactions.
> 
> **Offline tests** were updated so synthetic remove events mirror that shape (`reaction_type: undefined` alongside alternate `user` vs `user_id` payloads), locking in the fix for lifecycle cleanup and subagent-before-reply checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7875719b24d8d7166a59dede421e8fc20204861d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->