### PR TITLE
test(smoke): add durable timing margin

### DIFF
--- a/scripts/live-smoke/agent-workspace/AGENTS.md
+++ b/scripts/live-smoke/agent-workspace/AGENTS.md
@@ -13,11 +13,11 @@ the spawn as the final action of the current turn. Do not include `VALUE` or
 any other text in that turn. Only after a later child-completion event resumes
 you, verify the child's exact result and reply with exactly `VALUE`.
 
-For `durable VALUE`, wait at least 16 seconds, read the complete contents of
+For `durable VALUE`, wait at least 18 seconds, read the complete contents of
 `.smoke-gateway-generation`, then reply with exactly `VALUE:GENERATION`, where
-`GENERATION` is the file's exact contents. The extra second lets the harness
-prove a full 15-second delay using Zulip's integer server timestamps. Do not
-cache the file before waiting.
+`GENERATION` is the file's exact contents. The extra margin lets the harness
+prove a full 15-second delay using Zulip's integer server timestamps despite
+scheduling jitter. Do not cache the file before waiting.
 
 For `react EMOJI VALUE`, add that reaction to the inbound message with the
 message tool and then reply with exactly `VALUE`.

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -1157,6 +1157,7 @@ test("workflow is manual, protected, pinned, and bounded", async () => {
   assert.match(workflow, /ZULIP_SMOKE_ENABLE_DURABLE: '1'/);
   assert.match(workflow, /SMOKE_OPENCLAW_VERSION/);
   assert.match(workflow, /SMOKE_PLUGIN_VERSION/);
+  assert.match(agentProtocol, /For `durable VALUE`, wait at least 18 seconds/);
   const prepareStep = workflow.slice(
     workflow.indexOf("- name: Prepare isolated OpenClaw state"),
     workflow.indexOf("- name: Run bounded live scenarios"),


### PR DESCRIPTION
## Summary

- widen the protected durable-command wait from 16 to 18 seconds
- retain the strict proof that Zulip server timestamps differ by more than 15 seconds
- lock the timing margin into the offline workflow-policy test

## Why

Protected run 33455930601 successfully staged the candidate as a bundled plugin and produced the replacement-generation durable reply after restart, but integer Zulip timestamps did not prove strictly more than 15 seconds. The prior 16-second instruction left no useful allowance for scheduling and timestamp rounding.

## Validation

- OpenClaw 2026.7.1-2: build, 293 Vitest tests, 61 offline smoke tests
- OpenClaw 2026.8.1: build, 293 Vitest tests, 61 offline smoke tests
- `git diff --check`

Issue #68 remains open until a protected exact-SHA run passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only smoke protocol and offline policy assertion; no production runtime or security behavior changes.
> 
> **Overview**
> Increases the protected smoke agent’s **`durable`** protocol wait from **16 to 18 seconds** before reading `.smoke-gateway-generation` and replying with `VALUE:GENERATION`. The harness still requires Zulip integer message timestamps to show **>15 seconds** between command and reply; the extra two seconds absorb scheduling jitter so that check does not flake.
> 
> **`AGENTS.md`** documents the new minimum wait and updated rationale. **`run.offline.mjs`** adds a workflow-policy assertion so the offline test locks the agent protocol to the 18-second instruction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72b6d74d538362d07d5636ba92a51bffd2a83fec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->