### PR TITLE
fix(durable): harden legacy reconciliation

### DIFF
--- a/src/zulip/durable-receive.ts
+++ b/src/zulip/durable-receive.ts
@@ -120,8 +120,20 @@ export function createZulipDurableInboundReceiveJournal(accountId: string) {
         metadata: completed.metadata,
         completedAt: completed.completedAt,
       });
-    } catch {
       return;
+    } catch {
+      let tombstoneExtended = false;
+      try {
+        await legacyCompletedStore.register(id, completed, {
+          ttlMs: ZULIP_DURABLE_INBOUND_PENDING_TTL_MS,
+        });
+        tombstoneExtended = true;
+      } catch {}
+      if (tombstoneExtended) {
+        try {
+          await queueJournal.deletePending(id);
+        } catch {}
+      }
     }
   };
 
@@ -134,6 +146,9 @@ export function createZulipDurableInboundReceiveJournal(accountId: string) {
       const key = normalizeId(id);
       const completed = await legacyCompletedStore.lookup(key);
       if (completed) {
+        try {
+          await reconcileLegacyCompletion(key, completed);
+        } catch {}
         return { kind: "completed" as const, duplicate: true as const, record: completed };
       }
       const pending = await legacyPendingStore.lookup(key);
@@ -141,11 +156,26 @@ export function createZulipDurableInboundReceiveJournal(accountId: string) {
         return { kind: "pending" as const, duplicate: true as const, record: pending };
       }
       const result = await queueJournal.accept(key, payload, options);
-      const completedAfterAccept = await legacyCompletedStore.lookup(key);
+      let completedAfterAccept: LegacyCompletedRecord | undefined;
+      try {
+        completedAfterAccept = await legacyCompletedStore.lookup(key);
+      } catch {
+        if (result.kind === "accepted") {
+          return {
+            kind: "pending" as const,
+            duplicate: true as const,
+            record: result.record,
+            retryInProcess: true as const,
+          };
+        }
+        return result;
+      }
       if (!completedAfterAccept) {
         return result;
       }
-      await reconcileLegacyCompletion(key, completedAfterAccept);
+      try {
+        await reconcileLegacyCompletion(key, completedAfterAccept);
+      } catch {}
       return {
         kind: "completed" as const,
         duplicate: true as const,

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -401,9 +401,17 @@ async function runMonitorOnce(
   });
 }
 
-function enableDurableInboundJournal() {
+function enableDurableInboundJournal(
+  journalOptions: {
+    completedLookupFailuresAfterAccept?: number;
+    completedLookupFailureIds?: readonly string[];
+    deferredPendingListFailures?: number;
+    queueCompletionFailures?: number;
+  } = {},
+) {
   state.durableStores = new Map();
   state.durableQueues = new Map();
+  let postAcceptLookupFailed = false;
   state.core.state = {
     openKeyedStore: vi.fn((options: { namespace: string }) => {
       const existing = state.durableStores.get(options.namespace);
@@ -411,6 +419,25 @@ function enableDurableInboundJournal() {
         return existing;
       }
       const store = state.createMemoryKeyedStore(options.maxEntries);
+      if (options.namespace.includes(".completed.")) {
+        let failuresRemaining = journalOptions.completedLookupFailuresAfterAccept ?? 0;
+        const failureIds = new Set(journalOptions.completedLookupFailureIds ?? []);
+        const lookupCounts = new Map<string, number>();
+        const lookup = store.lookup.getMockImplementation();
+        store.lookup.mockImplementation(async (key: string) => {
+          const count = (lookupCounts.get(key) ?? 0) + 1;
+          lookupCounts.set(key, count);
+          const targetedFailure = count === 2 && failureIds.delete(key);
+          if (count === 2 && (targetedFailure || failuresRemaining > 0)) {
+            if (!targetedFailure) {
+              failuresRemaining -= 1;
+            }
+            postAcceptLookupFailed = true;
+            throw new Error("synthetic legacy lookup failure");
+          }
+          return await lookup?.(key);
+        });
+      }
       state.durableStores.set(options.namespace, store);
       return store;
     }),
@@ -421,6 +448,24 @@ function enableDurableInboundJournal() {
         return existing;
       }
       const queue = state.createMemoryIngressQueue();
+      const complete = queue.complete.getMockImplementation();
+      let queueCompletionFailuresRemaining = journalOptions.queueCompletionFailures ?? 0;
+      queue.complete.mockImplementation(async (...args) => {
+        if (queueCompletionFailuresRemaining > 0) {
+          queueCompletionFailuresRemaining -= 1;
+          throw new Error("synthetic queue completion failure");
+        }
+        return await complete?.(...args);
+      });
+      const listPending = queue.listPending.getMockImplementation();
+      let pendingListFailuresRemaining = journalOptions.deferredPendingListFailures ?? 0;
+      queue.listPending.mockImplementation(async () => {
+        if (postAcceptLookupFailed && pendingListFailuresRemaining > 0) {
+          pendingListFailuresRemaining -= 1;
+          throw new Error("synthetic deferred pending-list failure");
+        }
+        return await listPending?.();
+      });
       state.durableQueues.set(accountId, queue);
       return queue;
     }),
@@ -2331,6 +2376,12 @@ describe("monitorZulipProvider", () => {
     queue!.complete.mockRejectedValueOnce(new Error("synthetic reconciliation failure"));
 
     await expect(journal.pending()).resolves.toEqual([]);
+    expect(completedStore!.register).toHaveBeenLastCalledWith(
+      durableId,
+      expect.objectContaining({ completedAt: 200 }),
+      { ttlMs: 30 * 24 * 60 * 60 * 1000 },
+    );
+    expect(queue!.delete).toHaveBeenCalledWith(durableId);
     expect(queue!.complete).toHaveBeenCalledWith(durableId, {
       metadata: { queueEventId: 10 },
       completedAt: 200,
@@ -2379,6 +2430,355 @@ describe("monitorZulipProvider", () => {
       duplicate: true,
     }));
     await expect(journal.pending()).resolves.toEqual([]);
+  });
+
+  it("keeps the queue fallback when completion and tombstone extension fail", async () => {
+    enableDurableInboundJournal();
+    const {
+      createZulipDurableInboundMessageId,
+      createZulipDurableInboundReceiveJournal,
+      serializeZulipDurableInboundMessage,
+    } = await import("./durable-receive.js");
+    const message = makeChannelMessage(2105);
+    const durableId = createZulipDurableInboundMessageId({
+      accountId: state.account.accountId,
+      messageId: String(message.id),
+    });
+    const journal = createZulipDurableInboundReceiveJournal(state.account.accountId);
+    const queue = state.durableQueues.get(state.account.accountId);
+    const completedStore = Array.from(state.durableStores.entries()).find(([namespace]) =>
+      namespace.includes(".completed."),
+    )?.[1];
+    expect(queue).toBeDefined();
+    expect(completedStore).toBeDefined();
+    await queue!.enqueue(durableId, {
+      message: serializeZulipDurableInboundMessage(message),
+      receivedAt: 100,
+    }, { receivedAt: 100 });
+    await completedStore!.register(durableId, {
+      id: durableId,
+      completedAt: 200,
+    });
+    queue!.complete.mockRejectedValueOnce(new Error("synthetic completion failure"));
+    completedStore!.register.mockRejectedValueOnce(new Error("synthetic extension failure"));
+
+    await expect(journal.pending()).resolves.toEqual([]);
+    expect(queue!.delete).not.toHaveBeenCalled();
+  });
+
+  it("defers delivery when the post-accept legacy completion lookup fails", async () => {
+    enableDurableInboundJournal();
+    const {
+      createZulipDurableInboundMessageId,
+      createZulipDurableInboundReceiveJournal,
+      serializeZulipDurableInboundMessage,
+    } = await import("./durable-receive.js");
+    const message = makeChannelMessage(2103);
+    const durableId = createZulipDurableInboundMessageId({
+      accountId: state.account.accountId,
+      messageId: String(message.id),
+    });
+    const journal = createZulipDurableInboundReceiveJournal(state.account.accountId);
+    const completedStore = Array.from(state.durableStores.entries()).find(([namespace]) =>
+      namespace.includes(".completed."),
+    )?.[1];
+    expect(completedStore).toBeDefined();
+    completedStore!.lookup
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("synthetic legacy lookup failure"));
+
+    await expect(journal.accept(durableId, {
+      message: serializeZulipDurableInboundMessage(message),
+      receivedAt: 300,
+    })).resolves.toEqual(expect.objectContaining({
+      kind: "pending",
+      duplicate: true,
+    }));
+    await expect(journal.pending()).resolves.toEqual([
+      expect.objectContaining({ id: durableId }),
+    ]);
+  });
+
+  it("retries a post-accept legacy lookup deferral without waiting for restart", async () => {
+    enableDurableInboundJournal({ completedLookupFailuresAfterAccept: 1 });
+    state.autoAbort = false;
+    const controller = new AbortController();
+    state.pollResponses = [{
+      result: "success",
+      events: [{ id: 12, type: "message", message: makeChannelMessage(2199) }],
+    }];
+
+    const monitorPromise = runMonitorOnce(controller);
+    await vi.waitFor(() => {
+      const queue = state.durableQueues.get(state.account.accountId);
+      expect(queue?.complete).toHaveBeenCalledWith(expect.any(String), {
+        metadata: { queueEventId: 12 },
+        completedAt: expect.any(Number),
+      });
+    });
+    controller.abort();
+    await monitorPromise;
+
+    expect(state.core.channel.inbound.buildContext).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries only the deferred durable message while another message is in flight", async () => {
+    const { createZulipDurableInboundMessageId } = await import("./durable-receive.js");
+    const firstMessage = makeChannelMessage(99200);
+    const deferredMessage = makeChannelMessage(99201);
+    const deferredDurableId = createZulipDurableInboundMessageId({
+      accountId: state.account.accountId,
+      messageId: String(deferredMessage.id),
+    });
+    enableDurableInboundJournal({ completedLookupFailureIds: [deferredDurableId] });
+    state.autoAbort = false;
+    const controller = new AbortController();
+    let releaseFirstReply!: () => void;
+    const firstReplyRelease = new Promise<void>((resolve) => {
+      releaseFirstReply = resolve;
+    });
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher
+      .mockImplementationOnce(async () => {
+        await firstReplyRelease;
+        return { counts: { tool: 0, block: 0, final: 1 } };
+      })
+      .mockImplementationOnce(async () => {
+        releaseFirstReply();
+        controller.abort();
+        return { counts: { tool: 0, block: 0, final: 1 } };
+      });
+    state.pollResponses = [{
+      result: "success",
+      events: [
+        { id: 15, type: "message", message: firstMessage },
+        { id: 16, type: "message", message: deferredMessage },
+      ],
+    }];
+
+    await runMonitorOnce(controller);
+
+    expect(
+      state.core.channel.inbound.buildContext.mock.calls.map(([input]) => input.messageId),
+    ).toEqual(["99200", "99201"]);
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries deferred durable replay after a transient pending-list failure", async () => {
+    const { createZulipDurableInboundMessageId } = await import("./durable-receive.js");
+    const message = makeChannelMessage(99202);
+    const durableId = createZulipDurableInboundMessageId({
+      accountId: state.account.accountId,
+      messageId: String(message.id),
+    });
+    enableDurableInboundJournal({
+      completedLookupFailureIds: [durableId],
+      deferredPendingListFailures: 1,
+    });
+    state.autoAbort = false;
+    const controller = new AbortController();
+    const runtimeError = vi.fn();
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async () => {
+        controller.abort();
+        return { counts: { tool: 0, block: 0, final: 1 } };
+      },
+    );
+    state.pollResponses = [{
+      result: "success",
+      events: [{ id: 17, type: "message", message }],
+    }];
+
+    await runMonitorOnce(controller, {
+      log: vi.fn(),
+      error: runtimeError,
+      exit: vi.fn(),
+    });
+
+    const queue = state.durableQueues.get(state.account.accountId);
+    expect(queue?.listPending).toHaveBeenCalledTimes(3);
+    expect(runtimeError).toHaveBeenCalledWith(
+      expect.stringContaining("synthetic deferred pending-list failure"),
+    );
+    expect(state.core.channel.inbound.buildContext).toHaveBeenCalledTimes(1);
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps retrying a deferred durable message after transient replay metadata failure", async () => {
+    const { createZulipDurableInboundMessageId } = await import("./durable-receive.js");
+    const message = makeChannelMessage(99203);
+    const durableId = createZulipDurableInboundMessageId({
+      accountId: state.account.accountId,
+      messageId: String(message.id),
+    });
+    enableDurableInboundJournal({ completedLookupFailureIds: [durableId] });
+    state.autoAbort = false;
+    state.streamLookups.set("4", new Error("synthetic replay metadata failure"));
+    const controller = new AbortController();
+    state.pollResponses = [{
+      result: "success",
+      events: [{ id: 18, type: "message", message }],
+    }];
+
+    const monitorPromise = runMonitorOnce(controller);
+    await vi.waitFor(() => {
+      const queue = state.durableQueues.get(state.account.accountId);
+      expect(queue?.release).toHaveBeenCalledWith(durableId, {
+        lastError: "Zulip stream metadata unavailable during durable replay",
+      });
+    });
+    state.streamLookups.set("4", { id: 4, name: "debbie", invite_only: false });
+    await vi.waitFor(() => {
+      const queue = state.durableQueues.get(state.account.accountId);
+      expect(queue?.complete).toHaveBeenCalledWith(durableId, {
+        metadata: { queueEventId: 18 },
+        completedAt: expect.any(Number),
+      });
+    });
+    controller.abort();
+    await monitorPromise;
+
+    expect(fetchZulipStreamMock).toHaveBeenCalledTimes(2);
+    expect(state.core.channel.inbound.buildContext).toHaveBeenCalledTimes(1);
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries only journal completion after a deferred reply was delivered", async () => {
+    const { createZulipDurableInboundMessageId } = await import("./durable-receive.js");
+    const message = makePrivateMessage(99206);
+    const durableId = createZulipDurableInboundMessageId({
+      accountId: state.account.accountId,
+      messageId: String(message.id),
+    });
+    enableDurableInboundJournal({
+      completedLookupFailureIds: [durableId],
+      queueCompletionFailures: 1,
+    });
+    state.autoAbort = false;
+    const controller = new AbortController();
+    state.pollResponses = [{
+      result: "success",
+      events: [{ id: 21, type: "message", message }],
+    }];
+
+    const monitorPromise = runMonitorOnce(controller);
+    await vi.waitFor(() => {
+      const queue = state.durableQueues.get(state.account.accountId);
+      expect(queue?.complete).toHaveBeenCalledTimes(2);
+    });
+    controller.abort();
+    await monitorPromise;
+
+    expect(state.core.channel.inbound.buildContext).toHaveBeenCalledTimes(1);
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries only journal completion after a live reply was delivered", async () => {
+    enableDurableInboundJournal({ queueCompletionFailures: 1 });
+    state.autoAbort = false;
+    const controller = new AbortController();
+    state.pollResponses = [{
+      result: "success",
+      events: [{ id: 22, type: "message", message: makePrivateMessage(99207) }],
+    }];
+
+    const monitorPromise = runMonitorOnce(controller);
+    await vi.waitFor(() => {
+      const queue = state.durableQueues.get(state.account.accountId);
+      expect(queue?.complete).toHaveBeenCalledTimes(2);
+    });
+    controller.abort();
+    await monitorPromise;
+
+    expect(state.core.channel.inbound.buildContext).toHaveBeenCalledTimes(1);
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let one retryable deferred message starve a later ready message", async () => {
+    const { createZulipDurableInboundMessageId } = await import("./durable-receive.js");
+    const retryableMessage = makeChannelMessage(99204);
+    const readyMessage = makePrivateMessage(99205);
+    const retryableDurableId = createZulipDurableInboundMessageId({
+      accountId: state.account.accountId,
+      messageId: String(retryableMessage.id),
+    });
+    const readyDurableId = createZulipDurableInboundMessageId({
+      accountId: state.account.accountId,
+      messageId: String(readyMessage.id),
+    });
+    enableDurableInboundJournal({
+      completedLookupFailureIds: [retryableDurableId, readyDurableId],
+    });
+    state.autoAbort = false;
+    state.streamLookups.set("4", new Error("persistent replay metadata failure"));
+    const controller = new AbortController();
+    state.pollResponses = [{
+      result: "success",
+      events: [
+        { id: 19, type: "message", message: retryableMessage },
+        { id: 20, type: "message", message: readyMessage },
+      ],
+    }];
+
+    const monitorPromise = runMonitorOnce(controller);
+    await vi.waitFor(() => {
+      const queue = state.durableQueues.get(state.account.accountId);
+      expect(queue?.release).toHaveBeenCalledWith(retryableDurableId, {
+        lastError: "Zulip stream metadata unavailable during durable replay",
+      });
+      expect(queue?.complete).toHaveBeenCalledWith(readyDurableId, {
+        metadata: { queueEventId: 20 },
+        completedAt: expect.any(Number),
+      });
+    });
+    controller.abort();
+    await monitorPromise;
+
+    expect(
+      state.core.channel.inbound.buildContext.mock.calls.map(([input]) => input.messageId),
+    ).toEqual(["99205"]);
+    expect(state.durableQueues.get(state.account.accountId)?.release).toHaveBeenCalledTimes(1);
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("serializes deferred durable replay and queues one follow-up pass", async () => {
+    enableDurableInboundJournal({ completedLookupFailuresAfterAccept: 2 });
+    state.autoAbort = false;
+    const controller = new AbortController();
+    let releaseFirstReply!: () => void;
+    let markFirstReplyStarted!: () => void;
+    const firstReplyStarted = new Promise<void>((resolve) => {
+      markFirstReplyStarted = resolve;
+    });
+    const firstReplyRelease = new Promise<void>((resolve) => {
+      releaseFirstReply = resolve;
+    });
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher
+      .mockImplementationOnce(async () => {
+        markFirstReplyStarted();
+        await firstReplyRelease;
+        return { counts: { tool: 0, block: 0, final: 1 } };
+      })
+      .mockImplementationOnce(async () => {
+        controller.abort();
+        return { counts: { tool: 0, block: 0, final: 1 } };
+      });
+    state.pollResponses = [{
+      result: "success",
+      events: [
+        { id: 13, type: "message", message: makeChannelMessage(99100) },
+        { id: 14, type: "message", message: makeChannelMessage(99101) },
+      ],
+    }];
+
+    const monitorPromise = runMonitorOnce(controller);
+    await firstReplyStarted;
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+    releaseFirstReply();
+    await monitorPromise;
+
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(2);
+    expect(state.core.channel.inbound.buildContext).toHaveBeenCalledTimes(2);
   });
 
   it("completes fresh durable inbound messages without filling the legacy tombstone store", async () => {
@@ -2638,6 +3038,39 @@ describe("monitorZulipProvider", () => {
 
     await expect(journal.pending()).resolves.toEqual([]);
     expect(getZulipEventsWithRetryMock).toHaveBeenCalledTimes(1);
+    expect(state.core.channel.inbound.buildContext).toHaveBeenCalledTimes(1);
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries only journal completion after a startup replay was delivered", async () => {
+    enableDurableInboundJournal({ queueCompletionFailures: 1 });
+    const {
+      createZulipDurableInboundMessageId,
+      createZulipDurableInboundReceiveJournal,
+      serializeZulipDurableInboundMessage,
+    } = await import("./durable-receive.js");
+    const message = makePrivateMessage(99208);
+    const durableId = createZulipDurableInboundMessageId({
+      accountId: state.account.accountId,
+      messageId: String(message.id),
+    });
+    const journal = createZulipDurableInboundReceiveJournal(state.account.accountId);
+    await journal.accept(durableId, {
+      message: serializeZulipDurableInboundMessage(message),
+      receivedAt: Date.now(),
+    });
+    state.autoAbort = false;
+    state.pollResponses = [{ result: "success", events: [] }];
+    const controller = new AbortController();
+
+    const monitorPromise = runMonitorOnce(controller);
+    await vi.waitFor(() => {
+      const queue = state.durableQueues.get(state.account.accountId);
+      expect(queue?.complete).toHaveBeenCalledTimes(2);
+    });
+    controller.abort();
+    await monitorPromise;
+
     expect(state.core.channel.inbound.buildContext).toHaveBeenCalledTimes(1);
     expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
   });

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -1606,7 +1606,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       acceptInbound?: () => Promise<boolean>;
       durableAccepted?: () => boolean;
     } = {},
-  ): Promise<void> => {
+  ): Promise<"settled" | "pending-delivery" | "pending-completion"> => {
     try {
       const outcome = await handleMessage(message, {
         skipRecentDedupe: options.replay,
@@ -1623,7 +1623,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
             lastError: "Zulip monitor stopped before delivery",
           });
         }
-        return;
+        return "pending-delivery";
       }
       if (outcome === RETRYABLE_INBOUND_MESSAGE) {
         if (durableInboundJournal && durableId && manageDurableRecord) {
@@ -1631,7 +1631,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
             lastError: "Zulip reply delivery failed before any visible response",
           });
         }
-        return;
+        return "pending-delivery";
       }
       if (outcome === RETRYABLE_STREAM_POLICY) {
         if (durableInboundJournal && durableId && manageDurableRecord) {
@@ -1639,11 +1639,17 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
             lastError: "Zulip stream metadata unavailable during durable replay",
           });
         }
-        return;
+        return "pending-delivery";
       }
       if (manageDurableRecord) {
-        await completeDurableInboundMessage(durableId, metadata);
+        try {
+          await completeDurableInboundMessage(durableId, metadata);
+        } catch (err) {
+          runtime.error?.(`zulip: durable inbound completion failed: ${String(err)}`);
+          return "pending-completion";
+        }
       }
+      return "settled";
     } catch (err) {
       if (
         durableInboundJournal &&
@@ -1663,7 +1669,139 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         });
       }
       runtime.error?.(`zulip message handler failed: ${String(err)}`);
+      return "pending-delivery";
     }
+  };
+
+  const deferredDurableReplayIds = new Set<string>();
+  const deferredDurableCompletionIds = new Set<string>();
+  const deferredDurableRetryState = new Map<
+    string,
+    { delayMs: number; nextAttemptAt: number }
+  >();
+  let deferredDurableReplayTask: Promise<void> | undefined;
+  let wakeDeferredDurableReplay: (() => void) | undefined;
+  const waitForDeferredDurableReplay = (ms: number): Promise<void> => {
+    if (opts.abortSignal?.aborted || ms <= 0) {
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      let settled = false;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const finish = () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        if (timer) {
+          clearTimeout(timer);
+        }
+        opts.abortSignal?.removeEventListener("abort", finish);
+        if (wakeDeferredDurableReplay === finish) {
+          wakeDeferredDurableReplay = undefined;
+        }
+        resolve();
+      };
+      wakeDeferredDurableReplay = finish;
+      opts.abortSignal?.addEventListener("abort", finish, { once: true });
+      timer = setTimeout(finish, ms);
+      timer.unref?.();
+    });
+  };
+  const deferDurableReplayRetry = (durableId: string) => {
+    const current = deferredDurableRetryState.get(durableId) ?? {
+      delayMs: 250,
+      nextAttemptAt: 0,
+    };
+    deferredDurableRetryState.set(durableId, {
+      delayMs: Math.min(30000, current.delayMs * 2),
+      nextAttemptAt: Date.now() + current.delayMs,
+    });
+    deferredDurableReplayIds.delete(durableId);
+    deferredDurableReplayIds.add(durableId);
+  };
+  const startDeferredDurableReplay = () => {
+    if (
+      deferredDurableReplayTask ||
+      !durableInboundJournal ||
+      opts.abortSignal?.aborted ||
+      deferredDurableReplayIds.size === 0
+    ) {
+      return;
+    }
+    const replayTask = (async () => {
+      while (!opts.abortSignal?.aborted && deferredDurableReplayIds.size > 0) {
+        const now = Date.now();
+        let durableId: string | undefined;
+        let waitMs = Number.POSITIVE_INFINITY;
+        for (const candidateId of deferredDurableReplayIds) {
+          const nextAttemptAt =
+            deferredDurableRetryState.get(candidateId)?.nextAttemptAt ?? 0;
+          if (nextAttemptAt <= now) {
+            durableId = candidateId;
+            break;
+          }
+          waitMs = Math.min(waitMs, nextAttemptAt - now);
+        }
+        if (!durableId) {
+          await waitForDeferredDurableReplay(waitMs);
+          continue;
+        }
+        try {
+          const pending = await durableInboundJournal.pending();
+          const record = pending.find((entry) => entry.id === durableId);
+          if (record) {
+            let disposition: "settled" | "pending-delivery" | "pending-completion";
+            if (deferredDurableCompletionIds.has(durableId)) {
+              await completeDurableInboundMessage(record.id, record.metadata);
+              disposition = "settled";
+            } else {
+              const payload = record.payload as ZulipDurableInboundPayload;
+              disposition = await deliverDurableInboundMessage(
+                record.id,
+                deserializeZulipDurableInboundMessage<ZulipMessage>(payload.message),
+                record.metadata,
+                { replay: true },
+              );
+            }
+            if (disposition !== "settled") {
+              if (disposition === "pending-completion") {
+                deferredDurableCompletionIds.add(durableId);
+              }
+              deferDurableReplayRetry(durableId);
+              continue;
+            }
+          }
+          deferredDurableReplayIds.delete(durableId);
+          deferredDurableCompletionIds.delete(durableId);
+          deferredDurableRetryState.delete(durableId);
+        } catch (err) {
+          runtime.error?.(`zulip: deferred durable replay failed: ${String(err)}`);
+          deferDurableReplayRetry(durableId);
+        }
+      }
+    })();
+    deferredDurableReplayTask = replayTask;
+    activeMessageTasks.add(replayTask);
+    void replayTask.finally(() => {
+      activeMessageTasks.delete(replayTask);
+      if (deferredDurableReplayTask === replayTask) {
+        deferredDurableReplayTask = undefined;
+      }
+      startDeferredDurableReplay();
+    });
+  };
+  const schedulePendingDurableReplay = (durableId: string) => {
+    deferredDurableReplayIds.add(durableId);
+    if (!deferredDurableRetryState.has(durableId)) {
+      deferredDurableRetryState.set(durableId, { delayMs: 250, nextAttemptAt: 0 });
+    }
+    wakeDeferredDurableReplay?.();
+    startDeferredDurableReplay();
+  };
+  const schedulePendingDurableCompletion = (durableId: string) => {
+    deferredDurableCompletionIds.add(durableId);
+    schedulePendingDurableReplay(durableId);
   };
 
   const processMessage = async (
@@ -1698,6 +1836,13 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
             },
           );
           durableAccepted = accepted.kind === "accepted";
+          if (
+            accepted.kind === "pending" &&
+            "retryInProcess" in accepted &&
+            accepted.retryInProcess === true
+          ) {
+            schedulePendingDurableReplay(acceptedDurableId);
+          }
           return durableAccepted;
         } catch (err) {
           runtime.log?.(`zulip: failed persisting durable inbound; delivering live: ${String(err)}`);
@@ -1735,11 +1880,14 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       return;
     }
 
-    await deliverDurableInboundMessage(durableId, message, metadata, {
+    const disposition = await deliverDurableInboundMessage(durableId, message, metadata, {
       streamDecision,
       acceptInbound,
       durableAccepted: () => durableAccepted,
     });
+    if (disposition === "pending-completion" && durableId) {
+      schedulePendingDurableCompletion(durableId);
+    }
   };
 
   const handleMonitorAbort = () => {
@@ -1757,12 +1905,15 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         break;
       }
       const payload = record.payload as ZulipDurableInboundPayload;
-      await deliverDurableInboundMessage(
+      const disposition = await deliverDurableInboundMessage(
         record.id,
         deserializeZulipDurableInboundMessage<ZulipMessage>(payload.message),
         record.metadata,
         { replay: true },
       );
+      if (disposition === "pending-completion") {
+        schedulePendingDurableCompletion(record.id);
+      }
     }
   };
 


### PR DESCRIPTION
Closes #71

## Summary

- defer live delivery when the legacy completion lookup fails after queue acceptance
- make legacy completion reconciliation durable by extending the tombstone to the queue pending lifetime
- delete stale queue-pending records when completion reconciliation fails
- retry only the affected durable message in process, with bounded exponential backoff
- serialize and coalesce deferred replay without replaying unrelated in-flight messages
- add regression coverage for every late review finding from #72 and #73

## Verification

- OpenClaw 2026.7.1-2: TypeScript build, 288 Vitest tests, 59 offline smoke tests
- OpenClaw 2026.8.1: TypeScript build, 288 Vitest tests, 59 offline smoke tests
- live Gateway unchanged on 2026.7.1-2

## Context

This is the corrective follow-up to #72. Hosted Codex surfaced two valid inline findings only after its summary switched to completed and the merge command had already started. Issue #71 was reopened immediately and remains open until this PR is reviewed and merged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes message delivery timing and journal reconciliation on failure paths; incorrect deferral could delay or duplicate replies, but scope is limited to durable inbound edge cases with extensive test coverage.
> 
> **Overview**
> Hardens **Zulip durable inbound** handling when legacy tombstones and the queue journal disagree or storage calls fail transiently.
> 
> In **`durable-receive.ts`**, failed queue `complete` during legacy reconciliation now **extends the completed tombstone** to pending TTL and **drops stale queue-pending** rows when extension succeeds; if both complete and extension fail, the queue entry is left intact. **`accept`** treats a **failed post-accept legacy completed lookup** as still-pending with **`retryInProcess`** instead of delivering live, and wraps reconciliation lookups in swallowing try/catch so duplicates stay safe.
> 
> In **`monitor.ts`**, delivery returns **`settled` / `pending-delivery` / `pending-completion`**. A new **deferred replay loop** (bounded exponential backoff, serialized task, wake on schedule) retries only affected IDs: full replay after lookup deferrals, **completion-only** after the user-visible reply succeeded, without blocking other in-flight messages. **`retryInProcess`** from `accept` schedules that path without restart.
> 
> **`monitor.test.ts`** adds synthetic failure hooks and regression tests for tombstone extension, lookup deferral, pending-list errors, completion-only retries, starvation avoidance, and serialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7d63ead79b4e5075cef9de7135054ee28691221. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->