### PR TITLE
fix(zulip): normalize reaction event identity

### DIFF
--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -363,7 +363,9 @@ export function normalizeScenarioError(signal, error) {
 }
 
 function reactionKey(event) {
-  return `${event.emoji_name ?? ""}:${event.emoji_code ?? ""}`;
+  const name = String(event.emoji_name ?? "").trim().toLowerCase();
+  const code = String(event.emoji_code ?? "").trim().toLowerCase();
+  return `${name}:${code}`;
 }
 
 function applyReactionEvent(active, event) {

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -397,7 +397,7 @@ test("requires lifecycle and subagent reactions to be removed", () => {
   assert.equal(lifecycleSummary([{ ...base, op: "add" }, { ...base, op: "remove" }, { ...base, op: "add" }], "42").allRemoved, false);
   assert.equal(lifecycleSummary([{ ...base, op: "add" }, { ...base, user_id: 8, op: "add" }, { ...base, op: "remove" }], "42").allRemoved, false);
   assert.equal(lifecycleSummary([
-    { ...base, op: "add" },
+    { ...base, emoji_code: "1F916", op: "add" },
     {
       ...base,
       user_id: undefined,
@@ -435,7 +435,7 @@ test("requires subagent lifecycle completion before the parent reply", () => {
   const reply = { type: "message", id: 3 };
   assert.equal(subagentCompletedBeforeReply([reaction(1, "add"), reaction(2, "remove"), reply], "42", reply), true);
   assert.equal(subagentCompletedBeforeReply([
-    reaction(1, "add"),
+    { ...reaction(1, "add"), emoji_code: "1F916" },
     {
       ...reaction(2, "remove"),
       user_id: undefined,


### PR DESCRIPTION
The protected queue exposed the last representation mismatch: both robot events have exact name robot, while their emoji codes compare equal only after lowercasing. The active multiset still used raw code.

Trim and lowercase Zulip emoji name+code before counted reconciliation. Exact message scoping, multiplicity, robot checks, and ordering assertions remain unchanged.

Verification: 274 Vitest tests, 55 offline smoke tests, TypeScript build, and diff checks passed. Independently approved at exact SHA 9626df019d81ad2d99a6c747088a14e57e610eeb.

Fixes the remaining lifecycle matcher blocker for #24.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness-only change to reaction event matching; no production Zulip or auth paths are modified.
> 
> **Overview**
> **Reaction add/remove reconciliation** in the live smoke harness now treats Zulip reaction events as the same emoji when `emoji_name` and `emoji_code` match after **trim** and **case folding**, instead of using raw string keys.
> 
> That change is confined to `reactionKey` / the active multiset used by `lifecycleSummary` and `subagentCompletedBeforeReply`, so mixed representations (e.g. `1f916` vs `1F916`) no longer leave “stuck” reactions and falsely fail `allRemoved` or “subagent completed before reply” checks. Offline tests were updated to assert those mixed-case and alternate remove payloads still reconcile to full cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9626df019d81ad2d99a6c747088a14e57e610eeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->