### PR TITLE
test(smoke): decouple lifecycle proof from parent echo

### DIFF
--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -315,6 +315,11 @@ export async function inspectLifecycleTurnEvidence(stateDir, parentMarker, child
   const userText = (record) => record?.message?.role === "user"
     ? (typeof record.message.content === "string" ? record.message.content : JSON.stringify(record.message.content ?? ""))
     : "";
+  const internalEvents = (record) => Array.isArray(record?.internalEvents)
+    ? record.internalEvents
+    : Array.isArray(record?.message?.internalEvents)
+      ? record.message.internalEvents
+      : [];
   for (const file of await listAgentTranscriptFiles(stateDir)) {
     const records = await readTranscriptRecords(file);
     if (!records.some((record) => userText(record).includes(parentMarker))) continue;
@@ -323,8 +328,13 @@ export async function inspectLifecycleTurnEvidence(stateDir, parentMarker, child
     spawnCalls += names.filter((name) => name === "sessions_spawn").length;
     yieldCalls += names.filter((name) => name === "sessions_yield").length;
     completionEvents += records.filter((record) => {
+      if (internalEvents(record).some((event) =>
+        event?.type === "task_completion" && event?.source === "subagent" &&
+        (String(event.result ?? "").includes(childMarker) || String(event.childSessionKey ?? "").includes("subagent")))) {
+        return true;
+      }
       const text = userText(record);
-      return text.includes(childMarker) && !text.includes(parentMarker);
+      return (text.includes("[Internal task completion event]") || text.includes(childMarker)) && !text.includes(parentMarker);
     }).length;
     exactReplies += records.flatMap(assistantMessageTexts).filter((text) => text === parentMarker).length;
   }
@@ -402,6 +412,18 @@ export function subagentCompletedBeforeReply(events, inboundMessageId, replyEven
     applyReactionEvent(active, event);
   }
   return sawSubagent && active.size === 0;
+}
+
+export async function waitForOptionalPrivateBotMessage(queue, predicate, timeoutMs, signal) {
+  const deadline = Date.now() + timeoutMs;
+  let event;
+  while (Date.now() < deadline && !event) {
+    event = queue.events.find(predicate);
+    if (event) break;
+    await queue.poll(signal);
+    await delay(500, undefined, { signal });
+  }
+  return event;
 }
 
 export function isExactPoll(widget, question, options) {
@@ -953,14 +975,11 @@ async function main() {
     });
 
     await scenario("typing-and-lifecycle-reactions", async (signal) => {
-      lifecyclePhase = "waiting_for_reply";
+      lifecyclePhase = "waiting_for_reaction_cleanup";
       const marker = `${runId}:lifecycle-ok`; const childResult = `${runId}:child-ok`; const eventStart = queue.events.length;
       lifecycleMarkers = { marker, childResult };
       const inboundId = await sendDm(command(`lifecycle ${marker} ${childResult}`), signal);
       lifecycleInboundId = inboundId;
-      const reply = await queue.waitFor((e) => isPrivateBotMessage(e, botUserId, actorUserId, marker), timeoutMs, "lifecycle reply", signal);
-      messageIds.bot.add(String(reply.message.id));
-      lifecyclePhase = "waiting_for_reaction_cleanup";
       const deadline = Date.now() + timeoutMs;
       let summary;
       while (Date.now() < deadline) {
@@ -979,6 +998,18 @@ async function main() {
       if (childTranscripts.total !== 1 || childTranscripts.completedExact !== 1) {
         throw new Error(`Found ${childTranscripts.total} child transcripts and ${childTranscripts.completedExact} exact completed results; expected exactly one of each`);
       }
+      lifecyclePhase = "checking_optional_parent_reply";
+      const reply = await waitForOptionalPrivateBotMessage(
+        queue,
+        (e) => isPrivateBotMessage(e, botUserId, actorUserId, marker),
+        5000,
+        signal,
+      );
+      if (reply) messageIds.bot.add(String(reply.message.id));
+      const turn = await inspectLifecycleTurnEvidence(env.OPENCLAW_STATE_DIR, marker, childResult);
+      if (turn.exactReplies > 0 && turn.completionEvents === 0) {
+        throw new Error("Lifecycle parent produced its final reply without transcript evidence of a child completion event");
+      }
       lifecyclePhase = "waiting_for_final_typing_stop";
       await drainEventQueueUntilQuiet(queue, signal, 500, timeoutMs, 100, () =>
         lifecycleSummary(queue.events, inboundId).allRemoved &&
@@ -991,8 +1022,8 @@ async function main() {
       if (!summary.sawSubagent) throw new Error("No truthful subagent lifecycle reaction was observed");
       if (summary.subagentCount !== 1) throw new Error(`Observed ${summary.subagentCount} subagent lifecycle reactions; expected exactly one`);
       if (!summary.allRemoved) throw new Error("Lifecycle reactions were not cleaned up after completion");
-      if (!subagentCompletedBeforeReply(queue.events, inboundId, reply)) {
-        throw new Error("The child lifecycle did not complete before the parent reply");
+      if (reply && !subagentCompletedBeforeReply(queue.events, inboundId, reply)) {
+        throw new Error("The optional parent reply was observed before child lifecycle cleanup");
       }
       lifecyclePhase = "complete";
     });

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -397,6 +397,31 @@ test("reports only count-based lifecycle parent-turn evidence", async () => {
     assert.deepEqual(await inspectLifecycleTurnEvidence(stateDir, "parent-marker", "child-marker"), {
       parentTranscripts: 1, spawnCalls: 1, yieldCalls: 1, completionEvents: 1, exactReplies: 1,
     });
+    await writeFile(join(sessionsDir, "parent.jsonl"), [
+      JSON.stringify({ message: { role: "user", content: "lifecycle parent-marker child-marker" } }),
+      JSON.stringify({ message: { role: "assistant", content: [{ type: "toolCall", name: "sessions_spawn" }] } }),
+      JSON.stringify({ message: { role: "assistant", content: [{ type: "tool_use", name: "sessions_yield" }] } }),
+      JSON.stringify({ internalEvents: [{
+        type: "task_completion", source: "subagent", childSessionKey: "agent:main:subagent:child",
+        result: "child-marker", announceType: "completion", taskLabel: "child", status: "ok",
+        statusLabel: "completed", replyInstruction: "continue",
+      }] }),
+      JSON.stringify({ message: { role: "assistant", content: [{ type: "text", text: "parent-marker" }] } }),
+    ].join("\n"));
+    assert.deepEqual(await inspectLifecycleTurnEvidence(stateDir, "parent-marker", "child-marker"), {
+      parentTranscripts: 1, spawnCalls: 1, yieldCalls: 1, completionEvents: 1, exactReplies: 1,
+    });
+    await writeFile(join(sessionsDir, "parent.jsonl"), [
+      JSON.stringify({ message: { role: "user", content: "lifecycle parent-marker child-marker" } }),
+      JSON.stringify({ message: { role: "assistant", content: [
+        { type: "toolCall", name: "sessions_spawn" },
+        { type: "tool_use", name: "sessions_yield" },
+      ] } }),
+      JSON.stringify({ message: { role: "assistant", content: "parent-marker" } }),
+    ].join("\n"));
+    assert.deepEqual(await inspectLifecycleTurnEvidence(stateDir, "parent-marker", "child-marker"), {
+      parentTranscripts: 1, spawnCalls: 1, yieldCalls: 1, completionEvents: 0, exactReplies: 1,
+    });
   } finally {
     await rm(stateDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
Closes part of #24.

The protected live smoke was correctly exercising Zulip subagent lifecycle reactions, but it still required a visible parent echo after `sessions_yield`. That proved too model/runtime-sensitive and is not a Zulip plugin invariant.

This changes the lifecycle scenario to require the plugin-owned evidence instead:

- the subagent lifecycle reaction is added and fully cleaned up
- the child transcript contains exactly one exact child result
- final typing state is stopped
- if a parent echo is observed, it still must occur only after lifecycle cleanup
- transcript diagnostics also recognize OpenClaw internal `task_completion` records when present

Verification:

- `pnpm test`
- `pnpm build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to live-smoke test harness and evidence helpers; no production Zulip plugin or runtime behavior is modified.
> 
> **Overview**
> The **typing-and-lifecycle-reactions** live smoke no longer requires a mandatory parent DM echo after `sessions_yield`. It now proves subagent lifecycle via Zulip reactions (add/remove), exactly one child transcript with the child marker, typing stop, and optional parent reply handling.
> 
> **Transcript diagnostics** in `inspectLifecycleTurnEvidence` count child completion when OpenClaw **`task_completion`** records appear on `internalEvents` (or legacy user text / internal completion markers), not only user messages containing the child marker.
> 
> A new **`waitForOptionalPrivateBotMessage`** polls up to 5s for the parent marker reply; if a reply appears without matching completion evidence, the scenario fails. Ordering checks (`subagentCompletedBeforeReply`) apply only when that optional reply is seen.
> 
> Offline tests cover internal-event completions and a parent reply with zero completion events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa8175d6467157653562e70c51b53526754e2bcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->