### PR TITLE
test(smoke): make protected delete probe best effort

### DIFF
--- a/scripts/live-smoke/agent-workspace/AGENTS.md
+++ b/scripts/live-smoke/agent-workspace/AGENTS.md
@@ -24,8 +24,9 @@ message tool and then reply with exactly `VALUE`.
 
 For `edit-delete BEFORE AFTER`, send a new message containing exactly `BEFORE`,
 edit that same message to exactly `AFTER`, keep it visible for at least six
-seconds so the harness can observe a full four-second window, then delete it
-with explicit confirmation. Do not send another reply.
+seconds so the harness can observe a full four-second window. Do not delete it
+and do not send another reply; the harness probes deletion separately because
+some protected Zulip realms disallow delete even when edit is permitted.
 
 For `read-upload VALUE`, read the attached text file and reply with exactly its
 contents. The file must contain `VALUE`.

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -1042,8 +1042,13 @@ async function main() {
       const id = String(created.message.id); messageIds.bot.add(id);
       await queue.waitFor((e) => e.type === "update_message" && String(e.message_id) === id && isExactRenderedContent(e.content, after), timeoutMs, "message edit", signal);
       await assertMessageRemainsExact(actor, id, after, 4000, signal);
-      await queue.waitFor((e) => e.type === "delete_message" && (e.message_ids ?? [e.message_id]).map(String).includes(id), timeoutMs, "message delete", signal);
-      messageIds.bot.delete(id); deletedBotMessageIds.add(id);
+      try {
+        await bot.request(`messages/${id}`, { method: "DELETE", signal });
+        await queue.waitFor((e) => e.type === "delete_message" && (e.message_ids ?? [e.message_id]).map(String).includes(id), timeoutMs, "message delete", signal);
+        messageIds.bot.delete(id); deletedBotMessageIds.add(id);
+      } catch (error) {
+        console.warn(`Delete warning: edited smoke message could not be deleted through the Zulip API: ${redactError(error)}`);
+      }
     });
 
     await scenario("upload-download", async (signal) => {


### PR DESCRIPTION
Closes part of #24.

The protected live environment can edit smoke messages but currently rejects message deletion through the Zulip API with `BAD_REQUEST`. Issue #24 explicitly scopes cleanup/delete to “where the Zulip API safely permits it,” so this keeps edit coverage strict and makes deletion a direct harness probe:

- agent sends and edits the message
- harness verifies the edited content remains exact for the visibility window
- harness attempts deletion with the bot API
- if deletion is permitted, it waits for the delete event
- if deletion is rejected by the protected realm, it reports a warning and continues

Verification:

- `pnpm test`
- `pnpm build`

Failed protected run that motivated this adjustment: https://github.com/FtlC-ian/openclaw-channel-zulip/actions/runs/33375173921

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only protected live-smoke harness and agent instructions; no production channel or auth logic.
> 
> **Overview**
> The protected live smoke **edit-delete** path no longer requires the agent to delete messages or the harness to fail when Zulip rejects deletion.
> 
> **Agent protocol (`AGENTS.md`):** For `edit-delete`, the bot still sends `BEFORE`, edits to `AFTER`, and keeps the message visible for the harness window—but it must **not** delete the message or send an extra reply. Deletion is left to the harness because some realms allow edit but return `BAD_REQUEST` on delete.
> 
> **Harness (`run.mjs`):** After verifying create, edit, and a four-second exact-content window, the runner issues a **direct bot API DELETE** on the edited message and waits for a `delete_message` event when the API succeeds. If delete is rejected, it logs a **warning** and the scenario still passes; strict checks remain for send and edit only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28e581612288419eb88665d743c75cbeca91605d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->