### PR TITLE
fix(zulip): persist routed session delivery context

### DIFF
--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -1472,7 +1472,7 @@ describe("monitorZulipProvider", () => {
     );
     expect(state.core.channel.session.updateLastRoute).toHaveBeenCalledWith({
       storePath: "/resolved/debbie/session-store",
-      sessionKey: "agent:debbie:main",
+      sessionKey: "agent:debbie:zulip:channel:4",
       deliveryContext: {
         channel: "zulip",
         to: "stream:debbie:zulip-plugin-pr",
@@ -1499,7 +1499,7 @@ describe("monitorZulipProvider", () => {
     );
     expect(state.core.channel.session.updateLastRoute).toHaveBeenCalledWith({
       storePath: "/tmp/openclaw-session-store.json",
-      sessionKey: "agent:debbie:main",
+      sessionKey: "agent:debbie:zulip:channel:4",
       deliveryContext: {
         channel: "zulip",
         to: "user:user8@zlp.pubnerd.app",
@@ -1535,7 +1535,7 @@ describe("monitorZulipProvider", () => {
     );
     expect(state.core.channel.session.updateLastRoute).toHaveBeenCalledWith({
       storePath: "/tmp/openclaw-session-store.json",
-      sessionKey: "agent:debbie:main",
+      sessionKey: "agent:debbie:zulip:channel:4",
       deliveryContext: {
         channel: "zulip",
         to: "user:123",

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -1008,7 +1008,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     });
     await core.channel.session.updateLastRoute({
       storePath,
-      sessionKey: route.mainSessionKey,
+      sessionKey,
       deliveryContext: {
         channel: "zulip",
         to,


### PR DESCRIPTION
The Zulip monitor persisted inbound delivery context on `route.mainSessionKey` while dispatching the turn on the routed `sessionKey`. OpenClaw’s push-based subagent completion looks up the requester session, so its direct announcement had no Zulip route and the protected lifecycle scenario remained waiting for the parent reply.

Persist the route on the actual dispatched session, matching current OpenClaw channel implementations. Existing DM and stream-topic tests now lock the routed key.

Verification: 274 Vitest tests, 55 offline smoke tests, TypeScript build, and diff checks pass. Live evidence: run 33361705282 reached `waiting_for_reply` after successful child end and reaction removal even with explicit `sessions_yield`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session-store last-route keys for Zulip inbound handling, which affects subagent completion and outbound routing lookups; scope is limited to the Zulip monitor path with test coverage.
> 
> **Overview**
> Fixes a mismatch where inbound Zulip delivery context was saved under **`route.mainSessionKey`** while the turn actually ran on the routed **`sessionKey`**.
> 
> **`updateLastRoute`** in the Zulip monitor now uses the same **`sessionKey`** used for dispatch and subagent registration, so push-based subagent completion can find the correct Zulip **`to`** / account route instead of leaving lifecycle flows stuck waiting on the parent session.
> 
> Monitor tests for stream topics and DMs now assert **`agent:debbie:zulip:channel:4`** instead of **`agent:debbie:main`** for last-route persistence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8affd58143fcd89f4a828783edd6ce097d268299. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->