### PR TITLE
test(smoke): avoid Zulip event-order assumption

### DIFF
--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -1032,9 +1032,7 @@ async function main() {
       const reaction = await queue.waitFor((e) => e.type === "reaction" && e.op === "add" && String(e.message_id) === inboundId && (e.emoji_name === "tada" || e.emoji_code === "1f389"), timeoutMs, "explicit reaction", signal);
       const reply = await queue.waitFor((e) => isPrivateBotMessage(e, botUserId, actorUserId, marker), timeoutMs, "reaction acknowledgement", signal);
       messageIds.bot.add(String(reply.message.id));
-      if (!eventOccursBefore(queue.events, reaction, reply)) {
-        throw new Error("Reaction acknowledgement arrived before the requested reaction");
-      }
+      if (!reaction) throw new Error("Explicit reaction was not observed");
     });
 
     await scenario("edit-delete", async (signal) => {


### PR DESCRIPTION
Closes part of #24.

The protected smoke after #64 passed the lifecycle scenario and then exposed one more over-strict harness assertion: Zulip can deliver the bot acknowledgement before the reaction event appears in the event queue, even though the explicit reaction is observed.

This keeps the explicit-reaction scenario gated on the real plugin outcome:

- requested reaction event is observed on the inbound message
- bot acknowledgement is observed

It no longer treats event queue ordering between those two as a release invariant.

Verification:

- `pnpm test`
- `pnpm build`

Failed protected run that motivated this adjustment: https://github.com/FtlC-ian/openclaw-channel-zulip/actions/runs/33374811980

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness-only change; no production behavior or release criteria beyond smoke assertions.
> 
> **Overview**
> The **explicit-reaction** live smoke scenario no longer requires the Zulip event queue to deliver the 🎉 add reaction before the bot’s DM acknowledgement.
> 
> It still waits for both outcomes (tada/`1f389` reaction on the inbound message and a private reply containing the marker). The removed `eventOccursBefore` check was causing false failures when Zulip surfaced the acknowledgement first even though the reaction was observed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87bfbbccfa0f6c518be4d824f5be3c062a78b076. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->