### PR TITLE
test(smoke): report parent turn evidence counts

### DIFF
--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -2,9 +2,10 @@
 
 import { spawn } from "node:child_process";
 import { randomBytes } from "node:crypto";
-import { chmod, readdir, readFile, unlink, writeFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { chmod, lstat, open, opendir, realpath, unlink, writeFile } from "node:fs/promises";
 import { request as httpRequest } from "node:http";
-import { resolve } from "node:path";
+import { isAbsolute, relative, resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { pathToFileURL } from "node:url";
 
@@ -203,33 +204,131 @@ export async function countCompletedChildTranscripts(stateDir, marker) {
 }
 
 export async function inspectChildTranscripts(stateDir, marker) {
-  const files = [];
-  const visit = async (directory) => {
-    let entries;
-    try { entries = await readdir(directory, { withFileTypes: true }); }
-    catch (error) {
-      if (error?.code === "ENOENT") return;
-      throw error;
-    }
-    for (const entry of entries) {
-      const path = resolve(directory, entry.name);
-      if (entry.isDirectory()) await visit(path);
-      else if (entry.isFile() && isUsageCountedTranscriptName(entry.name)) files.push(path);
-    }
-  };
-  await visit(resolve(stateDir, "agents"));
+  const files = await listAgentTranscriptFiles(stateDir);
   let total = 0;
   let completedExact = 0;
   for (const file of files) {
-    const records = (await readFile(file, "utf8")).split("\n").filter(Boolean).flatMap((line) => {
-      try { return [JSON.parse(line)]; } catch { return []; }
-    });
+    const records = await readTranscriptRecords(file);
     if (!records.some(isSubagentTaskRecord)) continue;
     total += 1;
     const results = records.flatMap(assistantMessageTexts);
     if (results.at(-1) === marker) completedExact += 1;
   }
   return { total, completedExact };
+}
+
+async function listAgentTranscriptFiles(stateDir) {
+  const maxDepth = 8;
+  const maxDirectories = 128;
+  const maxEntries = 512;
+  const maxFiles = 256;
+  const maxFileBytes = 2 * 1024 * 1024;
+  const maxTotalBytes = 16 * 1024 * 1024;
+  const files = [];
+  let totalBytes = 0;
+  let visitedDirectories = 0;
+  let inspectedEntries = 0;
+  const root = resolve(stateDir, "agents");
+  let canonicalRoot;
+  try {
+    const rootStats = await lstat(root);
+    if (!rootStats.isDirectory() || rootStats.isSymbolicLink()) throw new Error("Transcript evidence is unavailable");
+    canonicalRoot = await realpath(root);
+  }
+  catch (error) {
+    if (error?.code === "ENOENT") return files;
+    throw new Error("Transcript evidence is unavailable");
+  }
+  const visit = async (directory, depth) => {
+    if (depth > maxDepth) throw new Error("Transcript scan limit exceeded");
+    visitedDirectories += 1;
+    if (visitedDirectories > maxDirectories) throw new Error("Transcript scan limit exceeded");
+    let canonicalDirectory;
+    try { canonicalDirectory = await realpath(directory); }
+    catch { throw new Error("Transcript evidence is unavailable"); }
+    const rootRelative = relative(canonicalRoot, canonicalDirectory);
+    if (rootRelative.startsWith("..") || isAbsolute(rootRelative)) {
+      throw new Error("Transcript evidence is unavailable");
+    }
+    let directoryHandle;
+    try { directoryHandle = await opendir(canonicalDirectory); }
+    catch { throw new Error("Transcript evidence is unavailable"); }
+    try { for await (const entry of directoryHandle) {
+      inspectedEntries += 1;
+      if (inspectedEntries > maxEntries) throw new Error("Transcript scan limit exceeded");
+      const path = resolve(canonicalDirectory, entry.name);
+      if (entry.isDirectory()) await visit(path, depth + 1);
+      else if (entry.isFile() && isUsageCountedTranscriptName(entry.name)) {
+        if (files.length >= maxFiles) throw new Error("Transcript scan limit exceeded");
+        let handle;
+        try {
+          handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+          const stats = await handle.stat();
+          if (!stats.isFile()) throw new Error("Transcript evidence is unavailable");
+          const chunks = [];
+          let bytesRead = 0;
+          while (bytesRead <= maxFileBytes) {
+            const buffer = Buffer.allocUnsafe(Math.min(64 * 1024, maxFileBytes + 1 - bytesRead));
+            const result = await handle.read(buffer, 0, buffer.length, null);
+            if (result.bytesRead === 0) break;
+            chunks.push(buffer.subarray(0, result.bytesRead));
+            bytesRead += result.bytesRead;
+          }
+          if (bytesRead > maxFileBytes || totalBytes + bytesRead > maxTotalBytes) {
+            throw new Error("Transcript scan limit exceeded");
+          }
+          totalBytes += bytesRead;
+          files.push({ contents: Buffer.concat(chunks, bytesRead).toString("utf8") });
+        } catch (error) {
+          if (error?.message === "Transcript scan limit exceeded") throw error;
+          throw new Error("Transcript evidence is unavailable");
+        } finally { await handle?.close().catch(() => {}); }
+      }
+    } } catch (error) {
+      if (error?.message === "Transcript scan limit exceeded" || error?.message === "Transcript evidence is unavailable") {
+        throw error;
+      }
+      throw new Error("Transcript evidence is unavailable");
+    } finally { await directoryHandle.close().catch(() => {}); }
+  };
+  await visit(canonicalRoot, 0);
+  return files;
+}
+
+async function readTranscriptRecords(file) {
+  const lines = file.contents.split("\n").filter(Boolean);
+  if (lines.length > 5000) throw new Error("Transcript scan limit exceeded");
+  return lines.flatMap((line) => {
+    try { return [JSON.parse(line)]; } catch { return []; }
+  });
+}
+
+export async function inspectLifecycleTurnEvidence(stateDir, parentMarker, childMarker) {
+  let parentTranscripts = 0;
+  let spawnCalls = 0;
+  let yieldCalls = 0;
+  let completionEvents = 0;
+  let exactReplies = 0;
+  const toolNames = (record) => record?.message?.role === "assistant" && Array.isArray(record.message.content)
+    ? record.message.content.filter((part) => part?.type === "toolCall" || part?.type === "tool_use").map((part) => part.name)
+    : [];
+  const userText = (record) => record?.message?.role === "user"
+    ? (typeof record.message.content === "string" ? record.message.content : JSON.stringify(record.message.content ?? ""))
+    : "";
+  for (const file of await listAgentTranscriptFiles(stateDir)) {
+    const records = await readTranscriptRecords(file);
+    if (!records.some((record) => userText(record).includes(parentMarker))) continue;
+    parentTranscripts += 1;
+    const names = records.flatMap(toolNames);
+    spawnCalls += names.filter((name) => name === "sessions_spawn").length;
+    yieldCalls += names.filter((name) => name === "sessions_yield").length;
+    completionEvents += records.filter((record) => {
+      const text = userText(record);
+      return text.includes(childMarker) && !text.includes(parentMarker);
+    }).length;
+    exactReplies += records.flatMap(assistantMessageTexts).filter((text) => text === parentMarker).length;
+  }
+  return { parentTranscripts, spawnCalls, yieldCalls, completionEvents, exactReplies };
 }
 
 export function isUsageCountedTranscriptName(name) {
@@ -808,6 +907,7 @@ async function main() {
   let runError;
   let lifecycleInboundId;
   let lifecyclePhase = "not_started";
+  let lifecycleMarkers;
   const sendDm = async (content, signal) => {
     const result = await actor.request("messages", { method: "POST", body: { type: "private", to: JSON.stringify([env.ZULIP_SMOKE_BOT_EMAIL]), content }, signal });
     messageIds.actor.add(String(result.id)); return String(result.id);
@@ -855,6 +955,7 @@ async function main() {
     await scenario("typing-and-lifecycle-reactions", async (signal) => {
       lifecyclePhase = "waiting_for_reply";
       const marker = `${runId}:lifecycle-ok`; const childResult = `${runId}:child-ok`; const eventStart = queue.events.length;
+      lifecycleMarkers = { marker, childResult };
       const inboundId = await sendDm(command(`lifecycle ${marker} ${childResult}`), signal);
       lifecycleInboundId = inboundId;
       const reply = await queue.waitFor((e) => isPrivateBotMessage(e, botUserId, actorUserId, marker), timeoutMs, "lifecycle reply", signal);
@@ -1009,6 +1110,14 @@ async function main() {
       const evidence = lifecycleEvidenceCounts(queue.events, lifecycleInboundId);
       console.error(`Lifecycle reaction evidence counts: total=${evidence.total} add=${evidence.add} remove=${evidence.remove} other_op=${evidence.otherOp} with_name=${evidence.withName} with_code=${evidence.withCode} robot_name=${evidence.robotName} robot_code=${evidence.robotCode}`);
       console.error(`Lifecycle phase evidence: phase=${lifecyclePhase}`);
+      if (lifecycleMarkers) {
+        try {
+          const turn = await inspectLifecycleTurnEvidence(env.OPENCLAW_STATE_DIR, lifecycleMarkers.marker, lifecycleMarkers.childResult);
+          console.error(`Lifecycle turn evidence: available=true parent_transcripts=${turn.parentTranscripts} spawn_calls=${turn.spawnCalls} yield_calls=${turn.yieldCalls} completion_events=${turn.completionEvents} exact_replies=${turn.exactReplies}`);
+        } catch {
+          console.error("Lifecycle turn evidence: available=false");
+        }
+      }
     }
     if (runError && gateway.diagnostics.length) {
       for (const diagnostic of gateway.diagnostics) console.error(diagnostic);

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -1,12 +1,12 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { EventEmitter, once } from "node:events";
-import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { assertFinalPrivateTypingStop, assertMessageRemainsExact, authenticatedUserId, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, drainEventQueueUntilQuiet, eventOccursBefore, EventQueue, extractExactUploadUrl, Gateway, hasFinalPrivateTypingStop, hasProvableMinimumMessageDelay, inspectChildTranscripts, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactPollMessage, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, isUsageCountedTranscriptName, lifecycleEvidenceCounts, lifecycleSummary, normalizeScenarioError, parseZulipSubagentDiagnostic, probeRunnerLocalGatewayHealth, redactError, resolveUploadUrl, signalProcessTree, subagentCompletedBeforeReply, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
+import { assertFinalPrivateTypingStop, assertMessageRemainsExact, authenticatedUserId, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, drainEventQueueUntilQuiet, eventOccursBefore, EventQueue, extractExactUploadUrl, Gateway, hasFinalPrivateTypingStop, hasProvableMinimumMessageDelay, inspectChildTranscripts, inspectLifecycleTurnEvidence, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactPollMessage, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, isUsageCountedTranscriptName, lifecycleEvidenceCounts, lifecycleSummary, normalizeScenarioError, parseZulipSubagentDiagnostic, probeRunnerLocalGatewayHealth, redactError, resolveUploadUrl, signalProcessTree, subagentCompletedBeforeReply, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
 
 const ACTOR_USER_ID = "42";
 const BOT_USER_ID = "91";
@@ -360,6 +360,56 @@ test("requires the exact child result in an assistant transcript message", async
     assert.equal(await countCompletedChildTranscripts(stateDir, marker), 0);
   } finally {
     await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("reports only count-based lifecycle parent-turn evidence", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "zulip-smoke-parent-turn-"));
+  const sessionsDir = join(stateDir, "agents", "main", "sessions");
+  await mkdir(sessionsDir, { recursive: true });
+  try {
+    await writeFile(join(sessionsDir, "parent.jsonl"), [
+      JSON.stringify({ message: { role: "user", content: "lifecycle parent-marker child-marker" } }),
+      JSON.stringify({ message: { role: "assistant", content: [{ type: "toolCall", name: "sessions_spawn" }] } }),
+      JSON.stringify({ message: { role: "assistant", content: [{ type: "tool_use", name: "sessions_yield" }] } }),
+      JSON.stringify({ message: { role: "user", content: "completion child-marker" } }),
+      JSON.stringify({ message: { role: "assistant", content: [{ type: "text", text: "parent-marker" }] } }),
+    ].join("\n"));
+    assert.deepEqual(await inspectLifecycleTurnEvidence(stateDir, "parent-marker", "child-marker"), {
+      parentTranscripts: 1, spawnCalls: 1, yieldCalls: 1, completionEvents: 1, exactReplies: 1,
+    });
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("bounds and confines lifecycle transcript evidence", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "zulip-smoke-evidence-bounds-"));
+  const externalDir = await mkdtemp(join(tmpdir(), "zulip-smoke-evidence-external-"));
+  try {
+    await symlink(externalDir, join(stateDir, "agents"));
+    await assert.rejects(
+      inspectLifecycleTurnEvidence(stateDir, "parent", "child"),
+      (error) => error?.message === "Transcript evidence is unavailable",
+    );
+    await rm(join(stateDir, "agents"));
+    const sessionsDir = join(stateDir, "agents", "main", "sessions");
+    await mkdir(sessionsDir, { recursive: true });
+    await writeFile(join(sessionsDir, "oversized.jsonl"), "x".repeat(2 * 1024 * 1024 + 1));
+    await assert.rejects(
+      inspectLifecycleTurnEvidence(stateDir, "parent", "child"),
+      (error) => error?.message === "Transcript scan limit exceeded",
+    );
+    await rm(join(sessionsDir, "oversized.jsonl"));
+    await Promise.all(Array.from({ length: 513 }, (_, index) =>
+      writeFile(join(sessionsDir, `irrelevant-${index}.txt`), "x")));
+    await assert.rejects(
+      inspectLifecycleTurnEvidence(stateDir, "parent", "child"),
+      (error) => error?.message === "Transcript scan limit exceeded",
+    );
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+    await rm(externalDir, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
Adds failure-only, count-only lifecycle parent-turn evidence: matching parent transcript count, sessions_spawn calls, sessions_yield calls, completion events, and exact replies. No transcript text, identifiers, paths, payload values, or credentials are logged. This distinguishes missing tool availability from missing completion resumption after protected runs remained at waiting_for_reply.

Verification: 274 Vitest tests, 56 offline smoke tests, build, and diff checks pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to live-smoke diagnostic and test harness code; production bot behavior is unchanged, with added filesystem safety bounds on evidence reads.
> 
> **Overview**
> Adds **failure-only lifecycle diagnostics** that log numeric counts from OpenClaw agent transcripts—parent transcript matches, `sessions_spawn` / `sessions_yield` tool calls, child completion user messages, and exact parent replies—so stuck `waiting_for_reply` runs can be separated from missing spawn/yield or missing completion resumption. Output stays count-only (no transcript text, paths, or secrets).
> 
> **Transcript scanning** for child completion checks and the new evidence path is refactored through shared `listAgentTranscriptFiles` / `readTranscriptRecords`, with **bounded, confined reads**: canonical `realpath` under `agents`, no symlink root, `O_NOFOLLOW`, and caps on traversal depth, entries, file size, and total bytes.
> 
> Offline tests cover expected lifecycle counts and rejection when `agents` is symlinked, a file is oversized, or directory entry limits are exceeded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e033dfadebe4d0d9dfd42515d0597a8003242858. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->