### PR TITLE
fix(smoke): reconcile reactions by canonical name

### DIFF
--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -365,7 +365,7 @@ export function normalizeScenarioError(signal, error) {
 function reactionKey(event) {
   const name = String(event.emoji_name ?? "").trim().toLowerCase();
   const code = String(event.emoji_code ?? "").trim().toLowerCase();
-  return `${name}:${code}`;
+  return name ? `name:${name}` : `code:${code}`;
 }
 
 function applyReactionEvent(active, event) {

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -397,9 +397,10 @@ test("requires lifecycle and subagent reactions to be removed", () => {
   assert.equal(lifecycleSummary([{ ...base, op: "add" }, { ...base, op: "remove" }, { ...base, op: "add" }], "42").allRemoved, false);
   assert.equal(lifecycleSummary([{ ...base, op: "add" }, { ...base, user_id: 8, op: "add" }, { ...base, op: "remove" }], "42").allRemoved, false);
   assert.equal(lifecycleSummary([
-    { ...base, emoji_code: "1F916", op: "add" },
+    { ...base, emoji_code: "zulip-add-form", op: "add" },
     {
       ...base,
+      emoji_code: "zulip-remove-form",
       user_id: undefined,
       user: { id: 7 },
       reaction_type: undefined,


### PR DESCRIPTION
Closes the remaining protected live-smoke lifecycle mismatch for #24. Zulip reaction add/remove events preserve the canonical emoji name while code representation can vary, so lifecycle accounting now keys by normalized name and falls back to normalized code only when the name is absent.

Verification:
- 274 Vitest tests passed
- 55 offline live-smoke tests passed
- TypeScript build passed
- git diff --check passed

Live evidence motivating the change: run 33360411629 observed balanced 5 add / 5 remove events and successful plugin add/remove APIs but could not reconcile them by the combined name+code key.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to live-smoke reaction reconciliation helpers and offline tests; no production bot or auth paths.
> 
> **Overview**
> Fixes protected live-smoke **typing-and-lifecycle-reactions** false failures when Zulip emits balanced add/remove pairs that share the same emoji name but use different `emoji_code` values on add vs remove.
> 
> **Reaction accounting** in `run.mjs` no longer keys active reactions with a combined `name:code` string. It now uses normalized `emoji_name` when present (`name:…`), and only falls back to normalized `emoji_code` when the name is missing—so add and remove events for the same logical reaction reconcile even when codes differ.
> 
> Offline coverage replaces a case-only code mismatch with add/remove events that keep `robot` but use distinct Zulip form codes, asserting `lifecycleSummary` still reports `allRemoved: true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12522309c1a87c16376b4e7e3e58da0bd4839163. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->