### PR TITLE
fix(session): isolate Zulip direct messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 - **Per-stream inbound policy**: Add deterministic name/ID `streamOverrides` for inbound activation, mention requirements, and allowed/excluded topics while preserving legacy `streams`, `topics`, and `streamTopics` behavior.
 - **Early inbound filtering**: Resolve stream policy before durable acceptance, attachment downloads, reactions, typing, routing, or agent dispatch. Outbound access remains independent.
+- **DM session isolation**: Force realm/account/sender-scoped direct-message sessions independently of global `session.dmScope`, and document deterministic migration plus host-owned idle rotation.
 
 ### Compatibility
 - **OpenClaw 2026.8.1 compatibility**: Use the shared ingress queue and typed media-runtime SDK surfaces while retaining OpenClaw 2026.7.1-2 as the minimum supported host, draining legacy durable records, and keeping command access-group checks enabled.

--- a/README.md
+++ b/README.md
@@ -289,6 +289,38 @@ Topic-scoped conversations now resolve through the SDK session-conversation hook
 
 Basic approval authorization is now wired through `approvalCapability`, using normalized Zulip identities from `allowFrom` as the first pass.
 
+### Direct-message isolation and rotation
+
+Zulip DMs always use an isolated OpenClaw session keyed by agent, channel,
+normalized account id, Zulip realm, bot identity, and sender identity. This
+remains enforced when the global `session.dmScope` is `main`; explicit identity
+links do not merge Zulip DM sessions. Stream and topic sessions retain their
+existing keys.
+
+The isolated key format replaces older Zulip DM keys. After upgrading, each DM
+starts a fresh session on its first message. Existing transcripts remain on disk
+under their old keys but are not imported, because importing a previously shared
+session could copy another sender's context into the isolated session.
+
+Idle rotation is owned by OpenClaw. Configure its supported direct-session policy:
+
+```json
+{
+  "session": {
+    "resetByType": {
+      "direct": { "mode": "idle", "idleMinutes": 1440 }
+    }
+  }
+}
+```
+
+The host uses the last real interaction and considers the exact expiry timestamp
+fresh; the session rotates on the next millisecond. Restarts preserve that
+timestamp. OpenClaw 2026.7.1-2 through 2026.8.1 does not publish a turn-count
+session-rotation API. The plugin therefore does not create parallel session state
+or approximate turn rotation. Turn-count rotation remains blocked on a public
+host policy/API.
+
 ## Why concurrent processing?
 
 Most channel plugin implementations process incoming messages one at a time — each message waits for the previous one to finish before starting. Under load (e.g. a burst of messages after reconnect) this creates noticeable latency for later messages.

--- a/src/channel.test.ts
+++ b/src/channel.test.ts
@@ -2,7 +2,10 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
 import { createReplyPrefixOptions } from "openclaw/plugin-sdk/channel-outbound";
 import { describe, expect, it } from "vitest";
 import { zulipPlugin } from "./channel.js";
-import { resolveZulipSessionConversation } from "./session-conversation.js";
+import {
+  buildZulipDirectSessionKey,
+  resolveZulipSessionConversation,
+} from "./session-conversation.js";
 import { zulipMessageActions } from "./actions.js";
 import { zulipOnboardingAdapter } from "./onboarding.js";
 import { resolveZulipAccount } from "./zulip/accounts.js";
@@ -66,16 +69,64 @@ describe("zulipPlugin", () => {
 
       expect(
         resolveRoute({
-          cfg: {} as OpenClawConfig,
+          cfg: {
+            channels: {
+              zulip: {
+                url: "https://realm-a.example.test",
+                email: "bot@realm-a.example.test",
+              },
+            },
+            session: { dmScope: "main" },
+          } as OpenClawConfig,
           agentId: "main",
           target: "@ian@example.com",
         }),
       ).toMatchObject({
-        peer: { kind: "direct", id: "ian@example.com" },
+        sessionKey: buildZulipDirectSessionKey({
+          agentId: "main",
+          accountId: "default",
+          baseUrl: "https://realm-a.example.test",
+          botIdentity: "bot@realm-a.example.test",
+          senderIdentity: "ian@example.com",
+        }),
+        peer: { kind: "direct", id: expect.stringMatching(/^account-[0-9a-f]{64}:ian@example\.com$/) },
         chatType: "direct",
         from: "zulip:ian@example.com",
         to: "user:ian@example.com",
       });
+    });
+
+    it("isolates direct sessions across users, accounts, and realms despite collisions", () => {
+      const base = {
+        agentId: "main",
+        accountId: "default",
+        baseUrl: "https://realm-a.example.test",
+        botIdentity: "bot@realm-a.example.test",
+        senderIdentity: "same@example.com",
+      };
+      const sessionKey = buildZulipDirectSessionKey(base);
+
+      expect(buildZulipDirectSessionKey(base)).toBe(sessionKey);
+      expect(buildZulipDirectSessionKey({ ...base, senderIdentity: "other@example.com" }))
+        .not.toBe(sessionKey);
+      expect(buildZulipDirectSessionKey({ ...base, accountId: "secondary" }))
+        .not.toBe(sessionKey);
+      expect(buildZulipDirectSessionKey({ ...base, baseUrl: "https://realm-b.example.test" }))
+        .not.toBe(sessionKey);
+      expect(buildZulipDirectSessionKey({ ...base, botIdentity: "other-bot@example.test" }))
+        .not.toBe(sessionKey);
+    });
+
+    it("keeps direct sessions separate from stream and topic sessions", () => {
+      const direct = buildZulipDirectSessionKey({
+        agentId: "main",
+        accountId: "default",
+        baseUrl: "https://realm-a.example.test",
+        botIdentity: "bot@realm-a.example.test",
+        senderIdentity: "4",
+      });
+      expect(direct).not.toBe("agent:main:zulip:channel:4");
+      expect(direct).not.toBe("agent:main:zulip:channel:4:thread:4");
     });
 
     it("resolves outbound stream topic routes using canonical conversation ids", () => {

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -49,6 +49,7 @@ export {
   DEFAULT_ACCOUNT_ID,
   normalizeAccountId,
   applyAccountNameToChannelSection,
+  buildAgentSessionKey,
   buildChannelOutboundSessionRoute,
   deleteAccountFromConfigSection,
   formatPairingApproveHint,

--- a/src/session-conversation.ts
+++ b/src/session-conversation.ts
@@ -1,8 +1,64 @@
+import { createHash } from "node:crypto";
 import { sanitizeThreadId } from "./zulip/monitor-helpers.js";
-import { buildChannelOutboundSessionRoute, type OpenClawConfig } from "./sdk.js";
+import {
+  buildAgentSessionKey,
+  buildChannelOutboundSessionRoute,
+  type OpenClawConfig,
+} from "./sdk.js";
+import { resolveZulipAccount } from "./zulip/accounts.js";
+import { normalizeZulipBaseUrl } from "./zulip/client.js";
 import { parseZulipTarget, type ZulipTarget } from "./zulip/send.js";
 
 const TOPIC_MARKER = ":topic:";
+
+function canonicalizeZulipRealm(baseUrl: string): string {
+  const normalized = normalizeZulipBaseUrl(baseUrl);
+  if (!normalized) {
+    throw new Error("Zulip base URL is required for isolated DM session routing");
+  }
+  const url = new URL(normalized);
+  url.hash = "";
+  url.search = "";
+  return url.toString().replace(/\/+$/, "");
+}
+
+export function buildZulipDirectPeerId(params: {
+  baseUrl: string;
+  botIdentity: string;
+  senderIdentity: string;
+}): string {
+  const botIdentity = params.botIdentity.trim().toLowerCase();
+  const senderIdentity = params.senderIdentity.trim().toLowerCase();
+  if (!botIdentity) {
+    throw new Error("Zulip bot identity is required for isolated DM session routing");
+  }
+  if (!senderIdentity) {
+    throw new Error("Zulip sender identity is required for isolated DM session routing");
+  }
+  const accountScopeHash = createHash("sha256")
+    .update(`${canonicalizeZulipRealm(params.baseUrl)}\n${botIdentity}`)
+    .digest("hex");
+  return `account-${accountScopeHash}:${senderIdentity}`;
+}
+
+export function buildZulipDirectSessionKey(params: {
+  agentId: string;
+  accountId?: string | null;
+  baseUrl: string;
+  botIdentity: string;
+  senderIdentity: string;
+}): string {
+  return buildAgentSessionKey({
+    agentId: params.agentId,
+    channel: "zulip",
+    accountId: params.accountId,
+    peer: {
+      kind: "direct",
+      id: buildZulipDirectPeerId(params),
+    },
+    dmScope: "per-account-channel-peer",
+  });
+}
 
 export function buildZulipStreamConversation(params: {
   streamId: string;
@@ -97,16 +153,40 @@ export function resolveZulipOutboundSessionRoute(
   }
 
   if (target.kind === "user") {
-    return buildChannelOutboundSessionRoute({
+    const account = resolveZulipAccount({ cfg: params.cfg, accountId: params.accountId });
+    if (!account.baseUrl || !account.email) {
+      return null;
+    }
+    const peer = {
+      kind: "direct" as const,
+      id: buildZulipDirectPeerId({
+        baseUrl: account.baseUrl,
+        botIdentity: account.email,
+        senderIdentity: target.email,
+      }),
+    };
+    const route = buildChannelOutboundSessionRoute({
       cfg: params.cfg,
       agentId: params.agentId,
       channel: "zulip",
       accountId: params.accountId,
-      peer: { kind: "direct", id: target.email },
+      peer,
       chatType: "direct",
       from: `zulip:${target.email}`,
       to: `user:${target.email}`,
     });
+    const sessionKey = buildZulipDirectSessionKey({
+      agentId: params.agentId,
+      accountId: params.accountId,
+      baseUrl: account.baseUrl,
+      botIdentity: account.email,
+      senderIdentity: target.email,
+    });
+    return {
+      ...route,
+      sessionKey,
+      baseSessionKey: sessionKey,
+    };
   }
 
   const topic = resolveOutboundZulipTopic({

--- a/src/session-rotation.test.ts
+++ b/src/session-rotation.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluateSessionFreshness,
+  resolveSessionResetPolicy,
+} from "openclaw/plugin-sdk/session-store-runtime";
+
+describe("supported host session rotation", () => {
+  it("rotates a direct session at the exact configured idle boundary", () => {
+    const policy = resolveSessionResetPolicy({
+      sessionCfg: {
+        resetByType: {
+          direct: { mode: "idle", idleMinutes: 30 },
+        },
+      },
+      resetType: "direct",
+    });
+    const lastInteractionAt = 1_000_000;
+    const idleBoundary = lastInteractionAt + 30 * 60_000;
+
+    expect(evaluateSessionFreshness({
+      updatedAt: lastInteractionAt,
+      lastInteractionAt,
+      now: idleBoundary - 1,
+      policy,
+    })).toMatchObject({ fresh: true, idleExpiresAt: idleBoundary });
+    expect(evaluateSessionFreshness({
+      updatedAt: lastInteractionAt,
+      lastInteractionAt,
+      now: idleBoundary,
+      policy,
+    })).toMatchObject({ fresh: true, idleExpiresAt: idleBoundary });
+    expect(evaluateSessionFreshness({
+      updatedAt: lastInteractionAt,
+      lastInteractionAt,
+      now: idleBoundary + 1,
+      policy,
+    })).toMatchObject({ fresh: false, staleReason: "idle", idleExpiresAt: idleBoundary });
+  });
+
+  it("does not apply direct-message rotation to group or topic sessions", () => {
+    const sessionCfg = {
+      resetByType: {
+        direct: { mode: "idle" as const, idleMinutes: 30 },
+      },
+    };
+    expect(resolveSessionResetPolicy({ sessionCfg, resetType: "direct" }))
+      .toMatchObject({ mode: "idle", idleMinutes: 30, configured: true });
+    expect(resolveSessionResetPolicy({ sessionCfg, resetType: "group" }))
+      .not.toMatchObject({ mode: "idle", idleMinutes: 30 });
+    expect(resolveSessionResetPolicy({ sessionCfg, resetType: "thread" }))
+      .not.toMatchObject({ mode: "idle", idleMinutes: 30 });
+  });
+});

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -323,7 +323,8 @@ const typingCallbacksMock = vi.fn(() => ({
   onIdle: vi.fn(),
 }));
 
-vi.mock("../sdk.js", () => ({
+vi.mock("../sdk.js", async (importOriginal) => ({
+  ...await importOriginal<typeof import("../sdk.js")>(),
   createChannelPairingController: vi.fn(() => ({
     upsertPairingRequest: state.upsertPairingRequest,
     readStoreForDmPolicy: vi.fn(async () => state.pairingAllowFrom),
@@ -389,13 +390,19 @@ function makePrivateMessage(id: number, senderEmail = "user8@zlp.pubnerd.app") {
 async function runMonitorOnce(
   controller = new AbortController(),
   runtime?: RuntimeEnv,
-  options: { statusSink?: (patch: Record<string, unknown>) => void } = {},
+  options: {
+    statusSink?: (patch: Record<string, unknown>) => void;
+    email?: string;
+    baseUrl?: string;
+  } = {},
 ) {
   const { monitorZulipProvider } = await import("./monitor.js");
   state.abortController = controller;
   await monitorZulipProvider({
     config: state.core.config,
     runtime,
+    email: options.email,
+    baseUrl: options.baseUrl,
     abortSignal: state.abortController.signal,
     statusSink: options.statusSink,
   });
@@ -1633,7 +1640,9 @@ describe("monitorZulipProvider", () => {
     );
     expect(state.core.channel.session.updateLastRoute).toHaveBeenCalledWith({
       storePath: "/tmp/openclaw-session-store.json",
-      sessionKey: "agent:debbie:zulip:channel:4",
+      sessionKey: expect.stringMatching(
+        /^agent:debbie:zulip:default:direct:account-[0-9a-f]{64}:user8@zlp\.pubnerd\.app$/,
+      ),
       deliveryContext: {
         channel: "zulip",
         to: "user:user8@zlp.pubnerd.app",
@@ -1669,10 +1678,43 @@ describe("monitorZulipProvider", () => {
     );
     expect(state.core.channel.session.updateLastRoute).toHaveBeenCalledWith({
       storePath: "/tmp/openclaw-session-store.json",
-      sessionKey: "agent:debbie:zulip:channel:4",
+      sessionKey: expect.stringMatching(
+        /^agent:debbie:zulip:default:direct:account-[0-9a-f]{64}:123$/,
+      ),
       deliveryContext: {
         channel: "zulip",
         to: "user:123",
+        accountId: "default",
+      },
+    });
+  });
+
+  it("uses effective connection overrides to isolate private-message sessions", async () => {
+    const { buildZulipDirectSessionKey } = await import("../session-conversation.js");
+    state.pollResponses = [
+      {
+        result: "success",
+        events: [{ id: 1, type: "message", message: makePrivateMessage(1102) }],
+      },
+    ];
+
+    await runMonitorOnce(new AbortController(), undefined, {
+      baseUrl: "https://override-realm.example.test",
+      email: "override-bot@example.test",
+    });
+
+    expect(state.core.channel.session.updateLastRoute).toHaveBeenCalledWith({
+      storePath: "/tmp/openclaw-session-store.json",
+      sessionKey: buildZulipDirectSessionKey({
+        agentId: "debbie",
+        accountId: "default",
+        baseUrl: "https://override-realm.example.test",
+        botIdentity: "override-bot@example.test",
+        senderIdentity: "user8@zlp.pubnerd.app",
+      }),
+      deliveryContext: {
+        channel: "zulip",
+        to: "user:user8@zlp.pubnerd.app",
         accountId: "default",
       },
     });

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -51,7 +51,10 @@ import {
   type ZulipDurableInboundMetadata,
   type ZulipDurableInboundPayload,
 } from "./durable-receive.js";
-import { buildZulipStreamConversation } from "../session-conversation.js";
+import {
+  buildZulipDirectSessionKey,
+  buildZulipStreamConversation,
+} from "../session-conversation.js";
 import { sendMessageZulip } from "./send.js";
 import { downloadZulipUpload, extractZulipUploadUrls, sanitizeUploadFilename } from "./uploads.js";
 import {
@@ -937,7 +940,15 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
           }).sessionKey
         : undefined;
 
-    const sessionKey = route.sessionKey ?? `zulip:${account.accountId}:${channelId}`;
+    const sessionKey = isDM
+      ? buildZulipDirectSessionKey({
+          agentId: route.agentId,
+          accountId: route.accountId,
+          baseUrl,
+          botIdentity: email,
+          senderIdentity: dmTargetIdentity,
+        })
+      : route.sessionKey ?? `zulip:${account.accountId}:${channelId}`;
 
     const timestamp = message.timestamp ? message.timestamp * 1000 : undefined;
     const textWithId = `${bodyText}\n[zulip message id: ${messageId}]`;


### PR DESCRIPTION
Closes #28.

## What changed

- force Zulip DMs onto deterministic sessions scoped by agent, normalized account, realm, bot identity, and sender identity even when global `session.dmScope` is `main`
- use the same isolated key for inbound context, last-route persistence, and outbound route recovery without allowing identity links to merge Zulip DMs
- leave stream/topic session identity unchanged
- document the safe migration: old possibly shared DM sessions remain on disk but are not imported
- document and test OpenClaw's supported direct-session idle rotation, including its exact expiry boundary
- document turn-count rotation as blocked on a public host policy/API instead of creating plugin-owned session state

## Security coverage

- different users, account aliases, realms, and bot identities cannot share a key
- identical sender identities on different accounts or realms remain isolated
- connection overrides use the effective realm and bot identity
- DM keys remain separate from stream/topic keys and stable across restarts
- direct idle rotation does not affect group or topic sessions

## Verification

- OpenClaw 2026.7.1-2: build, 293 unit tests, 59 offline smoke tests
- OpenClaw 2026.8.1: build, 293 unit tests, 59 offline smoke tests
- focused isolation/rotation suite: 119 tests
- `git diff --check`
- local Codex security review clean after fixing its effective-connection-identity finding

No Gateway upgrade or deployment is included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes session key semantics for all Zulip DMs (privacy-critical); mis-keying could leak or merge conversation context, though the design explicitly scopes by realm, bot, account, and sender.
> 
> **Overview**
> **Zulip DMs now always get per-sender isolated OpenClaw sessions**, even when global `session.dmScope` is `main`. Identity links no longer merge DM history across users.
> 
> New helpers in `session-conversation.ts` build deterministic peer ids (realm + bot identity hashed with sender) and session keys via `buildAgentSessionKey` with `dmScope: "per-account-channel-peer"`. **Inbound** (`monitor.ts`) and **outbound** (`resolveZulipOutboundSessionRoute`) both use the same key for context, last-route storage, and route recovery. Stream/topic session keys are unchanged.
> 
> **Upgrade behavior:** the key format changes, so each DM starts fresh on first message after upgrade; old transcripts stay on disk under legacy keys and are **not** imported (avoids leaking another sender’s context).
> 
> README and CHANGELOG document migration, host-owned idle rotation via `session.resetByType.direct`, and that turn-count rotation is deferred until OpenClaw exposes a public API. Tests cover cross-user/account/realm isolation, connection overrides, outbound routing, and SDK idle-boundary rotation for direct sessions only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c51528b19be9cd8b643e5be69539f9763825dee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->