### PR TITLE
test(smoke): use compatible completion model

### DIFF
--- a/.github/workflows/zulip-live-smoke.yml
+++ b/.github/workflows/zulip-live-smoke.yml
@@ -86,6 +86,8 @@ jobs:
           umask 077
           mkdir -p "$(dirname "$OPENCLAW_CONFIG_PATH")" "$OPENCLAW_STATE_DIR"
           node --input-type=module <<'NODE'
+          import { writeFileSync } from "node:fs";
+          import { selectSmokeModel } from "./scripts/live-smoke/prepare-config.mjs";
           const config = JSON.parse(process.env.OPENCLAW_SMOKE_CONFIG_JSON);
           const zulip = config?.channels?.zulip ?? {};
           const { accounts: accountConfigs = {}, ...baseZulip } = zulip;
@@ -113,8 +115,10 @@ jobs:
           if (lifecycleValues.some((value) => ["robot", "🤖", "tada", "🎉"].includes(normalize(value)))) {
             throw new Error("Protected smoke config reserves robot and tada reactions for exact evidence");
           }
+          const targetId = "gpt-5.2";
+          selectSmokeModel(config, targetId);
+          writeFileSync(process.env.OPENCLAW_CONFIG_PATH, JSON.stringify(config), { mode: 0o600 });
           NODE
-          printf '%s' "$OPENCLAW_SMOKE_CONFIG_JSON" > "$OPENCLAW_CONFIG_PATH"
           pnpm exec openclaw plugins install -l "$GITHUB_WORKSPACE"
           pnpm exec openclaw config set agents.defaults.workspace "$GITHUB_WORKSPACE/scripts/live-smoke/agent-workspace"
           pnpm exec openclaw config validate

--- a/scripts/live-smoke/prepare-config.mjs
+++ b/scripts/live-smoke/prepare-config.mjs
@@ -1,0 +1,26 @@
+export function selectSmokeModel(config, targetId) {
+  const configuredModel = config?.agents?.defaults?.model;
+  const primary = typeof configuredModel === "string" ? configuredModel : configuredModel?.primary;
+  const separator = typeof primary === "string" ? primary.indexOf("/") : -1;
+  if (separator < 1) throw new Error("Protected smoke config must name its model provider");
+  const providerId = primary.slice(0, separator);
+  const baselineId = primary.slice(separator + 1);
+  const provider = config?.models?.providers?.[providerId];
+  const source = provider?.models?.find((model) => model.id === baselineId);
+  if (!source) throw new Error("Protected smoke config must declare the baseline model");
+  if (!provider.models.some((model) => model.id === targetId)) {
+    provider.models.push({ ...source, id: targetId, name: targetId });
+  }
+  const target = `${providerId}/${targetId}`;
+  const policies = config?.agents?.defaults?.models;
+  if (policies !== undefined) {
+    if (!policies || typeof policies !== "object" || Array.isArray(policies) || !Object.hasOwn(policies, primary)) {
+      throw new Error("Protected smoke config must allow its baseline model");
+    }
+    policies[target] = structuredClone(policies[primary]);
+  }
+  config.agents.defaults.model = typeof configuredModel === "string"
+    ? target
+    : { ...configuredModel, primary: target };
+  return config;
+}

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -7,6 +7,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { assertFinalPrivateTypingStop, assertMessageRemainsExact, authenticatedUserId, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, drainEventQueueUntilQuiet, eventOccursBefore, EventQueue, extractExactUploadUrl, Gateway, hasFinalPrivateTypingStop, hasProvableMinimumMessageDelay, inspectChildTranscripts, inspectLifecycleTurnEvidence, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactPollMessage, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, isUsageCountedTranscriptName, lifecycleEvidenceCounts, lifecycleSummary, normalizeScenarioError, parseZulipSubagentDiagnostic, probeRunnerLocalGatewayHealth, redactError, resolveUploadUrl, signalProcessTree, subagentCompletedBeforeReply, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
+import { selectSmokeModel } from "./prepare-config.mjs";
 
 const ACTOR_USER_ID = "42";
 const BOT_USER_ID = "91";
@@ -26,6 +27,24 @@ test("validates protected configuration while preserving base paths", () => {
   assert.equal(validateEnvironment(validEnv).ZULIP_URL, "https://zulip.example.test/path");
   assert.throws(() => validateEnvironment({ ...validEnv, ZULIP_URL: "http://zulip.test" }), /HTTPS/);
   assert.throws(() => validateEnvironment({ ...validEnv, ZULIP_SMOKE_USER_API_KEY: "" }), /protected configuration/);
+});
+
+test("selects a compatible smoke model while preserving its policy", () => {
+  const makeConfig = (model) => ({
+    agents: { defaults: { model, models: { "abacus/gpt-5-mini": { alias: "smoke", params: { safe: true } } } } },
+    models: { providers: { abacus: { models: [{ id: "gpt-5-mini", name: "mini", reasoning: true }] } } },
+  });
+  for (const model of ["abacus/gpt-5-mini", { primary: "abacus/gpt-5-mini", fallbacks: ["other/model"] }]) {
+    const config = selectSmokeModel(makeConfig(model), "gpt-5.2");
+    assert.equal(typeof config.agents.defaults.model === "string"
+      ? config.agents.defaults.model : config.agents.defaults.model.primary, "abacus/gpt-5.2");
+    assert.deepEqual(config.agents.defaults.models["abacus/gpt-5.2"], { alias: "smoke", params: { safe: true } });
+    assert.deepEqual(config.models.providers.abacus.models.at(-1), { id: "gpt-5.2", name: "gpt-5.2", reasoning: true });
+  }
+  assert.throws(() => selectSmokeModel({
+    ...makeConfig("abacus/gpt-5-mini"),
+    agents: { defaults: { model: "abacus/gpt-5-mini", models: {} } },
+  }, "gpt-5.2"), /allow its baseline model/);
 });
 
 test("preserves Zulip base paths when constructing API URLs", () => {
@@ -1019,6 +1038,9 @@ test("workflow is manual, protected, pinned, and bounded", async () => {
   assert.match(workflow, /Protected smoke config must disable stream mention gating/);
   assert.match(workflow, /Protected smoke config must use the robot subagent reaction/);
   assert.match(workflow, /reserves robot and tada reactions for exact evidence/);
+  assert.match(workflow, /const targetId = "gpt-5\.2"/);
+  assert.match(workflow, /writeFileSync\(process\.env\.OPENCLAW_CONFIG_PATH, JSON\.stringify\(config\), \{ mode: 0o600 \}\)/);
+  assert.doesNotMatch(workflow, /printf '%s' "\$OPENCLAW_SMOKE_CONFIG_JSON"/);
   assert.match(agentProtocol, /verify the child's exact result/);
   assert.match(agentProtocol, /Call `sessions_yield` after\nthe spawn as the final action/);
   assert.match(agentProtocol, /Do not include `VALUE` or\nany other text in that turn/);


### PR DESCRIPTION
The protected mini model repeatedly called sessions_yield and emitted the marker in the same pre-completion turn, even with the boundary explicitly locked. The preparation step now preserves the protected JSON and all credentials while cloning its declared Abacus model definition to the supported gpt-5.2 ID and selecting that model for smoke execution. The transformed config is written directly with mode 0600 and validated normally.

Verification: 274 Vitest tests, 57 offline smoke tests, build, and diff checks pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to CI smoke config preparation and test harness; no production runtime or credential handling paths beyond writing the transformed config with tighter file permissions.
> 
> **Overview**
> Live Zulip smoke no longer writes the protected secret JSON straight to disk. The **Prepare isolated OpenClaw state** step still runs the same Zulip/reaction guards, then **`selectSmokeModel`** rewrites the parsed config to run as **`gpt-5.2`**: it clones the declared baseline provider model entry when needed, copies the baseline **`agents.defaults.models`** policy to the new id, and sets the default primary model—without changing how secrets are sourced.
> 
> New shared helper **`scripts/live-smoke/prepare-config.mjs`** holds that logic; offline tests cover policy preservation and failure when the baseline model is not allowlisted, and workflow contract tests assert **`gpt-5.2`**, **`writeFileSync`** with mode **0600**, and that the old **`printf`** dump is gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9da7e323e43c5653ad216e41573f18ca34f82005. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->