### PR TITLE
test(smoke): enforce yield turn boundary

### DIFF
--- a/scripts/live-smoke/agent-workspace/AGENTS.md
+++ b/scripts/live-smoke/agent-workspace/AGENTS.md
@@ -9,8 +9,9 @@ For `echo VALUE`, reply with exactly `VALUE`.
 
 For `lifecycle VALUE CHILD_RESULT`, launch one child with `sessions_spawn` and
 instruct it to reply with exactly `CHILD_RESULT`. Call `sessions_yield` after
-the spawn so the completion event can resume this turn. After that event,
-verify the child's exact result, then reply with exactly `VALUE`.
+the spawn as the final action of the current turn. Do not include `VALUE` or
+any other text in that turn. Only after a later child-completion event resumes
+you, verify the child's exact result and reply with exactly `VALUE`.
 
 For `durable VALUE`, wait at least 16 seconds, read the complete contents of
 `.smoke-gateway-generation`, then reply with exactly `VALUE:GENERATION`, where

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -1020,7 +1020,9 @@ test("workflow is manual, protected, pinned, and bounded", async () => {
   assert.match(workflow, /Protected smoke config must use the robot subagent reaction/);
   assert.match(workflow, /reserves robot and tada reactions for exact evidence/);
   assert.match(agentProtocol, /verify the child's exact result/);
-  assert.match(agentProtocol, /Call `sessions_yield` after\nthe spawn/);
+  assert.match(agentProtocol, /Call `sessions_yield` after\nthe spawn as the final action/);
+  assert.match(agentProtocol, /Do not include `VALUE` or\nany other text in that turn/);
+  assert.match(agentProtocol, /Only after a later child-completion event resumes\nyou, verify the child's exact result and reply with exactly `VALUE`/);
   assert.match(agentProtocol, /\.smoke-gateway-generation/);
   assert.match(agentProtocol, /at least six\nseconds/);
   for (const use of workflow.matchAll(/uses:\s+([^\s]+)/g)) assert.match(use[1], /@[0-9a-f]{40}$/);


### PR DESCRIPTION
Protected run 33363430090 proved the parent called sessions_spawn and sessions_yield but emitted the exact marker in that same transcript turn before any completion event. OpenClaw correctly did not deliver post-yield text. The agent protocol now makes yield the final action with no text and permits VALUE only after the later completion event resumes the parent.

Verification: 274 Vitest tests, 57 offline smoke tests, build, and diff checks pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and offline assertion updates for the smoke agent protocol only; no production runtime or auth paths change.
> 
> **Overview**
> Tightens the protected smoke **`lifecycle`** agent protocol so **`sessions_yield`** is the **last action** of the spawn turn, with **no `VALUE` or other assistant text** in that same turn. The parent may emit **`VALUE` only after** a later child-completion event resumes the session, once the child's exact result is verified.
> 
> Offline workflow checks in **`run.offline.mjs`** now assert the updated **`AGENTS.md`** wording so release smoke cannot regress to replying in the pre-yield turn (which OpenClaw correctly drops).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25e7679a6e61680c9ca1fee81982cdff2c0b0e0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->