### PR TITLE
fix(sdk): support OpenClaw 8.1 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - **Per-stream inbound policy**: Add deterministic name/ID `streamOverrides` for inbound activation, mention requirements, and allowed/excluded topics while preserving legacy `streams`, `topics`, and `streamTopics` behavior.
 - **Early inbound filtering**: Resolve stream policy before durable acceptance, attachment downloads, reactions, typing, routing, or agent dispatch. Outbound access remains independent.
 
+### Compatibility
+- **OpenClaw 2026.8.1 compatibility**: Use the shared ingress queue and typed media-runtime SDK surfaces while retaining OpenClaw 2026.7.1-2 as the minimum supported host, draining legacy durable records, and keeping command access-group checks enabled.
+
 ## 2026.5.26
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -23,20 +23,23 @@
 
 ## Installation
 
-This source targets OpenClaw **2026.7.1-2**. It uses the focused channel SDK,
-ordered inbound media facts, buffered reply dispatch, and portable message
-presentations. The development dependency is pinned to that published SDK.
+This source supports OpenClaw **2026.7.1-2 through 2026.8.1**. The development
+dependency and minimum host version remain pinned to 2026.7.1-2, so the same
+plugin build can still be installed and tested on the current stable host.
 
-Do not use this branch with the 2026.8 beta yet: that SDK removes the keyed-store
-receive journal before an external-plugin migration path is available. Pending
-inbound records and deduplication tombstones retain their existing namespaces and
-retention; this update does not migrate or discard them. The newer ingress queue
-also requires host trust unavailable to ordinary third-party plugins.
+Durable inbound handling uses the shared ingress queue API available in both
+supported versions. When upgrading an existing installation, pending records and
+deduplication tombstones from the older keyed-store journal retain their original
+namespaces and retention. They are replayed or completed through the compatibility
+journal instead of being silently discarded.
 
-The stable setup adapter, session-store path resolver, human-delay resolver, and
-outbound media loader remain until supported replacements preserve their current
-contracts. The beta setup contract is not available in the pinned stable SDK;
-replacing the outbound loader must preserve host-provided file access limits.
+Outbound media loading uses the typed media-runtime SDK surface shared by both
+versions. Command access-group authorization remains enabled even if an older
+configuration still contains the removed `commands.useAccessGroups` toggle.
+
+OpenClaw 2026.8.1 compatibility does not require upgrading a running Gateway.
+Keep production on 2026.7.1-2 until the separate 2026.8.1 core startup regressions
+are resolved.
 
 ### Via plugin manager (recommended)
 

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -10,7 +10,32 @@ export type { WizardPrompter } from "openclaw/plugin-sdk/setup";
 export type { ChannelGroupContext } from "openclaw/plugin-sdk/channel-contract";
 
 export type { ChannelOutboundAdapter } from "openclaw/plugin-sdk/channel-send-result";
-export { loadOutboundMediaFromUrl } from "openclaw/plugin-sdk/outbound-media";
+import { buildOutboundMediaLoadOptions } from "openclaw/plugin-sdk/media-runtime";
+import { loadWebMedia } from "openclaw/plugin-sdk/web-media";
+
+type OutboundMediaLoadOptions = {
+  maxBytes?: number;
+  mediaAccess?: {
+    localRoots?: readonly string[];
+    readFile?: (filePath: string) => Promise<Buffer>;
+    workspaceDir?: string;
+  };
+  mediaLocalRoots?: readonly string[] | "any";
+  mediaReadFile?: (filePath: string) => Promise<Buffer>;
+  workspaceDir?: string;
+  proxyUrl?: string;
+  fetchImpl?: typeof fetch;
+  requestInit?: RequestInit;
+  optimizeImages?: boolean;
+  trustExplicitProxyDns?: boolean;
+};
+
+export async function loadOutboundMediaFromUrl(
+  mediaUrl: string,
+  options: OutboundMediaLoadOptions = {},
+) {
+  return await loadWebMedia(mediaUrl, buildOutboundMediaLoadOptions(options));
+}
 
 export {
   createChannelMessageAdapterFromOutbound,

--- a/src/zulip/durable-receive.ts
+++ b/src/zulip/durable-receive.ts
@@ -111,6 +111,20 @@ export function createZulipDurableInboundReceiveJournal(accountId: string) {
     return normalized;
   };
 
+  const reconcileLegacyCompletion = async (
+    id: string,
+    completed: LegacyCompletedRecord,
+  ): Promise<void> => {
+    try {
+      await queueJournal.complete(id, {
+        metadata: completed.metadata,
+        completedAt: completed.completedAt,
+      });
+    } catch {
+      return;
+    }
+  };
+
   return {
     accept: async (
       id: string,
@@ -131,10 +145,7 @@ export function createZulipDurableInboundReceiveJournal(accountId: string) {
       if (!completedAfterAccept) {
         return result;
       }
-      await queueJournal.complete(key, {
-        metadata: completedAfterAccept.metadata,
-        completedAt: completedAfterAccept.completedAt,
-      });
+      await reconcileLegacyCompletion(key, completedAfterAccept);
       return {
         kind: "completed" as const,
         duplicate: true as const,
@@ -159,10 +170,7 @@ export function createZulipDurableInboundReceiveJournal(accountId: string) {
       for (const record of queuePending) {
         const completed = await legacyCompletedStore.lookup(record.id);
         if (completed) {
-          await queueJournal.complete(record.id, {
-            metadata: completed.metadata,
-            completedAt: completed.completedAt,
-          });
+          await reconcileLegacyCompletion(record.id, completed);
         } else {
           records.set(record.id, record);
         }

--- a/src/zulip/durable-receive.ts
+++ b/src/zulip/durable-receive.ts
@@ -176,17 +176,22 @@ export function createZulipDurableInboundReceiveJournal(accountId: string) {
       options?: { metadata?: ZulipDurableInboundCompletedMetadata; completedAt?: number },
     ) => {
       const key = normalizeId(id);
+      const legacyPending = await legacyPendingStore.lookup(key);
       const completedAt = options?.completedAt ?? Date.now();
-      const record: LegacyCompletedRecord = {
-        id: key,
-        completedAt,
-        ...(options?.metadata === undefined ? {} : { metadata: options.metadata }),
-      };
-      await legacyCompletedStore.register(key, record, {
-        ttlMs: ZULIP_DURABLE_INBOUND_COMPLETED_TTL_MS,
-      });
+      if (legacyPending) {
+        const record: LegacyCompletedRecord = {
+          id: key,
+          completedAt,
+          ...(options?.metadata === undefined ? {} : { metadata: options.metadata }),
+        };
+        await legacyCompletedStore.register(key, record, {
+          ttlMs: ZULIP_DURABLE_INBOUND_COMPLETED_TTL_MS,
+        });
+      }
       await queueJournal.complete(key, { ...options, completedAt });
-      await legacyPendingStore.delete(key);
+      if (legacyPending) {
+        await legacyPendingStore.delete(key);
+      }
     },
     release: async (
       id: string,

--- a/src/zulip/durable-receive.ts
+++ b/src/zulip/durable-receive.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { createDurableInboundReceiveJournal } from "openclaw/plugin-sdk/channel-outbound";
+import { createDurableInboundReceiveJournalFromQueue } from "openclaw/plugin-sdk/channel-outbound";
 import type { PluginJsonValue } from "openclaw/plugin-sdk/plugin-entry";
 
 import { getZulipRuntime } from "../runtime.js";
@@ -22,6 +22,23 @@ export type ZulipDurableInboundMetadata = {
 
 export type ZulipDurableInboundCompletedMetadata = {
   queueEventId?: number;
+};
+
+type LegacyPendingRecord = {
+  id: string;
+  payload: ZulipDurableInboundPayload;
+  metadata?: ZulipDurableInboundMetadata;
+  receivedAt: number;
+  updatedAt: number;
+  attempts: number;
+  lastAttemptAt?: number;
+  lastError?: string;
+};
+
+type LegacyCompletedRecord = {
+  id: string;
+  completedAt: number;
+  metadata?: ZulipDurableInboundCompletedMetadata;
 };
 
 function hashNamespacePart(value: string): string {
@@ -51,26 +68,169 @@ export function deserializeZulipDurableInboundMessage<T>(
 
 export function createZulipDurableInboundReceiveJournal(accountId: string) {
   const runtime = getZulipRuntime();
-  if (typeof runtime.state?.openKeyedStore !== "function") {
-    throw new Error("plugin keyed state is not available");
+  if (
+    typeof runtime.state?.openKeyedStore !== "function" ||
+    typeof runtime.state?.openChannelIngressQueue !== "function"
+  ) {
+    throw new Error("durable plugin state is not available");
   }
   const accountPart = hashNamespacePart(accountId);
-  return createDurableInboundReceiveJournal<
+  const legacyPendingStore = runtime.state.openKeyedStore<LegacyPendingRecord>({
+    namespace: `inbound.v1.pending.${accountPart}`,
+    maxEntries: ZULIP_DURABLE_INBOUND_PENDING_MAX_ENTRIES,
+    defaultTtlMs: ZULIP_DURABLE_INBOUND_PENDING_TTL_MS,
+  });
+  const legacyCompletedStore = runtime.state.openKeyedStore<LegacyCompletedRecord>({
+    namespace: `inbound.v1.completed.${accountPart}`,
+    maxEntries: ZULIP_DURABLE_INBOUND_COMPLETED_MAX_ENTRIES,
+    defaultTtlMs: ZULIP_DURABLE_INBOUND_COMPLETED_TTL_MS,
+  });
+  const queueJournal = createDurableInboundReceiveJournalFromQueue<
     ZulipDurableInboundPayload,
     ZulipDurableInboundMetadata,
     ZulipDurableInboundCompletedMetadata
   >({
-    pendingStore: runtime.state.openKeyedStore({
-      namespace: `inbound.v1.pending.${accountPart}`,
-      maxEntries: ZULIP_DURABLE_INBOUND_PENDING_MAX_ENTRIES,
-      defaultTtlMs: ZULIP_DURABLE_INBOUND_PENDING_TTL_MS,
-    }),
-    completedStore: runtime.state.openKeyedStore({
-      namespace: `inbound.v1.completed.${accountPart}`,
-      maxEntries: ZULIP_DURABLE_INBOUND_COMPLETED_MAX_ENTRIES,
-      defaultTtlMs: ZULIP_DURABLE_INBOUND_COMPLETED_TTL_MS,
-    }),
-    pendingTtlMs: ZULIP_DURABLE_INBOUND_PENDING_TTL_MS,
-    completedTtlMs: ZULIP_DURABLE_INBOUND_COMPLETED_TTL_MS,
+    queue: runtime.state.openChannelIngressQueue<
+      ZulipDurableInboundPayload,
+      ZulipDurableInboundMetadata,
+      ZulipDurableInboundCompletedMetadata
+    >({ accountId }),
+    retention: {
+      pendingTtlMs: ZULIP_DURABLE_INBOUND_PENDING_TTL_MS,
+      completedTtlMs: ZULIP_DURABLE_INBOUND_COMPLETED_TTL_MS,
+      pendingMaxEntries: ZULIP_DURABLE_INBOUND_PENDING_MAX_ENTRIES,
+      completedMaxEntries: ZULIP_DURABLE_INBOUND_COMPLETED_MAX_ENTRIES,
+    },
   });
+
+  const normalizeId = (id: string) => {
+    const normalized = id.trim();
+    if (!normalized) {
+      throw new Error("Durable inbound receive id cannot be empty");
+    }
+    return normalized;
+  };
+
+  return {
+    accept: async (
+      id: string,
+      payload: ZulipDurableInboundPayload,
+      options?: { metadata?: ZulipDurableInboundMetadata; receivedAt?: number },
+    ) => {
+      const key = normalizeId(id);
+      const completed = await legacyCompletedStore.lookup(key);
+      if (completed) {
+        return { kind: "completed" as const, duplicate: true as const, record: completed };
+      }
+      const pending = await legacyPendingStore.lookup(key);
+      if (pending) {
+        return { kind: "pending" as const, duplicate: true as const, record: pending };
+      }
+      const result = await queueJournal.accept(key, payload, options);
+      const completedAfterAccept = await legacyCompletedStore.lookup(key);
+      if (!completedAfterAccept) {
+        return result;
+      }
+      await queueJournal.complete(key, {
+        metadata: completedAfterAccept.metadata,
+        completedAt: completedAfterAccept.completedAt,
+      });
+      return {
+        kind: "completed" as const,
+        duplicate: true as const,
+        record: completedAfterAccept,
+      };
+    },
+    pending: async () => {
+      const legacyEntries = await legacyPendingStore.entries();
+      const legacyPending: LegacyPendingRecord[] = [];
+      for (const entry of legacyEntries) {
+        if (await legacyCompletedStore.lookup(entry.key)) {
+          await legacyPendingStore.delete(entry.key);
+        } else {
+          legacyPending.push(entry.value);
+        }
+      }
+      const queuePending = await queueJournal.pending();
+      const records = new Map<string, LegacyPendingRecord>();
+      for (const record of legacyPending) {
+        records.set(record.id, record);
+      }
+      for (const record of queuePending) {
+        const completed = await legacyCompletedStore.lookup(record.id);
+        if (completed) {
+          await queueJournal.complete(record.id, {
+            metadata: completed.metadata,
+            completedAt: completed.completedAt,
+          });
+        } else {
+          records.set(record.id, record);
+        }
+      }
+      return [...records.values()].sort(
+        (left, right) => left.receivedAt - right.receivedAt || left.id.localeCompare(right.id),
+      );
+    },
+    complete: async (
+      id: string,
+      options?: { metadata?: ZulipDurableInboundCompletedMetadata; completedAt?: number },
+    ) => {
+      const key = normalizeId(id);
+      const completedAt = options?.completedAt ?? Date.now();
+      const record: LegacyCompletedRecord = {
+        id: key,
+        completedAt,
+        ...(options?.metadata === undefined ? {} : { metadata: options.metadata }),
+      };
+      await legacyCompletedStore.register(key, record, {
+        ttlMs: ZULIP_DURABLE_INBOUND_COMPLETED_TTL_MS,
+      });
+      await queueJournal.complete(key, { ...options, completedAt });
+      await legacyPendingStore.delete(key);
+    },
+    release: async (
+      id: string,
+      options?: { lastError?: string; releasedAt?: number },
+    ) => {
+      const key = normalizeId(id);
+      const pending = await legacyPendingStore.lookup(key);
+      if (!pending) {
+        return await queueJournal.release(key, options);
+      }
+      const releasedAt = options?.releasedAt ?? Date.now();
+      const next: LegacyPendingRecord = {
+        ...pending,
+        updatedAt: releasedAt,
+        attempts: pending.attempts + 1,
+        lastAttemptAt: releasedAt,
+        ...(options?.lastError === undefined ? {} : { lastError: options.lastError }),
+      };
+      if (legacyPendingStore.update) {
+        await legacyPendingStore.update(
+          key,
+          (current) => current ? {
+            ...current,
+            updatedAt: releasedAt,
+            attempts: current.attempts + 1,
+            lastAttemptAt: releasedAt,
+            ...(options?.lastError === undefined ? {} : { lastError: options.lastError }),
+          } : undefined,
+          { ttlMs: ZULIP_DURABLE_INBOUND_PENDING_TTL_MS },
+        );
+      } else {
+        await legacyPendingStore.register(key, next, {
+          ttlMs: ZULIP_DURABLE_INBOUND_PENDING_TTL_MS,
+        });
+      }
+      return true;
+    },
+    deletePending: async (id: string) => {
+      const key = normalizeId(id);
+      const [legacyDeleted, queueDeleted] = await Promise.all([
+        legacyPendingStore.delete(key),
+        queueJournal.deletePending(key),
+      ]);
+      return legacyDeleted || queueDeleted;
+    },
+  };
 }

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -38,6 +38,85 @@ const state = vi.hoisted(() => {
     };
   };
 
+  const createMemoryIngressQueue = () => {
+    const pending = new Map<string, Record<string, any>>();
+    const completed = new Map<string, Record<string, any>>();
+    return {
+      enqueue: vi.fn(async (
+        id: string,
+        payload: unknown,
+        options: { metadata?: unknown; receivedAt?: number } = {},
+      ) => {
+        const completedRecord = completed.get(id);
+        if (completedRecord) {
+          return { kind: "completed", duplicate: true, record: completedRecord };
+        }
+        const pendingRecord = pending.get(id);
+        if (pendingRecord) {
+          return { kind: "pending", duplicate: true, record: pendingRecord };
+        }
+        const receivedAt = options.receivedAt ?? Date.now();
+        const record = {
+          id,
+          channelId: "zulip",
+          accountId: "default",
+          queueName: "default",
+          payload,
+          ...(options.metadata === undefined ? {} : { metadata: options.metadata }),
+          receivedAt,
+          updatedAt: receivedAt,
+          attempts: 0,
+        };
+        pending.set(id, record);
+        return { kind: "accepted", duplicate: false, record };
+      }),
+      listPending: vi.fn(async () => [...pending.values()]),
+      listClaims: vi.fn(async () => []),
+      claimNext: vi.fn(async () => null),
+      claim: vi.fn(async () => null),
+      complete: vi.fn(async (
+        id: string,
+        options: { metadata?: unknown; completedAt?: number } = {},
+      ) => {
+        if (!pending.has(id) && completed.has(id)) {
+          return false;
+        }
+        pending.delete(id);
+        completed.set(id, {
+          id,
+          channelId: "zulip",
+          accountId: "default",
+          queueName: "default",
+          completedAt: options.completedAt ?? Date.now(),
+          ...(options.metadata === undefined ? {} : { metadata: options.metadata }),
+        });
+        return true;
+      }),
+      release: vi.fn(async (
+        id: string,
+        options: { lastError?: string; releasedAt?: number } = {},
+      ) => {
+        const record = pending.get(id);
+        if (!record) {
+          return false;
+        }
+        const releasedAt = options.releasedAt ?? Date.now();
+        pending.set(id, {
+          ...record,
+          updatedAt: releasedAt,
+          attempts: Number(record.attempts ?? 0) + 1,
+          lastAttemptAt: releasedAt,
+          ...(options.lastError === undefined ? {} : { lastError: options.lastError }),
+        });
+        return true;
+      }),
+      fail: vi.fn(async () => false),
+      delete: vi.fn(async (id: string) => pending.delete(id)),
+      recoverStaleClaims: vi.fn(async () => 0),
+      prune: vi.fn(async () => 0),
+    };
+  };
+
   const createCore = () => ({
     config: {
       channels: {
@@ -54,6 +133,7 @@ const state = vi.hoisted(() => {
       | undefined
       | {
           openKeyedStore: ReturnType<typeof vi.fn>;
+          openChannelIngressQueue: ReturnType<typeof vi.fn>;
         },
     system: {
       enqueueSystemEvent: vi.fn(),
@@ -114,9 +194,11 @@ const state = vi.hoisted(() => {
 
   return {
     createMemoryKeyedStore,
+    createMemoryIngressQueue,
     abortController: undefined as AbortController | undefined,
     autoAbort: true,
     durableStores: new Map<string, ReturnType<typeof createMemoryKeyedStore>>(),
+    durableQueues: new Map<string, ReturnType<typeof createMemoryIngressQueue>>(),
     pollResponses: [] as Array<Record<string, unknown>>,
     pairingAllowFrom: [] as string[],
     pairingUpsertError: undefined as Error | undefined,
@@ -321,6 +403,7 @@ async function runMonitorOnce(
 
 function enableDurableInboundJournal() {
   state.durableStores = new Map();
+  state.durableQueues = new Map();
   state.core.state = {
     openKeyedStore: vi.fn((options: { namespace: string }) => {
       const existing = state.durableStores.get(options.namespace);
@@ -330,6 +413,16 @@ function enableDurableInboundJournal() {
       const store = state.createMemoryKeyedStore(options.maxEntries);
       state.durableStores.set(options.namespace, store);
       return store;
+    }),
+    openChannelIngressQueue: vi.fn((options: { accountId?: string } = {}) => {
+      const accountId = options.accountId ?? "default";
+      const existing = state.durableQueues.get(accountId);
+      if (existing) {
+        return existing;
+      }
+      const queue = state.createMemoryIngressQueue();
+      state.durableQueues.set(accountId, queue);
+      return queue;
     }),
   };
 }
@@ -341,6 +434,7 @@ describe("monitorZulipProvider", () => {
     state.core = state.createCore();
     state.core.channel.inbound.buildContext.mockImplementation(buildChannelInboundEventContext);
     state.durableStores = new Map();
+    state.durableQueues = new Map();
     state.pairingAllowFrom = [];
     state.pairingUpsertError = undefined;
     state.upsertPairingRequest.mockReset().mockImplementation(async () => {
@@ -1438,11 +1532,6 @@ describe("monitorZulipProvider", () => {
       5 * 1024 * 1024,
     );
     expect(state.core.channel.media.saveMediaBuffer).toHaveBeenCalledTimes(3);
-    // The stable SDK projects canonical input facts into its older dispatch context.
-    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0]?.[0]?.ctx).toMatchObject({
-      MediaPaths: ["/managed/song.mp3", "/managed/image.png", "/managed/report.pdf"],
-      MediaTypes: ["audio/mpeg", "image/png", "application/pdf"],
-    });
     expect(state.core.channel.inbound.buildContext).toHaveBeenCalledWith(
       expect.objectContaining({
         media: [
@@ -2139,7 +2228,8 @@ describe("monitorZulipProvider", () => {
   it.each([
     { paired: true, expectedDispatches: 1 },
     { paired: false, expectedDispatches: 0 },
-  ])("preserves paired command authorization in open streams (paired=$paired)", async ({ paired, expectedDispatches }) => {
+  ])("keeps access-group command authorization enabled in open streams (paired=$paired)", async ({ paired, expectedDispatches }) => {
+    (state.core.config.commands as { useAccessGroups?: boolean }).useAccessGroups = false;
     state.account.config.dmPolicy = "pairing";
     state.pairingAllowFrom = paired ? ["user8@zlp.pubnerd.app"] : [];
     state.core.channel.commands.shouldHandleTextCommands.mockReturnValue(true);
@@ -2152,6 +2242,105 @@ describe("monitorZulipProvider", () => {
     if (paired) {
       expect(state.core.channel.inbound.buildContext).toHaveReturnedWith(expect.objectContaining({ CommandAuthorized: true }));
     }
+  });
+
+  it("drains legacy keyed-journal records through the queue-backed compatibility journal", async () => {
+    enableDurableInboundJournal();
+    const {
+      createZulipDurableInboundMessageId,
+      createZulipDurableInboundReceiveJournal,
+      serializeZulipDurableInboundMessage,
+    } = await import("./durable-receive.js");
+    const message = makeChannelMessage(2100);
+    const durableId = createZulipDurableInboundMessageId({
+      accountId: state.account.accountId,
+      messageId: String(message.id),
+    });
+    const journal = createZulipDurableInboundReceiveJournal(state.account.accountId);
+    const pendingStore = Array.from(state.durableStores.entries()).find(([namespace]) =>
+      namespace.includes(".pending."),
+    )?.[1];
+    expect(pendingStore).toBeDefined();
+    await pendingStore!.register(durableId, {
+      id: durableId,
+      payload: {
+        message: serializeZulipDurableInboundMessage(message),
+        receivedAt: 100,
+      },
+      receivedAt: 100,
+      updatedAt: 100,
+      attempts: 2,
+      lastAttemptAt: 100,
+      lastError: "legacy failure",
+    });
+
+    await expect(journal.pending()).resolves.toEqual([
+      expect.objectContaining({ id: durableId, attempts: 2, lastError: "legacy failure" }),
+    ]);
+    await expect(journal.release(durableId, {
+      lastError: "retry failure",
+      releasedAt: 200,
+    })).resolves.toBe(true);
+    await expect(journal.pending()).resolves.toEqual([
+      expect.objectContaining({ id: durableId, attempts: 3, lastError: "retry failure" }),
+    ]);
+
+    await journal.complete(durableId, {
+      metadata: { queueEventId: 9 },
+      completedAt: 300,
+    });
+    await expect(journal.pending()).resolves.toEqual([]);
+    await expect(journal.accept(durableId, {
+      message: serializeZulipDurableInboundMessage(message),
+      receivedAt: 400,
+    })).resolves.toEqual(expect.objectContaining({
+      kind: "completed",
+      duplicate: true,
+      record: expect.objectContaining({ completedAt: 300, metadata: { queueEventId: 9 } }),
+    }));
+  });
+
+  it("does not replay queue records covered by a legacy completion tombstone", async () => {
+    enableDurableInboundJournal();
+    const {
+      createZulipDurableInboundMessageId,
+      createZulipDurableInboundReceiveJournal,
+      serializeZulipDurableInboundMessage,
+    } = await import("./durable-receive.js");
+    const message = makeChannelMessage(2101);
+    const durableId = createZulipDurableInboundMessageId({
+      accountId: state.account.accountId,
+      messageId: String(message.id),
+    });
+    const journal = createZulipDurableInboundReceiveJournal(state.account.accountId);
+    const queue = state.durableQueues.get(state.account.accountId);
+    const completedStore = Array.from(state.durableStores.entries()).find(([namespace]) =>
+      namespace.includes(".completed."),
+    )?.[1];
+    expect(queue).toBeDefined();
+    expect(completedStore).toBeDefined();
+    await queue!.enqueue(durableId, {
+      message: serializeZulipDurableInboundMessage(message),
+      receivedAt: 100,
+    }, { receivedAt: 100 });
+    await completedStore!.register(durableId, {
+      id: durableId,
+      completedAt: 200,
+      metadata: { queueEventId: 10 },
+    });
+
+    await expect(journal.pending()).resolves.toEqual([]);
+    expect(queue!.complete).toHaveBeenCalledWith(durableId, {
+      metadata: { queueEventId: 10 },
+      completedAt: 200,
+    });
+    await expect(journal.accept(durableId, {
+      message: serializeZulipDurableInboundMessage(message),
+      receivedAt: 300,
+    })).resolves.toEqual(expect.objectContaining({
+      kind: "completed",
+      duplicate: true,
+    }));
   });
 
   it("records and completes durable inbound messages when plugin state is available", async () => {
@@ -2300,13 +2489,12 @@ describe("monitorZulipProvider", () => {
 
       await runMonitorOnce();
 
-      const pendingStore = Array.from(state.durableStores.entries()).find(([namespace]) =>
-        namespace.includes(".pending."),
-      )?.[1];
+      const { createZulipDurableInboundReceiveJournal } = await import("./durable-receive.js");
+      const journal = createZulipDurableInboundReceiveJournal(state.account.accountId);
       const completedStore = Array.from(state.durableStores.entries()).find(([namespace]) =>
         namespace.includes(".completed."),
       )?.[1];
-      await expect(pendingStore?.entries()).resolves.toHaveLength(1);
+      await expect(journal.pending()).resolves.toHaveLength(1);
       await expect(completedStore?.entries()).resolves.toEqual([]);
       expect(state.addZulipReaction).toHaveBeenCalledWith(
         state.client,
@@ -2325,7 +2513,7 @@ describe("monitorZulipProvider", () => {
         });
       await runMonitorOnce();
 
-      await expect(pendingStore?.entries()).resolves.toEqual([]);
+      await expect(journal.pending()).resolves.toEqual([]);
       await expect(completedStore?.entries()).resolves.toHaveLength(1);
       expect(
         state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher,

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -2343,7 +2343,7 @@ describe("monitorZulipProvider", () => {
     }));
   });
 
-  it("records and completes durable inbound messages when plugin state is available", async () => {
+  it("completes fresh durable inbound messages without filling the legacy tombstone store", async () => {
     enableDurableInboundJournal();
     state.pollResponses = [
       {
@@ -2361,10 +2361,11 @@ describe("monitorZulipProvider", () => {
       namespace.includes(".completed."),
     )?.[1];
     await expect(pendingStore?.entries()).resolves.toEqual([]);
-    const completedEntries = await completedStore?.entries();
-    expect(completedEntries).toHaveLength(1);
-    expect(completedEntries?.[0]?.value).toMatchObject({
+    await expect(completedStore?.entries()).resolves.toEqual([]);
+    const queue = state.durableQueues.get(state.account.accountId);
+    expect(queue?.complete).toHaveBeenCalledWith(expect.any(String), {
       metadata: { queueEventId: 2 },
+      completedAt: expect.any(Number),
     });
     expect(state.core.channel.inbound.buildContext).toHaveBeenCalledTimes(1);
   });
@@ -2390,7 +2391,7 @@ describe("monitorZulipProvider", () => {
       namespace.includes(".completed."),
     )?.[1];
     await expect(pendingStore?.entries()).resolves.toEqual([]);
-    await expect(completedStore?.entries()).resolves.toHaveLength(1);
+    await expect(completedStore?.entries()).resolves.toEqual([]);
     expect(state.editZulipMessage).toHaveBeenCalledExactlyOnceWith(state.client, {
       messageId: "outbound-1",
       content: "Turn failed.",
@@ -2438,7 +2439,7 @@ describe("monitorZulipProvider", () => {
       namespace.includes(".completed."),
     )?.[1];
     await expect(pendingStore?.entries()).resolves.toEqual([]);
-    await expect(completedStore?.entries()).resolves.toHaveLength(1);
+    await expect(completedStore?.entries()).resolves.toEqual([]);
     expect(state.sendMessageZulip).toHaveBeenNthCalledWith(
       3,
       "stream:debbie:zulip-plugin-pr",
@@ -2514,7 +2515,7 @@ describe("monitorZulipProvider", () => {
       await runMonitorOnce();
 
       await expect(journal.pending()).resolves.toEqual([]);
-      await expect(completedStore?.entries()).resolves.toHaveLength(1);
+      await expect(completedStore?.entries()).resolves.toEqual([]);
       expect(
         state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher,
       ).toHaveBeenCalledTimes(1);
@@ -2550,7 +2551,7 @@ describe("monitorZulipProvider", () => {
       namespace.includes(".completed."),
     )?.[1];
     await expect(pendingStore?.entries()).resolves.toEqual([]);
-    await expect(completedStore?.entries()).resolves.toHaveLength(1);
+    await expect(completedStore?.entries()).resolves.toEqual([]);
     expect(state.addZulipReaction).toHaveBeenCalledWith(
       state.client,
       expect.objectContaining({ messageId: "2110", emojiName: "cross_mark" }),
@@ -2739,7 +2740,7 @@ describe("monitorZulipProvider", () => {
     const completedStore = Array.from(state.durableStores.entries()).find(([namespace]) =>
       namespace.includes(".completed."),
     )?.[1];
-    await expect(completedStore?.entries()).resolves.toHaveLength(1);
+    await expect(completedStore?.entries()).resolves.toEqual([]);
 
     state.removeZulipReaction.mockResolvedValue(undefined);
     state.autoAbort = true;

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -2328,6 +2328,7 @@ describe("monitorZulipProvider", () => {
       completedAt: 200,
       metadata: { queueEventId: 10 },
     });
+    queue!.complete.mockRejectedValueOnce(new Error("synthetic reconciliation failure"));
 
     await expect(journal.pending()).resolves.toEqual([]);
     expect(queue!.complete).toHaveBeenCalledWith(durableId, {
@@ -2341,6 +2342,43 @@ describe("monitorZulipProvider", () => {
       kind: "completed",
       duplicate: true,
     }));
+  });
+
+  it("suppresses delivery when post-accept legacy completion reconciliation fails", async () => {
+    enableDurableInboundJournal();
+    const {
+      createZulipDurableInboundMessageId,
+      createZulipDurableInboundReceiveJournal,
+      serializeZulipDurableInboundMessage,
+    } = await import("./durable-receive.js");
+    const message = makeChannelMessage(2102);
+    const durableId = createZulipDurableInboundMessageId({
+      accountId: state.account.accountId,
+      messageId: String(message.id),
+    });
+    const journal = createZulipDurableInboundReceiveJournal(state.account.accountId);
+    const queue = state.durableQueues.get(state.account.accountId);
+    const completedStore = Array.from(state.durableStores.entries()).find(([namespace]) =>
+      namespace.includes(".completed."),
+    )?.[1];
+    expect(queue).toBeDefined();
+    expect(completedStore).toBeDefined();
+    await completedStore!.register(durableId, {
+      id: durableId,
+      completedAt: 200,
+      metadata: { queueEventId: 11 },
+    });
+    completedStore!.lookup.mockResolvedValueOnce(undefined);
+    queue!.complete.mockRejectedValueOnce(new Error("synthetic reconciliation failure"));
+
+    await expect(journal.accept(durableId, {
+      message: serializeZulipDurableInboundMessage(message),
+      receivedAt: 300,
+    })).resolves.toEqual(expect.objectContaining({
+      kind: "completed",
+      duplicate: true,
+    }));
+    await expect(journal.pending()).resolves.toEqual([]);
   });
 
   it("completes fresh durable inbound messages without filling the legacy tombstone store", async () => {

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -706,7 +706,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     });
     const hasControlCommand = core.channel.text.hasControlCommand(rawText, cfg);
     const isControlCommand = allowTextCommands && hasControlCommand;
-    const useAccessGroups = cfg.commands?.useAccessGroups !== false;
+    const useAccessGroups = true;
     const senderAllowedForCommands = isSenderAllowed({
       senderId: senderIdentity,
       senderName,


### PR DESCRIPTION
Closes #71.

## Summary

- support OpenClaw 2026.8.1 while retaining 2026.7.1-2 as the minimum host
- move durable inbound processing to the shared ingress queue while draining legacy keyed-store records and tombstones
- keep command access-group authorization fail-closed after removal of `commands.useAccessGroups`
- replace the broken 8.1 outbound-media type export with the public typed media-runtime and web-media SDK surfaces
- document the compatibility matrix and keep the live Gateway on 2026.7.1-2

## Verification

- OpenClaw 2026.7.1-2: TypeScript build, 276 Vitest tests, and 59 offline smoke tests pass
- OpenClaw 2026.8.1: TypeScript build, 276 Vitest tests, and 59 offline smoke tests pass
- isolated local 7.1-2 plugin load reports the Zulip channel loaded with zero plugin diagnostics
- `git diff --check` passes
- Codex branch review completed against frozen commit `575af46`; its sole queue-only-host concern was rejected because both exact supported SDKs expose keyed-store and ingress-queue state, and keyed state is required to honor the promised legacy-record transition

The protected live smoke is intentionally deferred until the separate OpenClaw 8.1 Gateway startup regressions are resolved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes durable inbound persistence and command authorization semantics during host upgrades; incorrect legacy/queue reconciliation could duplicate or drop messages, though the PR adds explicit migration and tombstone handling.
> 
> **Overview**
> Adds **OpenClaw 2026.7.1-2 through 2026.8.1** support while keeping the minimum host pin unchanged, and documents upgrade behavior (ingress queue, legacy journal replay, outbound media, access groups).
> 
> **Durable inbound** now backs the receive journal with `openChannelIngressQueue` and `createDurableInboundReceiveJournalFromQueue`, while still reading the old keyed `inbound.v1.pending` / `inbound.v1.completed` namespaces. Accept, pending, complete, release, and delete merge queue and legacy state so pending work drains, tombstones block duplicates, and fresh completions no longer populate the legacy completed store.
> 
> **Outbound media** stops re-exporting `loadOutboundMediaFromUrl` from `outbound-media`; the plugin wrapper builds options via `media-runtime` and loads through `loadWebMedia`.
> 
> **Command authorization** always uses access groups (`useAccessGroups = true`), so `commands.useAccessGroups: false` no longer disables pairing/allowlist checks for control commands in streams.
> 
> Tests add in-memory ingress queue fakes and cases for legacy drain, tombstone reconciliation, and the updated completion paths; README/CHANGELOG describe the compatibility matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05aebfa980501ecdfc22dc3b5fef1a7d300fbaeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->