### PR TITLE
test(smoke): enforce durable offline interval

### DIFF
--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -20,6 +20,8 @@ export const REQUIRED_ENV = [
   "OPENCLAW_STATE_DIR",
 ];
 
+export const DURABLE_OFFLINE_DELAY_MS = 16_000;
+
 export function validateEnvironment(env) {
   const missing = REQUIRED_ENV.filter((name) => !env[name]?.trim());
   if (missing.length) throw new Error(`Missing required protected configuration: ${missing.join(", ")}`);
@@ -1131,6 +1133,7 @@ async function main() {
           throw new Error("Durable reply completed before interruption; replay was not exercised");
         }
         await gateway.stop();
+        await delay(DURABLE_OFFLINE_DELAY_MS, undefined, { signal });
         const replacementGeneration = randomBytes(16).toString("hex");
         await writeGatewayGeneration(gatewayGenerationPath, replacementGeneration);
         await gateway.start(signal);
@@ -1142,7 +1145,12 @@ async function main() {
             throw new Error("Durable reply did not contain the replacement gateway generation");
           }
           if (!hasProvableMinimumMessageDelay(commandEvent, e, 15)) {
-            throw new Error("Durable reply did not prove the required 15-second delay");
+            const commandTimestamp = commandEvent?.message?.timestamp;
+            const replyTimestamp = e?.message?.timestamp;
+            const timestampDelta = Number.isSafeInteger(commandTimestamp) && Number.isSafeInteger(replyTimestamp)
+              ? replyTimestamp - commandTimestamp
+              : "unavailable";
+            throw new Error(`Durable reply did not prove the required 15-second delay (timestamp delta: ${timestampDelta})`);
           }
           return true;
         }, timeoutMs, "durable replay reply", signal);

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -7,7 +7,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
-import { assertFinalPrivateTypingStop, assertMessageRemainsExact, authenticatedUserId, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, drainEventQueueUntilQuiet, eventOccursBefore, EventQueue, extractExactUploadUrl, Gateway, hasFinalPrivateTypingStop, hasProvableMinimumMessageDelay, inspectChildTranscripts, inspectLifecycleTurnEvidence, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactPollMessage, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, isUsageCountedTranscriptName, lifecycleEvidenceCounts, lifecycleSummary, normalizeScenarioError, parseZulipSubagentDiagnostic, probeRunnerLocalGatewayHealth, redactError, resolveUploadUrl, signalProcessTree, subagentCompletedBeforeReply, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
+import { assertFinalPrivateTypingStop, assertMessageRemainsExact, authenticatedUserId, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, drainEventQueueUntilQuiet, DURABLE_OFFLINE_DELAY_MS, eventOccursBefore, EventQueue, extractExactUploadUrl, Gateway, hasFinalPrivateTypingStop, hasProvableMinimumMessageDelay, inspectChildTranscripts, inspectLifecycleTurnEvidence, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactPollMessage, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, isUsageCountedTranscriptName, lifecycleEvidenceCounts, lifecycleSummary, normalizeScenarioError, parseZulipSubagentDiagnostic, probeRunnerLocalGatewayHealth, redactError, resolveUploadUrl, signalProcessTree, subagentCompletedBeforeReply, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
 import { selectSmokeModel } from "./prepare-config.mjs";
 import { stageBundledPlugin } from "./stage-bundled-plugin.mjs";
 
@@ -275,6 +275,7 @@ test("requires the explicit reaction event to precede its acknowledgement", () =
 });
 
 test("proves the durable delay from Zulip server message timestamps", () => {
+  assert.equal(DURABLE_OFFLINE_DELAY_MS, 16_000);
   const commandEvent = { message: { timestamp: 100 } };
   assert.equal(hasProvableMinimumMessageDelay(commandEvent, { message: { timestamp: 116 } }, 15), true);
   assert.equal(hasProvableMinimumMessageDelay(commandEvent, { message: { timestamp: 115 } }, 15), false);


### PR DESCRIPTION
## Summary

- enforce a harness-owned 16-second Gateway-offline interval in the durable replay scenario
- retain the strict greater-than-15-second Zulip server-timestamp proof
- include the observed timestamp delta in failures
- cover the required interval in the offline smoke suite

## Why

Two protected runs proved trusted bundled staging and replacement-generation durable replay, but an agent-managed wait landed on the integer server-timestamp boundary. Holding the Gateway offline makes the timing evidence deterministic and independent of model scheduling.

## Validation

- OpenClaw 2026.7.1-2: build, 293 Vitest tests, 61 offline smoke tests
- OpenClaw 2026.8.1: build, 293 Vitest tests, 61 offline smoke tests
- `git diff --check`

The exact branch SHA will be run through the protected live workflow before merge.

Closes #68

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to live-smoke test harness timing and failure diagnostics; no production runtime or auth paths are affected.
> 
> **Overview**
> The **durable replay** live-smoke scenario now keeps the runner-local Gateway **offline for a fixed 16 seconds** (`DURABLE_OFFLINE_DELAY_MS`) after stopping it and before writing the replacement generation and restarting. That harness-owned gap makes the existing **>15 second** Zulip server-timestamp check reliable instead of depending on agent timing that could sit on an integer-second boundary.
> 
> When that delay proof still fails, the error now reports the **observed timestamp delta** (or `unavailable`). The offline smoke suite **asserts the constant is 16_000** alongside the existing `hasProvableMinimumMessageDelay` unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b07add0cc5978365451fec4a21403509103f649. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->