### PR TITLE
fix(ci): batch protected smoke iterations

### DIFF
--- a/.github/workflows/zulip-live-smoke.yml
+++ b/.github/workflows/zulip-live-smoke.yml
@@ -4,7 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       candidate_sha:
-        description: Full commit SHA to test (must already be reachable from main)
+        description: Full commit SHA to test
+        required: false
+        type: string
+      candidate_ref:
+        description: Same-repository branch containing the candidate (defaults to main)
         required: false
         type: string
 
@@ -23,36 +27,19 @@ jobs:
     outputs:
       candidate_sha: ${{ steps.candidate.outputs.sha }}
     steps:
-      - name: Require dispatch from this repository's main branch
-        env:
-          DISPATCH_REPOSITORY: ${{ github.repository }}
-          DISPATCH_REF: ${{ github.ref }}
-        run: |
-          if [[ "$DISPATCH_REPOSITORY" != "FtlC-ian/openclaw-channel-zulip" || "$DISPATCH_REF" != "refs/heads/main" ]]; then
-            echo "Live credentials are available only to workflows dispatched from this repository's main branch" >&2
-            exit 1
-          fi
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Require a commit already reachable from main
+      - name: Require a commit reachable from the trusted candidate branch
         id: candidate
         env:
+          REQUESTED_REF: ${{ inputs.candidate_ref }}
           REQUESTED_SHA: ${{ inputs.candidate_sha }}
-        run: |
-          candidate="${REQUESTED_SHA:-$GITHUB_SHA}"
-          if [[ ! "$candidate" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "candidate_sha must be a full lowercase commit SHA" >&2
-            exit 1
-          fi
-          git fetch --no-tags origin main
-          git cat-file -e "$candidate^{commit}"
-          if ! git merge-base --is-ancestor "$candidate" origin/main; then
-            echo "Refusing to expose live credentials to a commit not reachable from main" >&2
-            exit 1
-          fi
-          echo "sha=$candidate" >> "$GITHUB_OUTPUT"
+          DISPATCH_ACTOR: ${{ github.actor }}
+          DISPATCH_REPOSITORY: ${{ github.repository }}
+          DISPATCH_REF: ${{ github.ref }}
+        run: scripts/live-smoke/authorize-candidate.sh
 
   live-smoke:
     name: Live Zulip scenarios

--- a/README.md
+++ b/README.md
@@ -333,9 +333,11 @@ openclaw gateway restart
 Pull requests and pushes to `main` run the release-blocking **CI** workflow on Node 22.19 and Node 24. Each run installs from `pnpm-lock.yaml` with `--frozen-lockfile`, builds, runs the full test suite, checks whitespace errors with `git diff --check`, packs the release artifact, installs it with the locked OpenClaw host in a clean temporary project, and imports its public package entry point. The workflow has read-only repository permissions and does not receive repository or Zulip secrets.
 
 Release candidates also have a manual **Zulip live smoke (protected)** workflow.
-It can run only from `main`, accepts only a full commit SHA already reachable
-from `main`, and obtains dedicated-realm credentials only after approval through
-the protected `zulip-live-smoke` GitHub Environment. See
+Its workflow definition can run only from `main`. By default it accepts a full
+commit SHA reachable from `main`; the repository owner may instead name a
+same-repository candidate branch so live-only fixes can be tested repeatedly
+before one final pull request is opened. Dedicated-realm credentials remain
+unavailable until approval through the protected `zulip-live-smoke` GitHub Environment. See
 [the release checklist](docs/RELEASE_CHECKLIST.md) for setup and evidence rules.
 
 The scheduled **OpenClaw compatibility (advisory)** workflow is intentionally separate from release gating. Once a week it chooses the first eligible release from OpenClaw's `latest` and `extended-stable` npm channels that has been published for at least 24 hours, then installs and tests it in a temporary copy of the plugin. That temporary install and the packed-artifact smoke test enforce pnpm's 24-hour release-age rule and may update only disposable lockfiles; they never change or commit this repository's lockfile. A failure identifies compatibility work to investigate; it does not replace the locked CI evidence required for a release.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -4,9 +4,8 @@ Before publishing a release candidate:
 
 - Confirm CI passed for the exact commit being released.
 - From the `main` branch, dispatch **Zulip live smoke (protected)** with the
-  candidate's full commit SHA. The workflow rejects commits not already
-  reachable from `main` before the protected environment or its secrets are
-  available.
+  candidate's full commit SHA. For a release, leave `candidate_ref` empty so the
+  workflow requires the commit to be reachable from `main`.
 - Record the successful run URL and tested SHA here and on GitHub issue #24:
   `Live smoke: <run URL>; tested SHA: <40-character SHA>`.
 - Confirm the run summary reports every scenario as `PASS`. A skipped or
@@ -25,6 +24,15 @@ configuration in `OPENCLAW_SMOKE_CONFIG_JSON`; store the test actor and bot
 credentials in the environment-scoped secrets named by the workflow. Set
 `ZULIP_SMOKE_STREAM` as an environment variable. Never define these as
 repository-level secrets.
+
+When debugging a live-only failure, keep the fixes on one same-repository
+feature branch and dispatch the workflow with both `candidate_sha` and
+`candidate_ref`. Repeat on that branch until the smoke run passes, then open one
+pull request. Do not merge each experimental fix to `main`: that creates noisy
+review and failure notifications and leaves `main` holding known-bad candidates.
+Only the repository owner can dispatch a branch candidate, the candidate must
+be reachable from the named same-repository branch, and environment approval is
+still required before credentials are released.
 
 The isolated configuration must enable the checked-out local Zulip plugin, use
 the dedicated bot account, allow DMs from the smoke actor, monitor the smoke

--- a/scripts/live-smoke/authorize-candidate.sh
+++ b/scripts/live-smoke/authorize-candidate.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$DISPATCH_REPOSITORY" != "FtlC-ian/openclaw-channel-zulip" || "$DISPATCH_REF" != "refs/heads/main" ]]; then
+  echo "Live credentials are available only to workflows dispatched from this repository's main branch" >&2
+  exit 1
+fi
+if [[ "$DISPATCH_ACTOR" != "FtlC-ian" ]]; then
+  echo "Live candidates may be dispatched only by the repository owner" >&2
+  exit 1
+fi
+
+candidate="${REQUESTED_SHA:-$GITHUB_SHA}"
+candidate_ref="${REQUESTED_REF:-main}"
+if [[ ! "$candidate" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "candidate_sha must be a full lowercase commit SHA" >&2
+  exit 1
+fi
+if ! git check-ref-format --branch "$candidate_ref" >/dev/null; then
+  echo "candidate_ref must be a valid branch name" >&2
+  exit 1
+fi
+
+git fetch --no-tags origin "refs/heads/$candidate_ref:refs/remotes/origin/$candidate_ref"
+git cat-file -e "$candidate^{commit}"
+if ! git merge-base --is-ancestor "$candidate" "refs/remotes/origin/$candidate_ref"; then
+  echo "Refusing to expose live credentials to a commit not reachable from candidate_ref" >&2
+  exit 1
+fi
+echo "sha=$candidate" >> "$GITHUB_OUTPUT"

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -6,11 +6,30 @@ import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import { assertFinalPrivateTypingStop, assertMessageRemainsExact, authenticatedUserId, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, drainEventQueueUntilQuiet, eventOccursBefore, EventQueue, extractExactUploadUrl, Gateway, hasFinalPrivateTypingStop, hasProvableMinimumMessageDelay, inspectChildTranscripts, inspectLifecycleTurnEvidence, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactPollMessage, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, isUsageCountedTranscriptName, lifecycleEvidenceCounts, lifecycleSummary, normalizeScenarioError, parseZulipSubagentDiagnostic, probeRunnerLocalGatewayHealth, redactError, resolveUploadUrl, signalProcessTree, subagentCompletedBeforeReply, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
 import { selectSmokeModel } from "./prepare-config.mjs";
 
 const ACTOR_USER_ID = "42";
 const BOT_USER_ID = "91";
+
+function runCommand(command, args, { cwd, env = process.env } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd, env, stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.once("error", reject);
+    child.once("close", (code, signal) => resolve({ code, signal, stdout, stderr }));
+  });
+}
+
+async function runSuccessfulCommand(command, args, options) {
+  const result = await runCommand(command, args, options);
+  assert.equal(result.code, 0, `${command} ${args.join(" ")} failed: ${result.stderr}`);
+  return result.stdout.trim();
+}
 
 const validEnv = {
   ZULIP_URL: "https://zulip.example.test/path",
@@ -1033,15 +1052,99 @@ test("terminates the complete detached process group", { skip: process.platform 
   }
 });
 
+test("authorizes only owner-dispatched commits reachable from the requested same-repository branch", async () => {
+  const root = await mkdtemp(join(tmpdir(), "zulip-smoke-authorize-"));
+  const remoteDir = join(root, "remote.git");
+  const seedDir = join(root, "seed");
+  const runDir = join(root, "run");
+  const authorizeScript = fileURLToPath(new URL("./authorize-candidate.sh", import.meta.url));
+  let outputIndex = 0;
+  try {
+    await mkdir(seedDir);
+    await runSuccessfulCommand("git", ["init", "--bare", remoteDir]);
+    await runSuccessfulCommand("git", ["init", "-b", "main"], { cwd: seedDir });
+    await runSuccessfulCommand("git", ["config", "user.name", "Smoke Test"], { cwd: seedDir });
+    await runSuccessfulCommand("git", ["config", "user.email", "smoke@example.test"], { cwd: seedDir });
+    await writeFile(join(seedDir, "candidate.txt"), "main\n");
+    await runSuccessfulCommand("git", ["add", "candidate.txt"], { cwd: seedDir });
+    await runSuccessfulCommand("git", ["commit", "-m", "main"], { cwd: seedDir });
+    const mainSha = await runSuccessfulCommand("git", ["rev-parse", "HEAD"], { cwd: seedDir });
+    await runSuccessfulCommand("git", ["remote", "add", "origin", remoteDir], { cwd: seedDir });
+    await runSuccessfulCommand("git", ["push", "-u", "origin", "main"], { cwd: seedDir });
+
+    await runSuccessfulCommand("git", ["switch", "-c", "fix/test-candidate"], { cwd: seedDir });
+    await writeFile(join(seedDir, "candidate.txt"), "candidate\n");
+    await runSuccessfulCommand("git", ["commit", "-am", "candidate"], { cwd: seedDir });
+    const candidateSha = await runSuccessfulCommand("git", ["rev-parse", "HEAD"], { cwd: seedDir });
+    await runSuccessfulCommand("git", ["push", "origin", "HEAD"], { cwd: seedDir });
+
+    await runSuccessfulCommand("git", ["switch", "main"], { cwd: seedDir });
+    await runSuccessfulCommand("git", ["switch", "-c", "other"], { cwd: seedDir });
+    await writeFile(join(seedDir, "other.txt"), "other\n");
+    await runSuccessfulCommand("git", ["add", "other.txt"], { cwd: seedDir });
+    await runSuccessfulCommand("git", ["commit", "-m", "other"], { cwd: seedDir });
+    const otherSha = await runSuccessfulCommand("git", ["rev-parse", "HEAD"], { cwd: seedDir });
+    await runSuccessfulCommand("git", ["push", "origin", "HEAD"], { cwd: seedDir });
+    await runSuccessfulCommand("git", ["clone", "--branch", "main", remoteDir, runDir]);
+
+    const runAuthorization = async ({ actor = "FtlC-ian", requestedRef = "", requestedSha = mainSha } = {}) => {
+      const outputPath = join(root, `github-output-${outputIndex++}`);
+      await writeFile(outputPath, "");
+      const result = await runCommand(authorizeScript, [], { cwd: runDir, env: {
+        ...process.env,
+        DISPATCH_ACTOR: actor,
+        DISPATCH_REPOSITORY: "FtlC-ian/openclaw-channel-zulip",
+        DISPATCH_REF: "refs/heads/main",
+        GITHUB_OUTPUT: outputPath,
+        GITHUB_SHA: mainSha,
+        REQUESTED_REF: requestedRef,
+        REQUESTED_SHA: requestedSha,
+      } });
+      return { ...result, output: await readFile(outputPath, "utf8") };
+    };
+
+    await runSuccessfulCommand("git", ["update-ref", "-d", "refs/remotes/origin/main"], { cwd: runDir });
+    const defaultMain = await runAuthorization();
+    assert.equal(defaultMain.code, 0, defaultMain.stderr);
+    assert.equal(defaultMain.output, `sha=${mainSha}\n`);
+    assert.equal(await runSuccessfulCommand("git", ["rev-parse", "refs/remotes/origin/main"], { cwd: runDir }), mainSha);
+
+    await runSuccessfulCommand("git", ["update-ref", "-d", "refs/remotes/origin/fix/test-candidate"], { cwd: runDir });
+    const branchCandidate = await runAuthorization({ requestedRef: "fix/test-candidate", requestedSha: candidateSha });
+    assert.equal(branchCandidate.code, 0, branchCandidate.stderr);
+    assert.equal(branchCandidate.output, `sha=${candidateSha}\n`);
+    assert.equal(await runSuccessfulCommand("git", ["rev-parse", "refs/remotes/origin/fix/test-candidate"], { cwd: runDir }), candidateSha);
+
+    const nonOwner = await runAuthorization({ actor: "someone-else" });
+    assert.equal(nonOwner.code, 1);
+    assert.match(nonOwner.stderr, /only by the repository owner/);
+
+    const invalidRef = await runAuthorization({ requestedRef: "../invalid", requestedSha: candidateSha });
+    assert.equal(invalidRef.code, 1);
+    assert.match(invalidRef.stderr, /valid branch name/);
+
+    const nonAncestor = await runAuthorization({ requestedRef: "fix/test-candidate", requestedSha: otherSha });
+    assert.equal(nonAncestor.code, 1);
+    assert.match(nonAncestor.stderr, /not reachable from candidate_ref/);
+
+    const invalidSha = await runAuthorization({ requestedSha: "abc123" });
+    assert.equal(invalidSha.code, 1);
+    assert.match(invalidSha.stderr, /full lowercase commit SHA/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("workflow is manual, protected, pinned, and bounded", async () => {
   const workflow = await readFile(new URL("../../.github/workflows/zulip-live-smoke.yml", import.meta.url), "utf8");
   const agentProtocol = await readFile(new URL("./agent-workspace/AGENTS.md", import.meta.url), "utf8");
   assert.match(workflow, /workflow_dispatch:/);
   assert.doesNotMatch(workflow, /pull_request:|\n\s+push:/);
   assert.match(workflow, /environment: zulip-live-smoke/);
+  assert.match(workflow, /DISPATCH_ACTOR.*github\.actor/);
   assert.match(workflow, /DISPATCH_REF.*github\.ref/);
-  assert.match(workflow, /DISPATCH_REF\" != \"refs\/heads\/main/);
-  assert.match(workflow, /merge-base --is-ancestor/);
+  assert.match(workflow, /REQUESTED_REF.*inputs\.candidate_ref/);
+  assert.match(workflow, /run: scripts\/live-smoke\/authorize-candidate\.sh/);
   assert.match(workflow, /permissions:\n\s+contents: read/);
   assert.match(workflow, /timeout-minutes: 35/);
   assert.doesNotMatch(workflow, /timeout-minutes: 35\n\s+env:/);


### PR DESCRIPTION
## Summary

- allow the repository owner to run the protected live smoke against a commit on a named same-repository branch
- preserve the main-workflow, exact-SHA, ancestry, and environment-approval trust gates
- document one-branch/one-PR live-smoke iteration instead of merging every experiment
- add behavioral authorization tests using temporary Git repositories

Closes #69.

## Verification

- `shellcheck scripts/live-smoke/authorize-candidate.sh`
- `git diff --check`
- `pnpm run build`
- `pnpm test` (274 Vitest tests and 59 offline live-smoke tests)
- independent security review approved commit `d738aeda43734d47f2405465db88759b48c13bd1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes gate access to protected live Zulip credentials via new branch-based ancestry rules and owner-only dispatch; misconfiguration could expose secrets to untrusted commits or actors.
> 
> **Overview**
> Extends the **Zulip live smoke (protected)** workflow so the repository owner can test commits on a named same-repo branch without merging each fix to `main`. A new **`candidate_ref`** dispatch input (default **`main`**) pairs with **`candidate_sha`**; authorization is centralized in **`scripts/live-smoke/authorize-candidate.sh`**, which still requires dispatch from **`main`**, restricts dispatch to the owner, validates the SHA and branch name, and only releases the candidate when the commit is an ancestor of the fetched **`candidate_ref`**.
> 
> **README** and **`docs/RELEASE_CHECKLIST.md`** describe the one-branch / one-PR iteration flow for live-only failures. Offline tests in **`run.offline.mjs`** exercise the script with temporary git repos and update workflow contract checks to expect the script invocation and **`DISPATCH_ACTOR`** wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d738aeda43734d47f2405465db88759b48c13bd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->