### PR TITLE
test(smoke): yield for child completion

### DIFF
--- a/scripts/live-smoke/agent-workspace/AGENTS.md
+++ b/scripts/live-smoke/agent-workspace/AGENTS.md
@@ -8,8 +8,9 @@ unrequested text in a response.
 For `echo VALUE`, reply with exactly `VALUE`.
 
 For `lifecycle VALUE CHILD_RESULT`, launch one child with `sessions_spawn` and
-instruct it to reply with exactly `CHILD_RESULT`. Wait for it to finish, verify
-that exact result, then reply with exactly `VALUE`.
+instruct it to reply with exactly `CHILD_RESULT`. Call `sessions_yield` after
+the spawn so the completion event can resume this turn. After that event,
+verify the child's exact result, then reply with exactly `VALUE`.
 
 For `durable VALUE`, wait at least 16 seconds, read the complete contents of
 `.smoke-gateway-generation`, then reply with exactly `VALUE:GENERATION`, where

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -969,7 +969,8 @@ test("workflow is manual, protected, pinned, and bounded", async () => {
   assert.match(workflow, /Protected smoke config must disable stream mention gating/);
   assert.match(workflow, /Protected smoke config must use the robot subagent reaction/);
   assert.match(workflow, /reserves robot and tada reactions for exact evidence/);
-  assert.match(agentProtocol, /verify\nthat exact result/);
+  assert.match(agentProtocol, /verify the child's exact result/);
+  assert.match(agentProtocol, /Call `sessions_yield` after\nthe spawn/);
   assert.match(agentProtocol, /\.smoke-gateway-generation/);
   assert.match(agentProtocol, /at least six\nseconds/);
   for (const use of workflow.matchAll(/uses:\s+([^\s]+)/g)) assert.match(use[1], /@[0-9a-f]{40}$/);


### PR DESCRIPTION
Run 33361246177 localized the lifecycle timeout to waiting for the parent reply, despite successful child spawn/end and reaction cleanup. The protected agent protocol now explicitly calls `sessions_yield` after `sessions_spawn`, allowing OpenClaw’s push-based child completion event to resume the parent turn before exact result verification and reply.

Verification: 274 Vitest tests, 55 offline smoke tests, build, and diff checks pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and offline assertion updates for the smoke agent protocol only; no production runtime or auth paths change.
> 
> **Overview**
> Updates the protected Zulip smoke agent **`lifecycle`** instructions so the parent must call **`sessions_yield`** right after **`sessions_spawn`**, then resume on the child completion event before verifying the child's exact result and replying with **`VALUE`**. This replaces implicit blocking/wait wording that could leave the harness timing out on the parent reply even when the child finished.
> 
> Offline smoke workflow checks in **`run.offline.mjs`** now assert the new **`AGENTS.md`** phrases (`sessions_yield`, updated verify wording) so the release workflow stays aligned with the protocol.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48ff4988a16a5f68b3aa67a2eb96adbee8fb1dbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->