### PR TITLE
test(smoke): exercise trusted durable receive

### DIFF
--- a/.github/workflows/zulip-live-smoke.yml
+++ b/.github/workflows/zulip-live-smoke.yml
@@ -64,6 +64,8 @@ jobs:
         run: |
           pnpm install --frozen-lockfile --config.minimumReleaseAge=1440
           pnpm run build
+      - name: Stage candidate through the bundled-plugin trust path
+        run: node scripts/live-smoke/stage-bundled-plugin.mjs
       - name: Prepare isolated OpenClaw state
         env:
           OPENCLAW_SMOKE_CONFIG_JSON: ${{ secrets.OPENCLAW_SMOKE_CONFIG_JSON }}
@@ -106,9 +108,22 @@ jobs:
           selectSmokeModel(config, targetId);
           writeFileSync(process.env.OPENCLAW_CONFIG_PATH, JSON.stringify(config), { mode: 0o600 });
           NODE
-          pnpm exec openclaw plugins install -l "$GITHUB_WORKSPACE"
           pnpm exec openclaw config set agents.defaults.workspace "$GITHUB_WORKSPACE/scripts/live-smoke/agent-workspace"
           pnpm exec openclaw config validate
+          plugin_list="$(mktemp "$RUNNER_TEMP/zulip-plugin-list.XXXXXX.json")"
+          trap 'rm -f "$plugin_list"' EXIT
+          pnpm exec openclaw plugins list --json > "$plugin_list"
+          node --input-type=module - "$plugin_list" <<'NODE'
+          import { readFileSync } from "node:fs";
+          const report = JSON.parse(readFileSync(process.argv[2], "utf8"));
+          const plugin = report.plugins?.find((entry) => entry.id === "zulip");
+          if (!plugin || plugin.origin !== "bundled" || plugin.status !== "loaded") {
+            throw new Error("Protected smoke requires the loaded Zulip candidate to have bundled origin");
+          }
+          if (plugin.version !== process.env.SMOKE_PLUGIN_VERSION) {
+            throw new Error("Loaded Zulip version does not match the staged candidate");
+          }
+          NODE
       - name: Run bounded live scenarios
         env:
           ZULIP_URL: ${{ secrets.ZULIP_URL }}
@@ -123,6 +138,7 @@ jobs:
           OPENCLAW_STATE_DIR: ${{ runner.temp }}/openclaw-smoke/state
           SMOKE_GATEWAY_PORT: '18789'
           ZULIP_SUBAGENT_DIAGNOSTICS: '1'
+          ZULIP_SMOKE_ENABLE_DURABLE: '1'
         run: node scripts/live-smoke/run.mjs
       - name: Record release evidence
         if: always()
@@ -134,5 +150,7 @@ jobs:
             echo ""
             echo "- Result: ${{ job.status }}"
             echo "- Tested commit: \`$TESTED_SHA\`"
+            echo "- Plugin version: \`$SMOKE_PLUGIN_VERSION\`"
+            echo "- OpenClaw version: \`$SMOKE_OPENCLAW_VERSION\`"
             echo "- Run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Features
+- **Trusted durable live smoke**: Stage protected exact-SHA candidates through OpenClaw's bundled-plugin trust path and require interruption/replay/completion/deduplication evidence with exact host and plugin versions.
 - **Per-stream inbound policy**: Add deterministic name/ID `streamOverrides` for inbound activation, mention requirements, and allowed/excluded topics while preserving legacy `streams`, `topics`, and `streamTopics` behavior.
 - **Early inbound filtering**: Resolve stream policy before durable acceptance, attachment downloads, reactions, typing, routing, or agent dispatch. Outbound access remains independent.
 - **DM session isolation**: Force realm/account/sender-scoped direct-message sessions independently of global `session.dmScope`, and document deterministic migration plus host-owned idle rotation.

--- a/README.md
+++ b/README.md
@@ -374,6 +374,12 @@ same-repository candidate branch so live-only fixes can be tested repeatedly
 before one final pull request is opened. Dedicated-realm credentials remain
 unavailable until approval through the protected `zulip-live-smoke` GitHub Environment. See
 [the release checklist](docs/RELEASE_CHECKLIST.md) for setup and evidence rules.
+The workflow stages the already-authorized, exact-SHA candidate inside the
+locked OpenClaw package's bundled extension directory. It verifies that the
+host reports Zulip as a loaded bundled plugin before credentials are used, then
+runs durable receive interruption, replay, completion, and deduplication with
+plugin keyed state enabled. This staging exists only in the ephemeral runner;
+release installation remains the separately published plugin package.
 
 The scheduled **OpenClaw compatibility (advisory)** workflow is intentionally separate from release gating. Once a week it chooses the first eligible release from OpenClaw's `latest` and `extended-stable` npm channels that has been published for at least 24 hours, then installs and tests it in a temporary copy of the plugin. That temporary install and the packed-artifact smoke test enforce pnpm's 24-hour release-age rule and may update only disposable lockfiles; they never change or commit this repository's lockfile. A failure identifies compatibility work to investigate; it does not replace the locked CI evidence required for a release.
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -34,7 +34,10 @@ Only the repository owner can dispatch a branch candidate, the candidate must
 be reachable from the named same-repository branch, and environment approval is
 still required before credentials are released.
 
-The isolated configuration must enable the checked-out local Zulip plugin, use
+The workflow must stage the exact checked-out candidate through
+`scripts/live-smoke/stage-bundled-plugin.mjs` and verify that OpenClaw reports
+the Zulip plugin with `origin: bundled` and `status: loaded`; it must not install
+the checkout as a local linked plugin. The isolated configuration must use
 the dedicated bot account, allow DMs from the smoke actor, monitor the smoke
 stream with an open group policy, and disable stream mention gating with
 `chatmode: "onmessage"` and `requireMention: false` at the root and for every
@@ -52,3 +55,7 @@ transcript and reads the edited Zulip message before and after its required
 four-second visibility window. Durable replay uses a random generation value
 written only after the old gateway process group is fully down; the replacement
 must read and return that value, so a queued pre-restart reply cannot pass.
+The protected workflow enables the durable scenario unconditionally. Its
+summary records the exact candidate SHA, plugin version, OpenClaw version, and
+run URL; the console report must show
+`PASS durable-receive-completion-deduplication` rather than `SKIP`.

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -1160,7 +1160,7 @@ async function main() {
     });
     else skipScenario(
       "durable-receive-completion-deduplication",
-      "skipped because protected checkout smoke installs the candidate as a local, non-trusted plugin; durable plugin keyed state requires a bundled or trusted official install",
+      "skipped because durable smoke is disabled; durable plugin keyed state requires a bundled or trusted official install",
     );
   } catch (error) {
     runError = error;

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -9,6 +9,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { assertFinalPrivateTypingStop, assertMessageRemainsExact, authenticatedUserId, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, drainEventQueueUntilQuiet, eventOccursBefore, EventQueue, extractExactUploadUrl, Gateway, hasFinalPrivateTypingStop, hasProvableMinimumMessageDelay, inspectChildTranscripts, inspectLifecycleTurnEvidence, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactPollMessage, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, isUsageCountedTranscriptName, lifecycleEvidenceCounts, lifecycleSummary, normalizeScenarioError, parseZulipSubagentDiagnostic, probeRunnerLocalGatewayHealth, redactError, resolveUploadUrl, signalProcessTree, subagentCompletedBeforeReply, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
 import { selectSmokeModel } from "./prepare-config.mjs";
+import { stageBundledPlugin } from "./stage-bundled-plugin.mjs";
 
 const ACTOR_USER_ID = "42";
 const BOT_USER_ID = "91";
@@ -1148,6 +1149,14 @@ test("workflow is manual, protected, pinned, and bounded", async () => {
   assert.match(workflow, /permissions:\n\s+contents: read/);
   assert.match(workflow, /timeout-minutes: 35/);
   assert.doesNotMatch(workflow, /timeout-minutes: 35\n\s+env:/);
+  assert.match(workflow, /Stage candidate through the bundled-plugin trust path/);
+  assert.match(workflow, /node scripts\/live-smoke\/stage-bundled-plugin\.mjs/);
+  assert.doesNotMatch(workflow, /plugins install -l/);
+  assert.match(workflow, /plugin\.origin !== "bundled"/);
+  assert.match(workflow, /plugin\.status !== "loaded"/);
+  assert.match(workflow, /ZULIP_SMOKE_ENABLE_DURABLE: '1'/);
+  assert.match(workflow, /SMOKE_OPENCLAW_VERSION/);
+  assert.match(workflow, /SMOKE_PLUGIN_VERSION/);
   const prepareStep = workflow.slice(
     workflow.indexOf("- name: Prepare isolated OpenClaw state"),
     workflow.indexOf("- name: Run bounded live scenarios"),
@@ -1176,4 +1185,63 @@ test("workflow is manual, protected, pinned, and bounded", async () => {
   assert.match(agentProtocol, /\.smoke-gateway-generation/);
   assert.match(agentProtocol, /at least six\nseconds/);
   for (const use of workflow.matchAll(/uses:\s+([^\s]+)/g)) assert.match(use[1], /@[0-9a-f]{40}$/);
+});
+
+test("stages a built candidate only inside the host bundled extension root", async () => {
+  const root = await mkdtemp(join(tmpdir(), "zulip-smoke-bundled-stage-"));
+  const hostRoot = join(root, "host");
+  const pluginRoot = join(root, "candidate");
+  try {
+    await mkdir(join(hostRoot, "dist", "extensions"), { recursive: true });
+    await mkdir(join(pluginRoot, "dist"), { recursive: true });
+    await writeFile(join(hostRoot, "package.json"), JSON.stringify({ name: "openclaw", version: "2026.7.1-2" }));
+    await writeFile(join(pluginRoot, "package.json"), JSON.stringify({
+      name: "openclaw-channel-zulip",
+      version: "2026.5.26",
+      openclaw: { extensions: ["./dist/index.js"] },
+    }));
+    await writeFile(join(pluginRoot, "openclaw.plugin.json"), JSON.stringify({ id: "zulip" }));
+    await writeFile(join(pluginRoot, "dist", "index.js"), "export default {};\n");
+
+    const result = await stageBundledPlugin({ hostRoot, pluginRoot });
+
+    assert.equal(result.pluginId, "zulip");
+    assert.equal(result.pluginVersion, "2026.5.26");
+    assert.equal(result.openclawVersion, "2026.7.1-2");
+    assert.equal(await readFile(join(hostRoot, "dist", "extensions", "zulip", "dist", "index.js"), "utf8"), "export default {};\n");
+    assert.equal((await stat(join(pluginRoot, "dist", "index.js"))).isFile(), true);
+    await assert.rejects(
+      stageBundledPlugin({ hostRoot, pluginRoot }),
+      /already contains a bundled Zulip plugin/,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("refuses symbolic links while staging a bundled candidate", async () => {
+  const root = await mkdtemp(join(tmpdir(), "zulip-smoke-bundled-link-"));
+  const hostRoot = join(root, "host");
+  const pluginRoot = join(root, "candidate");
+  try {
+    await mkdir(join(hostRoot, "dist", "extensions"), { recursive: true });
+    await mkdir(join(pluginRoot, "dist"), { recursive: true });
+    await writeFile(join(hostRoot, "package.json"), JSON.stringify({ name: "openclaw", version: "2026.7.1-2" }));
+    await writeFile(join(pluginRoot, "package.json"), JSON.stringify({
+      name: "openclaw-channel-zulip",
+      version: "2026.5.26",
+      openclaw: { extensions: ["./dist/index.js"] },
+    }));
+    await writeFile(join(pluginRoot, "openclaw.plugin.json"), JSON.stringify({ id: "zulip" }));
+    await writeFile(join(root, "outside.js"), "export default {};\n");
+    await symlink(join(root, "outside.js"), join(pluginRoot, "dist", "index.js"));
+
+    await assert.rejects(
+      stageBundledPlugin({ hostRoot, pluginRoot }),
+      /Candidate must be built|Refusing to stage symbolic link/,
+    );
+    await assert.rejects(stat(join(hostRoot, "dist", "extensions", "zulip")), /ENOENT/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });

--- a/scripts/live-smoke/stage-bundled-plugin.mjs
+++ b/scripts/live-smoke/stage-bundled-plugin.mjs
@@ -1,0 +1,120 @@
+import { randomBytes } from "node:crypto";
+import { appendFile, copyFile, lstat, mkdir, readFile, readdir, rename, rm } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const name = argv[index];
+    if (name !== "--host-root" && name !== "--plugin-root") {
+      throw new Error(`Unknown argument: ${name}`);
+    }
+    const value = argv[index + 1];
+    if (!value) throw new Error(`Missing value for ${name}`);
+    args[name.slice(2)] = value;
+    index += 1;
+  }
+  return args;
+}
+
+async function readJson(path) {
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+async function copyTreeWithoutLinks(source, destination) {
+  const sourceStat = await lstat(source);
+  if (sourceStat.isSymbolicLink()) throw new Error(`Refusing to stage symbolic link: ${source}`);
+  if (sourceStat.isFile()) {
+    await copyFile(source, destination);
+    return;
+  }
+  if (!sourceStat.isDirectory()) throw new Error(`Refusing to stage non-file entry: ${source}`);
+  await mkdir(destination, { mode: 0o700 });
+  for (const entry of await readdir(source)) {
+    await copyTreeWithoutLinks(join(source, entry), join(destination, entry));
+  }
+}
+
+function resolveInstalledOpenClawRoot() {
+  const sdkPath = fileURLToPath(import.meta.resolve("openclaw/plugin-sdk"));
+  return resolve(dirname(sdkPath), "../..");
+}
+
+export async function stageBundledPlugin({
+  hostRoot = resolveInstalledOpenClawRoot(),
+  pluginRoot = process.cwd(),
+} = {}) {
+  const resolvedHostRoot = resolve(hostRoot);
+  const resolvedPluginRoot = resolve(pluginRoot);
+  const hostPackage = await readJson(join(resolvedHostRoot, "package.json"));
+  if (hostPackage.name !== "openclaw" || typeof hostPackage.version !== "string") {
+    throw new Error("Host root is not an OpenClaw package");
+  }
+
+  const pluginPackage = await readJson(join(resolvedPluginRoot, "package.json"));
+  const pluginManifest = await readJson(join(resolvedPluginRoot, "openclaw.plugin.json"));
+  if (pluginPackage.name !== "openclaw-channel-zulip" || pluginManifest.id !== "zulip") {
+    throw new Error("Candidate is not the Zulip channel plugin");
+  }
+  const extensionEntries = pluginPackage.openclaw?.extensions;
+  if (!Array.isArray(extensionEntries) || extensionEntries.length !== 1 || extensionEntries[0] !== "./dist/index.js") {
+    throw new Error("Candidate has an unexpected OpenClaw extension entry");
+  }
+  const builtEntry = join(resolvedPluginRoot, "dist", "index.js");
+  if (!(await lstat(builtEntry)).isFile()) throw new Error("Candidate must be built before trusted staging");
+
+  const extensionsRoot = join(resolvedHostRoot, "dist", "extensions");
+  const target = join(extensionsRoot, "zulip");
+  try {
+    await lstat(target);
+    throw new Error("OpenClaw host already contains a bundled Zulip plugin");
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+
+  await mkdir(extensionsRoot, { recursive: true, mode: 0o700 });
+  const staging = join(extensionsRoot, `.zulip-stage-${process.pid}-${randomBytes(8).toString("hex")}`);
+  try {
+    await mkdir(staging, { mode: 0o700 });
+    await copyTreeWithoutLinks(join(resolvedPluginRoot, "dist"), join(staging, "dist"));
+    await copyTreeWithoutLinks(join(resolvedPluginRoot, "package.json"), join(staging, "package.json"));
+    await copyTreeWithoutLinks(
+      join(resolvedPluginRoot, "openclaw.plugin.json"),
+      join(staging, "openclaw.plugin.json"),
+    );
+    await rename(staging, target);
+  } catch (error) {
+    await rm(staging, { recursive: true, force: true });
+    throw error;
+  }
+
+  return {
+    pluginId: "zulip",
+    pluginVersion: String(pluginPackage.version),
+    openclawVersion: hostPackage.version,
+    targetDir: target,
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const result = await stageBundledPlugin({
+    ...(args["host-root"] ? { hostRoot: args["host-root"] } : {}),
+    ...(args["plugin-root"] ? { pluginRoot: args["plugin-root"] } : {}),
+  });
+  if (process.env.GITHUB_ENV) {
+    await appendFile(
+      process.env.GITHUB_ENV,
+      `SMOKE_OPENCLAW_VERSION=${result.openclawVersion}\nSMOKE_PLUGIN_VERSION=${result.pluginVersion}\n`,
+      { encoding: "utf8", mode: 0o600 },
+    );
+  }
+  process.stdout.write(
+    `Staged ${result.pluginId} ${result.pluginVersion} as bundled on OpenClaw ${result.openclawVersion}\n`,
+  );
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main();
+}


### PR DESCRIPTION
Closes #68 after the required protected run is recorded.

## What changed

- stage the exact authorized candidate inside the locked OpenClaw host's bundled extension root
- fail closed unless OpenClaw reports Zulip as loaded with bundled origin and the exact candidate version
- enable the durable receive interruption/replay/completion/deduplication scenario unconditionally
- record candidate SHA, plugin version, host version, and run URL in the workflow summary
- add offline staging, symlink rejection, and workflow-policy regression coverage

## Verification

- OpenClaw 2026.7.1-2: build, 293 Vitest tests, and 61 offline smoke tests passed
- OpenClaw 2026.8.1: build, 293 Vitest tests, and 61 offline smoke tests passed
- both hosts report the staged candidate as `origin: bundled`, `status: loaded`
- `git diff --check` passed

The protected workflow can only be dispatched from `main`, so issue #68 remains open after merge until the exact merged SHA passes the live durable scenario and the run evidence is recorded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to CI smoke scripts, workflow, and docs; production plugin install paths are unchanged.
> 
> **Overview**
> Protected **Zulip live smoke** no longer installs the checkout with `openclaw plugins install -l`. After build, **`stage-bundled-plugin.mjs`** copies the exact candidate into the locked OpenClaw host’s `dist/extensions/zulip` tree (real files only—no symlinks), then the prepare step **fails** unless `openclaw plugins list` shows Zulip as **`origin: bundled`**, **`status: loaded`**, and the **staged plugin version**.
> 
> The workflow sets **`ZULIP_SMOKE_ENABLE_DURABLE: '1'`**, so the harness always runs **durable receive interruption/replay/completion/deduplication** when trusted keyed state is available; the skip reason when durable is off is generalized. Release evidence in the job summary now includes **plugin and OpenClaw versions** (from `GITHUB_ENV`).
> 
> Offline tests lock in the new workflow policy and cover staging success, duplicate-stage rejection, and symlink refusal. README, release checklist, and changelog document the bundled trust path and mandatory durable `PASS`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd8c4fa2c59c9b0762ade3d360476570113fc1c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->