### PR TITLE
Optionally mark handled messages read

### DIFF
--- a/.github/workflows/zulip-live-smoke.yml
+++ b/.github/workflows/zulip-live-smoke.yml
@@ -150,6 +150,7 @@ jobs:
           OPENCLAW_STATE_DIR: ${{ runner.temp }}/openclaw-smoke/state
           SMOKE_GATEWAY_PORT: '18789'
           ZULIP_SUBAGENT_DIAGNOSTICS: '1'
+          ZULIP_HANDLED_READ_DIAGNOSTICS: '1'
           ZULIP_SMOKE_ENABLE_DURABLE: '1'
         run: node scripts/live-smoke/run.mjs
       - name: Record release evidence

--- a/.github/workflows/zulip-live-smoke.yml
+++ b/.github/workflows/zulip-live-smoke.yml
@@ -78,24 +78,12 @@ jobs:
           import { writeFileSync } from "node:fs";
           import { selectSmokeModel } from "./scripts/live-smoke/prepare-config.mjs";
           const config = JSON.parse(process.env.OPENCLAW_SMOKE_CONFIG_JSON);
-          const zulip = config?.channels?.zulip;
-          if (!zulip || typeof zulip !== "object" || Array.isArray(zulip)) {
-            throw new Error("Protected smoke config must contain a Zulip channel object");
-          }
-          zulip.markHandledRead = true;
+          const zulip = config?.channels?.zulip ?? {};
           const { accounts: accountConfigs = {}, ...baseZulip } = zulip;
-          for (const account of Object.values(accountConfigs)) {
-            if (account && typeof account === "object" && !Array.isArray(account)) {
-              account.markHandledRead = true;
-            }
-          }
           const accounts = [baseZulip,
             ...Object.values(accountConfigs).map((account) => ({ ...baseZulip, ...account }))];
           if (accounts.some((account) => account.chatmode !== "onmessage" || account.requireMention !== false)) {
             throw new Error("Protected smoke config must disable stream mention gating");
-          }
-          if (accounts.some((account) => account.markHandledRead !== true)) {
-            throw new Error("Protected smoke config must enable handled-message read state");
           }
           const configured = accounts.map((account) => account?.reactions?.subagent)
             .filter((value) => value !== undefined);
@@ -150,7 +138,6 @@ jobs:
           OPENCLAW_STATE_DIR: ${{ runner.temp }}/openclaw-smoke/state
           SMOKE_GATEWAY_PORT: '18789'
           ZULIP_SUBAGENT_DIAGNOSTICS: '1'
-          ZULIP_HANDLED_READ_DIAGNOSTICS: '1'
           ZULIP_SMOKE_ENABLE_DURABLE: '1'
         run: node scripts/live-smoke/run.mjs
       - name: Record release evidence

--- a/.github/workflows/zulip-live-smoke.yml
+++ b/.github/workflows/zulip-live-smoke.yml
@@ -78,12 +78,24 @@ jobs:
           import { writeFileSync } from "node:fs";
           import { selectSmokeModel } from "./scripts/live-smoke/prepare-config.mjs";
           const config = JSON.parse(process.env.OPENCLAW_SMOKE_CONFIG_JSON);
-          const zulip = config?.channels?.zulip ?? {};
+          const zulip = config?.channels?.zulip;
+          if (!zulip || typeof zulip !== "object" || Array.isArray(zulip)) {
+            throw new Error("Protected smoke config must contain a Zulip channel object");
+          }
+          zulip.markHandledRead = true;
           const { accounts: accountConfigs = {}, ...baseZulip } = zulip;
+          for (const account of Object.values(accountConfigs)) {
+            if (account && typeof account === "object" && !Array.isArray(account)) {
+              account.markHandledRead = true;
+            }
+          }
           const accounts = [baseZulip,
             ...Object.values(accountConfigs).map((account) => ({ ...baseZulip, ...account }))];
           if (accounts.some((account) => account.chatmode !== "onmessage" || account.requireMention !== false)) {
             throw new Error("Protected smoke config must disable stream mention gating");
+          }
+          if (accounts.some((account) => account.markHandledRead !== true)) {
+            throw new Error("Protected smoke config must enable handled-message read state");
           }
           const configured = accounts.map((account) => account?.reactions?.subagent)
             .filter((value) => value !== undefined);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Features
+- **Handled-message read state**: Add an account-level `markHandledRead` opt-in that marks DM and stream/topic messages read only after successful dispatch settlement and durable receive completion, with safe batching and non-fatal failure reporting.
 - **Trusted durable live smoke**: Stage protected exact-SHA candidates through OpenClaw's bundled-plugin trust path and require interruption/replay/completion/deduplication evidence with exact host and plugin versions.
 - **Per-stream inbound policy**: Add deterministic name/ID `streamOverrides` for inbound activation, mention requirements, and allowed/excluded topics while preserving legacy `streams`, `topics`, and `streamTopics` behavior.
 - **Early inbound filtering**: Resolve stream policy before durable acceptance, attachment downloads, reactions, typing, routing, or agent dispatch. Outbound access remains independent.

--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ Add the plugin id to `plugins.allow` in `~/.openclaw/openclaw.json`:
       // Group policy: "open" | "allowlist" | "disabled"
       "groupPolicy": "open",
 
+      // Opt in to marking successfully handled inbound messages read.
+      // Default: false.
+      "markHandledRead": true,
+
       // Truthful lifecycle reactions on the inbound message. The defaults show
       // queued, thinking, tool category, compaction, stalls, done/error, and
       // a separate robot while one or more spawned children are active.
@@ -209,6 +213,20 @@ Then restart the Gateway:
 ```sh
 openclaw gateway restart
 ```
+
+### Handled-message read state
+
+`markHandledRead` is disabled by default and may be enabled globally or for an
+individual account. When enabled, the plugin marks an inbound DM, stream, or
+topic message read only after reply dispatch has settled successfully and its
+accepted durable receive record has completed. A successful silent turn is
+handled; a cancelled or failed turn is not. Messages dropped by authorization
+or routing policy, messages already read, duplicate deliveries, and messages
+without durable-completion proof are not changed.
+
+The read update is best-effort and safely batched per account. An API failure is
+logged without turning an otherwise successful reply into a failure or causing
+the message to be dispatched again.
 
 ### Per-stream inbound policy and migration
 
@@ -378,7 +396,9 @@ The workflow stages the already-authorized, exact-SHA candidate inside the
 locked OpenClaw package's bundled extension directory. It verifies that the
 host reports Zulip as a loaded bundled plugin before credentials are used, then
 runs durable receive interruption, replay, completion, and deduplication with
-plugin keyed state enabled. This staging exists only in the ephemeral runner;
+plugin keyed state enabled. It also proves that the durable command remains
+unread while accepted but unfinished, then becomes read only after successful
+reply settlement and journal completion. This staging exists only in the ephemeral runner;
 release installation remains the separately published plugin package.
 
 The scheduled **OpenClaw compatibility (advisory)** workflow is intentionally separate from release gating. Once a week it chooses the first eligible release from OpenClaw's `latest` and `extended-stable` npm channels that has been published for at least 24 hours, then installs and tests it in a temporary copy of the plugin. That temporary install and the packed-artifact smoke test enforce pnpm's 24-hour release-age rule and may update only disposable lockfiles; they never change or commit this repository's lockfile. A failure identifies compatibility work to investigate; it does not replace the locked CI evidence required for a release.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -55,6 +55,9 @@ transcript and reads the edited Zulip message before and after its required
 four-second visibility window. Durable replay uses a random generation value
 written only after the old gateway process group is fully down; the replacement
 must read and return that value, so a queued pre-restart reply cannot pass.
+The protected config enables `markHandledRead`. The durable command must remain
+unread after acceptance and become read only after the replacement reply settles
+and durable journal completion succeeds.
 The protected workflow enables the durable scenario unconditionally. Its
 summary records the exact candidate SHA, plugin version, OpenClaw version, and
 run URL; the console report must show

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -120,6 +120,7 @@
               "groupAllowFrom": { "type": "array", "items": { "anyOf": [{ "type": "string" }, { "type": "number" }] } },
               "groupPolicy": { "type": "string", "enum": ["open", "disabled", "allowlist"] },
               "mediaMaxMb": { "type": "integer", "minimum": 1 },
+              "markHandledRead": { "type": "boolean" },
               "reactions": {
                 "type": "object",
                 "additionalProperties": false,
@@ -190,6 +191,7 @@
           "groupAllowFrom": { "type": "array", "items": { "anyOf": [{ "type": "string" }, { "type": "number" }] } },
           "groupPolicy": { "type": "string", "enum": ["open", "disabled", "allowlist"] },
           "mediaMaxMb": { "type": "integer", "minimum": 1 },
+          "markHandledRead": { "type": "boolean" },
           "reactions": {
             "type": "object",
             "additionalProperties": false,
@@ -267,6 +269,10 @@
         },
         "requireMention": {
           "label": "Require @mention in Streams"
+        },
+        "markHandledRead": {
+          "label": "Mark Successfully Handled Messages Read",
+          "description": "Opt in to marking an inbound message read only after successful dispatch settlement and durable receive completion."
         },
         "reactions.enabled": {
           "label": "Lifecycle Reaction Indicators"

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -740,6 +740,22 @@ export function parseZulipSubagentDiagnostic(line) {
   return observed.size === Object.keys(schema).length ? line : undefined;
 }
 
+const zulipHandledReadDiagnosticEvents = new Set([
+  "delivery_handled",
+  "delivery_unhandled",
+  "disabled",
+  "missing_id",
+  "already_read",
+  "attempted",
+  "succeeded",
+  "failed",
+]);
+
+export function parseZulipHandledReadDiagnostic(line) {
+  const match = line.match(/^ZULIP_HANDLED_READ_DIAGNOSTIC event=([a-z_]+)$/);
+  return match && zulipHandledReadDiagnosticEvents.has(match[1]) ? line : undefined;
+}
+
 export class Gateway {
   constructor(port, {
     termTimeoutMs = 10000,
@@ -791,7 +807,8 @@ export class Gateway {
         } else if (newline < 0) {
           state.remainder = candidate;
         } else {
-          const diagnostic = parseZulipSubagentDiagnostic(candidate);
+          const diagnostic = parseZulipSubagentDiagnostic(candidate) ??
+            parseZulipHandledReadDiagnostic(candidate);
           if (diagnostic && this.diagnostics.length < 200) this.diagnostics.push(diagnostic);
           state.remainder = "";
         }

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -201,6 +201,25 @@ export async function assertMessageRemainsExact(client, id, expected, minimumMs,
   await assertCurrent();
 }
 
+export async function readZulipMessageFlags(client, id, signal) {
+  const result = await client.request(`messages/${id}`, { signal });
+  if (!Array.isArray(result.message?.flags)) {
+    throw new Error("Zulip message flags were unavailable");
+  }
+  return result.message.flags.map(String);
+}
+
+export async function waitForZulipMessageRead(client, id, timeoutMs, signal) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if ((await readZulipMessageFlags(client, id, signal)).includes("read")) {
+      return;
+    }
+    await delay(250, undefined, { signal });
+  }
+  throw new Error("Handled Zulip message did not become read before timeout");
+}
+
 export async function countCompletedChildTranscripts(stateDir, marker) {
   return (await inspectChildTranscripts(stateDir, marker)).completedExact;
 }
@@ -1128,6 +1147,9 @@ async function main() {
           String(e.message?.id) === inboundId && sameUserId(e.message?.sender_id, actorUserId),
         timeoutMs, "durable command event", signal);
         await queue.waitFor((e) => e.type === "reaction" && e.op === "add" && String(e.message_id) === inboundId, timeoutMs, "durable accept signal", signal);
+        if ((await readZulipMessageFlags(bot, inboundId, signal)).includes("read")) {
+          throw new Error("Durable command became read before reply settlement and journal completion");
+        }
         await delay(2000, undefined, { signal });
         if (captureReplies().length) {
           throw new Error("Durable reply completed before interruption; replay was not exercised");
@@ -1155,6 +1177,7 @@ async function main() {
           return true;
         }, timeoutMs, "durable replay reply", signal);
         messageIds.bot.add(String(reply.message.id));
+        await waitForZulipMessageRead(bot, inboundId, timeoutMs, signal);
         const settleDeadline = Date.now() + 10000;
         while (Date.now() < settleDeadline) { await queue.poll(signal); await delay(500, undefined, { signal }); }
         const replies = captureReplies();

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -220,6 +220,47 @@ export async function waitForZulipMessageRead(client, id, timeoutMs, signal) {
   throw new Error("Handled Zulip message did not become read before timeout");
 }
 
+export async function enableHandledReadForSmokeConfig(configPath) {
+  const handle = await open(configPath, constants.O_RDWR | constants.O_NOFOLLOW);
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile()) throw new Error("Smoke OpenClaw config must be a regular file");
+    const config = JSON.parse(await handle.readFile("utf8"));
+    const zulip = config?.channels?.zulip;
+    if (!zulip || typeof zulip !== "object" || Array.isArray(zulip)) {
+      throw new Error("Smoke OpenClaw config must contain a Zulip channel object");
+    }
+    zulip.markHandledRead = true;
+    const accounts = zulip.accounts ?? {};
+    if (!accounts || typeof accounts !== "object" || Array.isArray(accounts)) {
+      throw new Error("Smoke Zulip accounts must be an object");
+    }
+    for (const account of Object.values(accounts)) {
+      if (!account || typeof account !== "object" || Array.isArray(account)) {
+        throw new Error("Smoke Zulip account entries must be objects");
+      }
+      account.markHandledRead = true;
+    }
+    const serialized = Buffer.from(JSON.stringify(config));
+    await handle.truncate(0);
+    let offset = 0;
+    while (offset < serialized.length) {
+      const { bytesWritten } = await handle.write(
+        serialized,
+        offset,
+        serialized.length - offset,
+        offset,
+      );
+      if (bytesWritten <= 0) throw new Error("Failed to write smoke OpenClaw config");
+      offset += bytesWritten;
+    }
+    await handle.chmod(0o600);
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
 export async function countCompletedChildTranscripts(stateDir, marker) {
   return (await inspectChildTranscripts(stateDir, marker)).completedExact;
 }
@@ -973,6 +1014,12 @@ function command(value) { return `SMOKE_COMMAND\n${value}\nEND_SMOKE_COMMAND`; }
 
 async function main() {
   const env = validateEnvironment(process.env);
+  if (env.ZULIP_SMOKE_ENABLE_DURABLE === "1") {
+    const configPath = env.OPENCLAW_CONFIG_PATH?.trim();
+    if (!configPath) throw new Error("OPENCLAW_CONFIG_PATH is required for durable smoke");
+    await enableHandledReadForSmokeConfig(configPath);
+    process.env.ZULIP_HANDLED_READ_DIAGNOSTICS = "1";
+  }
   const timeoutMs = Number(env.SMOKE_SCENARIO_TIMEOUT_MS || 120000);
   if (!Number.isFinite(timeoutMs) || timeoutMs < 10000 || timeoutMs > 300000) throw new Error("Invalid SMOKE_SCENARIO_TIMEOUT_MS");
   const runId = `smoke-${env.SMOKE_TESTED_SHA.slice(0, 8)}-${randomBytes(5).toString("hex")}`;

--- a/scripts/live-smoke/run.mjs
+++ b/scripts/live-smoke/run.mjs
@@ -1142,23 +1142,29 @@ async function main() {
       try {
         const oldGeneration = randomBytes(16).toString("hex");
         await writeGatewayGeneration(gatewayGenerationPath, oldGeneration);
+        console.log("durable-receive-completion-deduplication phase=send_command");
         const inboundId = await sendDm(command(`durable ${marker}`), signal);
         const commandEvent = await queue.waitFor((e) => e.type === "message" &&
           String(e.message?.id) === inboundId && sameUserId(e.message?.sender_id, actorUserId),
         timeoutMs, "durable command event", signal);
+        console.log(`durable-receive-completion-deduplication phase=command_observed message_id=${inboundId}`);
         await queue.waitFor((e) => e.type === "reaction" && e.op === "add" && String(e.message_id) === inboundId, timeoutMs, "durable accept signal", signal);
-        if ((await readZulipMessageFlags(bot, inboundId, signal)).includes("read")) {
+        const preInterruptionFlags = await readZulipMessageFlags(bot, inboundId, signal);
+        if (preInterruptionFlags.includes("read")) {
           throw new Error("Durable command became read before reply settlement and journal completion");
         }
+        console.log("durable-receive-completion-deduplication phase=accepted_unread");
         await delay(2000, undefined, { signal });
         if (captureReplies().length) {
           throw new Error("Durable reply completed before interruption; replay was not exercised");
         }
         await gateway.stop();
+        console.log("durable-receive-completion-deduplication phase=gateway_stopped");
         await delay(DURABLE_OFFLINE_DELAY_MS, undefined, { signal });
         const replacementGeneration = randomBytes(16).toString("hex");
         await writeGatewayGeneration(gatewayGenerationPath, replacementGeneration);
         await gateway.start(signal);
+        console.log("durable-receive-completion-deduplication phase=replacement_started");
         const replacementReply = `${marker}:${replacementGeneration}`;
         const reply = await queue.waitFor((e) => {
           if (!isAttributable(e)) return false;
@@ -1177,7 +1183,9 @@ async function main() {
           return true;
         }, timeoutMs, "durable replay reply", signal);
         messageIds.bot.add(String(reply.message.id));
+        console.log(`durable-receive-completion-deduplication phase=reply_observed message_id=${reply.message.id}`);
         await waitForZulipMessageRead(bot, inboundId, timeoutMs, signal);
+        console.log("durable-receive-completion-deduplication phase=read_observed");
         const settleDeadline = Date.now() + 10000;
         while (Date.now() < settleDeadline) { await queue.poll(signal); await delay(500, undefined, { signal }); }
         const replies = captureReplies();
@@ -1185,6 +1193,7 @@ async function main() {
         if (replies.length !== 1 || validReplies.length !== 1) {
           throw new Error(`Durable receive produced ${replies.length} attributable replies (${validReplies.length} valid); expected exactly one valid replacement reply`);
         }
+        console.log("durable-receive-completion-deduplication phase=complete");
       } finally {
         captureReplies();
       }

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -7,7 +7,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
-import { assertFinalPrivateTypingStop, assertMessageRemainsExact, authenticatedUserId, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, drainEventQueueUntilQuiet, DURABLE_OFFLINE_DELAY_MS, eventOccursBefore, EventQueue, extractExactUploadUrl, Gateway, hasFinalPrivateTypingStop, hasProvableMinimumMessageDelay, inspectChildTranscripts, inspectLifecycleTurnEvidence, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactPollMessage, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, isUsageCountedTranscriptName, lifecycleEvidenceCounts, lifecycleSummary, normalizeScenarioError, parseZulipSubagentDiagnostic, probeRunnerLocalGatewayHealth, redactError, resolveUploadUrl, signalProcessTree, subagentCompletedBeforeReply, validateEnvironment, waitForProcessTreeExit, writeGatewayGeneration } from "./run.mjs";
+import { assertFinalPrivateTypingStop, assertMessageRemainsExact, authenticatedUserId, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, drainEventQueueUntilQuiet, DURABLE_OFFLINE_DELAY_MS, eventOccursBefore, EventQueue, extractExactUploadUrl, Gateway, hasFinalPrivateTypingStop, hasProvableMinimumMessageDelay, inspectChildTranscripts, inspectLifecycleTurnEvidence, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactPollMessage, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, isUsageCountedTranscriptName, lifecycleEvidenceCounts, lifecycleSummary, normalizeScenarioError, parseZulipSubagentDiagnostic, probeRunnerLocalGatewayHealth, readZulipMessageFlags, redactError, resolveUploadUrl, signalProcessTree, subagentCompletedBeforeReply, validateEnvironment, waitForProcessTreeExit, waitForZulipMessageRead, writeGatewayGeneration } from "./run.mjs";
 import { selectSmokeModel } from "./prepare-config.mjs";
 import { stageBundledPlugin } from "./stage-bundled-plugin.mjs";
 
@@ -280,6 +280,21 @@ test("proves the durable delay from Zulip server message timestamps", () => {
   assert.equal(hasProvableMinimumMessageDelay(commandEvent, { message: { timestamp: 116 } }, 15), true);
   assert.equal(hasProvableMinimumMessageDelay(commandEvent, { message: { timestamp: 115 } }, 15), false);
   assert.equal(hasProvableMinimumMessageDelay(commandEvent, { message: {} }, 15), false);
+});
+
+test("reads message flags and waits for the handled read transition", async () => {
+  const responses = [
+    { message: { flags: ["starred"] } },
+    { message: { flags: ["starred", "read"] } },
+  ];
+  const client = { request: async () => responses.shift() };
+  assert.deepEqual(await readZulipMessageFlags(client, "42"), ["starred"]);
+  await waitForZulipMessageRead(client, "42", 1000);
+  assert.equal(responses.length, 0);
+  await assert.rejects(
+    readZulipMessageFlags({ request: async () => ({ message: {} }) }, "42"),
+    /flags were unavailable/,
+  );
 });
 
 test("captures every attributable reply id before an early failure", () => {
@@ -1167,6 +1182,8 @@ test("workflow is manual, protected, pinned, and bounded", async () => {
     workflow.indexOf("- name: Run bounded live scenarios"),
     workflow.indexOf("- name: Record release evidence"),
   );
+  assert.match(prepareStep, /markHandledRead = true/);
+  assert.match(prepareStep, /must enable handled-message read state/);
   assert.equal(workflow.match(/secrets\.OPENCLAW_SMOKE_CONFIG_JSON/g)?.length, 1);
   assert.match(prepareStep, /secrets\.OPENCLAW_SMOKE_CONFIG_JSON/);
   for (const secret of ["ZULIP_URL", "ZULIP_SMOKE_USER_EMAIL", "ZULIP_SMOKE_USER_API_KEY", "ZULIP_SMOKE_BOT_EMAIL", "ZULIP_SMOKE_BOT_API_KEY"]) {

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -7,7 +7,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
-import { assertFinalPrivateTypingStop, assertMessageRemainsExact, authenticatedUserId, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, drainEventQueueUntilQuiet, DURABLE_OFFLINE_DELAY_MS, eventOccursBefore, EventQueue, extractExactUploadUrl, Gateway, hasFinalPrivateTypingStop, hasProvableMinimumMessageDelay, inspectChildTranscripts, inspectLifecycleTurnEvidence, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactPollMessage, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, isUsageCountedTranscriptName, lifecycleEvidenceCounts, lifecycleSummary, normalizeScenarioError, parseZulipSubagentDiagnostic, probeRunnerLocalGatewayHealth, readZulipMessageFlags, redactError, resolveUploadUrl, signalProcessTree, subagentCompletedBeforeReply, validateEnvironment, waitForProcessTreeExit, waitForZulipMessageRead, writeGatewayGeneration } from "./run.mjs";
+import { assertFinalPrivateTypingStop, assertMessageRemainsExact, authenticatedUserId, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, drainEventQueueUntilQuiet, DURABLE_OFFLINE_DELAY_MS, eventOccursBefore, EventQueue, extractExactUploadUrl, Gateway, hasFinalPrivateTypingStop, hasProvableMinimumMessageDelay, inspectChildTranscripts, inspectLifecycleTurnEvidence, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactPollMessage, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, isUsageCountedTranscriptName, lifecycleEvidenceCounts, lifecycleSummary, normalizeScenarioError, parseZulipHandledReadDiagnostic, parseZulipSubagentDiagnostic, probeRunnerLocalGatewayHealth, readZulipMessageFlags, redactError, resolveUploadUrl, signalProcessTree, subagentCompletedBeforeReply, validateEnvironment, waitForProcessTreeExit, waitForZulipMessageRead, writeGatewayGeneration } from "./run.mjs";
 import { selectSmokeModel } from "./prepare-config.mjs";
 import { stageBundledPlugin } from "./stage-bundled-plugin.mjs";
 
@@ -655,11 +655,13 @@ test("captures only bounded allowlisted gateway lifecycle diagnostics", () => {
   gateway.captureDiagnostics("ZULIP_SUBAGENT_DIAGNOSTIC event=run_ended binding_found=ABC123\n");
   gateway.captureDiagnostics("ZULIP_SUBAGENT_DIAGNOSTIC event=indicator_");
   gateway.captureDiagnostics("shown\n");
+  gateway.captureDiagnostics("ZULIP_HANDLED_READ_DIAGNOSTIC event=attempted\n");
   for (let index = 0; index < 250; index += 1) {
     gateway.captureDiagnostics("ZULIP_SUBAGENT_DIAGNOSTIC event=reaction_add_succeeded\n");
   }
 
   assert.equal(gateway.diagnostics[0], "ZULIP_SUBAGENT_DIAGNOSTIC event=indicator_shown");
+  assert.equal(gateway.diagnostics[1], "ZULIP_HANDLED_READ_DIAGNOSTIC event=attempted");
   assert.equal(gateway.diagnostics.length, 200);
   assert.equal(gateway.diagnostics.some((line) => line.includes("secret")), false);
 });
@@ -705,6 +707,9 @@ test("rejects unknown lifecycle diagnostic schemas and secret-shaped values", ()
   assert.equal(parseZulipSubagentDiagnostic("ZULIP_SUBAGENT_DIAGNOSTIC event=run_ended unknown=true"), undefined);
   assert.equal(parseZulipSubagentDiagnostic("ZULIP_SUBAGENT_DIAGNOSTIC event=run_ended binding_found=ABC123"), undefined);
   assert.equal(parseZulipSubagentDiagnostic("ZULIP_SUBAGENT_DIAGNOSTIC event=context_registered key_count=999 active_contexts=1"), undefined);
+  assert.equal(parseZulipHandledReadDiagnostic("ZULIP_HANDLED_READ_DIAGNOSTIC event=succeeded"), "ZULIP_HANDLED_READ_DIAGNOSTIC event=succeeded");
+  assert.equal(parseZulipHandledReadDiagnostic("ZULIP_HANDLED_READ_DIAGNOSTIC event=unknown"), undefined);
+  assert.equal(parseZulipHandledReadDiagnostic("ZULIP_HANDLED_READ_DIAGNOSTIC event=failed secret=ABC123"), undefined);
 });
 
 test("reconciles a placeholder update into cached message matching and cleanup attribution", async () => {
@@ -1171,6 +1176,7 @@ test("workflow is manual, protected, pinned, and bounded", async () => {
   assert.match(workflow, /plugin\.origin !== "bundled"/);
   assert.match(workflow, /plugin\.status !== "loaded"/);
   assert.match(workflow, /ZULIP_SMOKE_ENABLE_DURABLE: '1'/);
+  assert.match(workflow, /ZULIP_HANDLED_READ_DIAGNOSTICS: '1'/);
   assert.match(workflow, /SMOKE_OPENCLAW_VERSION/);
   assert.match(workflow, /SMOKE_PLUGIN_VERSION/);
   assert.match(agentProtocol, /For `durable VALUE`, wait at least 18 seconds/);

--- a/scripts/live-smoke/run.offline.mjs
+++ b/scripts/live-smoke/run.offline.mjs
@@ -7,7 +7,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
-import { assertFinalPrivateTypingStop, assertMessageRemainsExact, authenticatedUserId, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, drainEventQueueUntilQuiet, DURABLE_OFFLINE_DELAY_MS, eventOccursBefore, EventQueue, extractExactUploadUrl, Gateway, hasFinalPrivateTypingStop, hasProvableMinimumMessageDelay, inspectChildTranscripts, inspectLifecycleTurnEvidence, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactPollMessage, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, isUsageCountedTranscriptName, lifecycleEvidenceCounts, lifecycleSummary, normalizeScenarioError, parseZulipHandledReadDiagnostic, parseZulipSubagentDiagnostic, probeRunnerLocalGatewayHealth, readZulipMessageFlags, redactError, resolveUploadUrl, signalProcessTree, subagentCompletedBeforeReply, validateEnvironment, waitForProcessTreeExit, waitForZulipMessageRead, writeGatewayGeneration } from "./run.mjs";
+import { assertFinalPrivateTypingStop, assertMessageRemainsExact, authenticatedUserId, buildApiUrl, captureMessageIds, captureObservedSmokeBotMessageIds, countCompletedChildTranscripts, countMessageDeletionFailures, drainEventQueueUntilQuiet, DURABLE_OFFLINE_DELAY_MS, enableHandledReadForSmokeConfig, eventOccursBefore, EventQueue, extractExactUploadUrl, Gateway, hasFinalPrivateTypingStop, hasProvableMinimumMessageDelay, inspectChildTranscripts, inspectLifecycleTurnEvidence, isBotMessage, isChildRunning, isDurableReplyEvent, isExactPoll, isExactPollMessage, isExactRenderedContent, isExactUtf8, isPrivateBotEvent, isPrivateBotMessage, isPrivateTypingEvent, isUsageCountedTranscriptName, lifecycleEvidenceCounts, lifecycleSummary, normalizeScenarioError, parseZulipHandledReadDiagnostic, parseZulipSubagentDiagnostic, probeRunnerLocalGatewayHealth, readZulipMessageFlags, redactError, resolveUploadUrl, signalProcessTree, subagentCompletedBeforeReply, validateEnvironment, waitForProcessTreeExit, waitForZulipMessageRead, writeGatewayGeneration } from "./run.mjs";
 import { selectSmokeModel } from "./prepare-config.mjs";
 import { stageBundledPlugin } from "./stage-bundled-plugin.mjs";
 
@@ -295,6 +295,40 @@ test("reads message flags and waits for the handled read transition", async () =
     readZulipMessageFlags({ request: async () => ({ message: {} }) }, "42"),
     /flags were unavailable/,
   );
+});
+
+test("enables handled-read proof in the checked-out durable smoke harness", async () => {
+  const root = await mkdtemp(join(tmpdir(), "zulip-smoke-config-"));
+  const configPath = join(root, "openclaw.json");
+  try {
+    await writeFile(configPath, JSON.stringify({
+      channels: { zulip: { markHandledRead: false, accounts: {
+        primary: { markHandledRead: false }, secondary: {},
+      } } },
+    }), { mode: 0o644 });
+    await enableHandledReadForSmokeConfig(configPath);
+    const config = JSON.parse(await readFile(configPath, "utf8"));
+    assert.equal(config.channels.zulip.markHandledRead, true);
+    assert.equal(config.channels.zulip.accounts.primary.markHandledRead, true);
+    assert.equal(config.channels.zulip.accounts.secondary.markHandledRead, true);
+    assert.equal((await stat(configPath)).mode & 0o777, 0o600);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("refuses a symlinked durable smoke config", async () => {
+  const root = await mkdtemp(join(tmpdir(), "zulip-smoke-config-link-"));
+  const targetPath = join(root, "target.json");
+  const linkPath = join(root, "openclaw.json");
+  try {
+    await writeFile(targetPath, JSON.stringify({ channels: { zulip: {} } }), { mode: 0o600 });
+    await symlink(targetPath, linkPath);
+    await assert.rejects(enableHandledReadForSmokeConfig(linkPath));
+    assert.equal(JSON.parse(await readFile(targetPath, "utf8")).channels.zulip.markHandledRead, undefined);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });
 
 test("captures every attributable reply id before an early failure", () => {
@@ -1176,7 +1210,6 @@ test("workflow is manual, protected, pinned, and bounded", async () => {
   assert.match(workflow, /plugin\.origin !== "bundled"/);
   assert.match(workflow, /plugin\.status !== "loaded"/);
   assert.match(workflow, /ZULIP_SMOKE_ENABLE_DURABLE: '1'/);
-  assert.match(workflow, /ZULIP_HANDLED_READ_DIAGNOSTICS: '1'/);
   assert.match(workflow, /SMOKE_OPENCLAW_VERSION/);
   assert.match(workflow, /SMOKE_PLUGIN_VERSION/);
   assert.match(agentProtocol, /For `durable VALUE`, wait at least 18 seconds/);
@@ -1188,8 +1221,6 @@ test("workflow is manual, protected, pinned, and bounded", async () => {
     workflow.indexOf("- name: Run bounded live scenarios"),
     workflow.indexOf("- name: Record release evidence"),
   );
-  assert.match(prepareStep, /markHandledRead = true/);
-  assert.match(prepareStep, /must enable handled-message read state/);
   assert.equal(workflow.match(/secrets\.OPENCLAW_SMOKE_CONFIG_JSON/g)?.length, 1);
   assert.match(prepareStep, /secrets\.OPENCLAW_SMOKE_CONFIG_JSON/);
   for (const secret of ["ZULIP_URL", "ZULIP_SMOKE_USER_EMAIL", "ZULIP_SMOKE_USER_API_KEY", "ZULIP_SMOKE_BOT_EMAIL", "ZULIP_SMOKE_BOT_API_KEY"]) {

--- a/src/config-schema.test.ts
+++ b/src/config-schema.test.ts
@@ -3,6 +3,30 @@ import { describe, expect, it } from "vitest";
 import { zulipChannelConfigSchema } from "./config-schema.js";
 
 describe("Zulip lifecycle reaction config", () => {
+  it("accepts the conservative handled-read account opt-in and exposes it in the manifest", () => {
+    expect(zulipChannelConfigSchema.runtime.safeParse({ markHandledRead: true }).success).toBe(true);
+    expect(zulipChannelConfigSchema.runtime.safeParse({ markHandledRead: false }).success).toBe(true);
+    expect(zulipChannelConfigSchema.runtime.safeParse({}).success).toBe(true);
+
+    const manifest = JSON.parse(
+      fs.readFileSync(new URL("../openclaw.plugin.json", import.meta.url), "utf8"),
+    ) as {
+      channelConfigs: {
+        zulip: {
+          schema: {
+            $defs: { zulipAccount: { properties: Record<string, unknown> } };
+            properties: Record<string, unknown>;
+          };
+          uiHints: Record<string, unknown>;
+        };
+      };
+    };
+    const config = manifest.channelConfigs.zulip;
+    expect(config.schema.properties).toHaveProperty("markHandledRead");
+    expect(config.schema.$defs.zulipAccount.properties).toHaveProperty("markHandledRead");
+    expect(config.uiHints).toHaveProperty("markHandledRead");
+  });
+
   it("accepts strict per-stream inbound policy fields", () => {
     const result = zulipChannelConfigSchema.runtime.safeParse({
       streamOverrides: {

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -161,6 +161,7 @@ const ZulipAccountSchemaBase = z
     groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     groupPolicy: GroupPolicySchema.optional(),
     mediaMaxMb: z.number().int().positive().optional(),
+    markHandledRead: z.boolean().optional(),
     reactions: z
       .object({
         enabled: z.boolean().optional(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,8 @@ export type ZulipAccountConfig = {
   groupPolicy?: GroupPolicy;
   /** Inbound media max size (MB). Default: 5. */
   mediaMaxMb?: number;
+  /** Mark successfully handled inbound messages read after durable completion. Default: false. */
+  markHandledRead?: boolean;
   /** Automatic lifecycle reactions on the inbound Zulip message. */
   reactions?: {
     enabled?: boolean;

--- a/src/zulip/client.test.ts
+++ b/src/zulip/client.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it, vi } from "vitest";
 import {
   addZulipReaction,
   createZulipClient,
+  createZulipReadBatcher,
   registerZulipQueue,
   removeZulipReaction,
+  updateZulipMessageFlag,
+  updateZulipMessageFlags,
   zulipRequestWithRetry,
   type ZulipRequestLogger,
 } from "./client.js";
@@ -314,5 +317,102 @@ describe("Zulip reactions", () => {
     await expect(
       addZulipReaction(client, { messageId: "123", emojiName: "not an emoji" }),
     ).rejects.toThrow("Zulip add reaction failed: Invalid emoji name");
+  });
+});
+
+describe("Zulip message flags", () => {
+  it("updates a safe batch without replacing unrelated message flags", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({ result: "success" }),
+    );
+    const client = createZulipClient({
+      baseUrl: "https://zulip.example.test/",
+      email: "bot@example.test",
+      apiKey: "secret",
+      fetchImpl,
+    });
+
+    await updateZulipMessageFlags(client, {
+      messageIds: [101, "102"],
+      flag: "read",
+      op: "add",
+    });
+
+    const [url, init] = fetchImpl.mock.calls[0] ?? [];
+    const body = new URLSearchParams(String(init?.body));
+    expect(url).toBe("https://zulip.example.test/api/v1/messages/flags");
+    expect(body.get("messages")).toBe("[101,102]");
+    expect(body.get("flag")).toBe("read");
+    expect(body.get("op")).toBe("add");
+  });
+
+  it("keeps the single-message starred action compatible", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({ result: "success" }),
+    );
+    const client = createZulipClient({
+      baseUrl: "https://zulip.example.test/",
+      email: "bot@example.test",
+      apiKey: "secret",
+      fetchImpl,
+    });
+
+    await updateZulipMessageFlag(client, {
+      messageId: "103",
+      flag: "starred",
+      op: "remove",
+    });
+
+    const [, init] = fetchImpl.mock.calls[0] ?? [];
+    const body = new URLSearchParams(String(init?.body));
+    expect(body.get("messages")).toBe("[103]");
+    expect(body.get("flag")).toBe("starred");
+    expect(body.get("op")).toBe("remove");
+  });
+
+  it("rejects invalid or empty batches before requesting Zulip", async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    const client = createZulipClient({
+      baseUrl: "https://zulip.example.test/",
+      email: "bot@example.test",
+      apiKey: "secret",
+      fetchImpl,
+    });
+
+    await expect(updateZulipMessageFlags(client, {
+      messageIds: ["103oops"],
+      flag: "read",
+      op: "add",
+    })).rejects.toThrow("Invalid messageId");
+    await expect(updateZulipMessageFlags(client, {
+      messageIds: [],
+      flag: "read",
+      op: "add",
+    })).rejects.toThrow("At least one messageId is required");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("coalesces concurrent read updates and deduplicates message ids", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({ result: "success" }),
+    );
+    const client = createZulipClient({
+      baseUrl: "https://zulip.example.test/",
+      email: "bot@example.test",
+      apiKey: "secret",
+      fetchImpl,
+    });
+    const batcher = createZulipReadBatcher(client);
+
+    await Promise.all([
+      batcher.markRead("104"),
+      batcher.markRead(105),
+      batcher.markRead("104"),
+    ]);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [, init] = fetchImpl.mock.calls[0] ?? [];
+    const body = new URLSearchParams(String(init?.body));
+    expect(body.get("messages")).toBe("[104,105]");
   });
 });

--- a/src/zulip/client.ts
+++ b/src/zulip/client.ts
@@ -76,6 +76,7 @@ export type ZulipSubscription = {
 
 export type ZulipMessage = {
   id: string;
+  flags?: string[];
   sender_id?: string | null;
   sender_email?: string | null;
   sender_full_name?: string | null;
@@ -907,18 +908,38 @@ export async function updateZulipMessageFlag(
   client: ZulipClient,
   params: {
     messageId: string | number;
-    flag: "starred";
+    flag: "read" | "starred";
     op: "add" | "remove";
   },
 ): Promise<void> {
-  // Convert messageId to integer
-  const messageIdInt =
-    typeof params.messageId === "number" ? params.messageId : parseInt(params.messageId, 10);
-  if (isNaN(messageIdInt)) {
-    throw new Error(`Invalid messageId: ${params.messageId}`);
+  await updateZulipMessageFlags(client, {
+    messageIds: [params.messageId],
+    flag: params.flag,
+    op: params.op,
+  });
+}
+
+export async function updateZulipMessageFlags(
+  client: ZulipClient,
+  params: {
+    messageIds: Array<string | number>;
+    flag: "read" | "starred";
+    op: "add" | "remove";
+  },
+): Promise<void> {
+  const messageIds = params.messageIds.map((messageId) => {
+    const messageIdInt =
+      typeof messageId === "number" ? messageId : Number(messageId);
+    if (!Number.isSafeInteger(messageIdInt) || messageIdInt < 0) {
+      throw new Error(`Invalid messageId: ${messageId}`);
+    }
+    return messageIdInt;
+  });
+  if (messageIds.length === 0) {
+    throw new Error("At least one messageId is required");
   }
   const body = new URLSearchParams({
-    messages: JSON.stringify([messageIdInt]),
+    messages: JSON.stringify(messageIds),
     flag: params.flag,
     op: params.op,
   });
@@ -927,6 +948,58 @@ export async function updateZulipMessageFlag(
     body: body.toString(),
   });
   assertSuccess(payload, "Zulip update message flags failed");
+}
+
+export function createZulipReadBatcher(client: ZulipClient): {
+  markRead: (messageId: string | number) => Promise<void>;
+} {
+  let pending = new Map<string, Array<{ resolve: () => void; reject: (error: unknown) => void }>>();
+  let flushScheduled = false;
+
+  const scheduleFlush = () => {
+    if (flushScheduled) {
+      return;
+    }
+    flushScheduled = true;
+    queueMicrotask(async () => {
+      flushScheduled = false;
+      const batch = pending;
+      pending = new Map();
+      try {
+        await updateZulipMessageFlags(client, {
+          messageIds: Array.from(batch.keys()),
+          flag: "read",
+          op: "add",
+        });
+        for (const waiters of batch.values()) {
+          for (const waiter of waiters) {
+            waiter.resolve();
+          }
+        }
+      } catch (error) {
+        for (const waiters of batch.values()) {
+          for (const waiter of waiters) {
+            waiter.reject(error);
+          }
+        }
+      }
+      if (pending.size > 0) {
+        scheduleFlush();
+      }
+    });
+  };
+
+  return {
+    markRead(messageId) {
+      const key = String(messageId);
+      return new Promise<void>((resolve, reject) => {
+        const waiters = pending.get(key) ?? [];
+        waiters.push({ resolve, reject });
+        pending.set(key, waiters);
+        scheduleFlush();
+      });
+    },
+  };
 }
 
 export async function updateZulipMessageTopic(

--- a/src/zulip/client.ts
+++ b/src/zulip/client.ts
@@ -89,6 +89,13 @@ export type ZulipMessage = {
   recipient_id?: string | null;
 };
 
+export type ZulipEvent = {
+  id: number;
+  type: string;
+  message?: ZulipMessage;
+  flags?: string[];
+};
+
 export function normalizeZulipBaseUrl(raw?: string | null): string | undefined {
   const trimmed = raw?.trim();
   if (!trimmed) {
@@ -422,7 +429,7 @@ export async function getZulipEvents(
     dontBlock?: boolean;
   },
 ): Promise<
-  ZulipApiResponse & { events?: Array<{ id: number; type: string; message?: ZulipMessage }> }
+  ZulipApiResponse & { events?: ZulipEvent[] }
 > {
   const qs = new URLSearchParams({
     queue_id: params.queueId,
@@ -443,7 +450,7 @@ export async function getZulipEvents(
   const timeout = setTimeout(() => controller.abort(), timeoutMs + 15000);
   try {
     return await client.request<
-      ZulipApiResponse & { events?: Array<{ id: number; type: string; message?: ZulipMessage }> }
+      ZulipApiResponse & { events?: ZulipEvent[] }
     >(`/events?${qs.toString()}`, { signal: controller.signal });
   } finally {
     clearTimeout(timeout);
@@ -461,7 +468,7 @@ export async function getZulipEventsWithRetry(
     dontBlock?: boolean;
   },
 ): Promise<
-  ZulipApiResponse & { events?: Array<{ id: number; type: string; message?: ZulipMessage }> }
+  ZulipApiResponse & { events?: ZulipEvent[] }
 > {
   const qs = new URLSearchParams({
     queue_id: params.queueId,
@@ -482,7 +489,7 @@ export async function getZulipEventsWithRetry(
   const timeout = setTimeout(() => controller.abort(), timeoutMs + 15000);
   try {
     return await zulipRequestWithRetry<
-      ZulipApiResponse & { events?: Array<{ id: number; type: string; message?: ZulipMessage }> }
+      ZulipApiResponse & { events?: ZulipEvent[] }
     >(
       client,
       `/events?${qs.toString()}`,

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -211,6 +211,7 @@ const state = vi.hoisted(() => {
     deleteZulipMessage: vi.fn(async () => {}),
     addZulipReaction: vi.fn(async () => {}),
     removeZulipReaction: vi.fn(async () => {}),
+    updateZulipMessageFlags: vi.fn(async () => {}),
     sendMessageZulip: vi.fn(async () => ({ messageId: "outbound-1", channelId: "debbie" })),
     client: { authHeader: "fake-auth" },
     botUser: {
@@ -283,6 +284,13 @@ vi.mock("./client.js", () => ({
   removeZulipReaction: state.removeZulipReaction,
   editZulipMessage: state.editZulipMessage,
   deleteZulipMessage: state.deleteZulipMessage,
+  createZulipReadBatcher: vi.fn(() => ({
+    markRead: (messageId: string | number) => state.updateZulipMessageFlags(state.client, {
+      messageIds: [messageId],
+      flag: "read",
+      op: "add",
+    }),
+  })),
 }));
 
 vi.mock("./accounts.js", () => ({
@@ -523,6 +531,7 @@ describe("monitorZulipProvider", () => {
     state.deleteZulipMessage.mockReset();
     state.addZulipReaction.mockReset();
     state.removeZulipReaction.mockReset();
+    state.updateZulipMessageFlags.mockReset().mockResolvedValue(undefined);
     state.sendMessageZulip.mockReset();
     state.sendMessageZulip.mockResolvedValue({ messageId: "outbound-1", channelId: "debbie" });
     downloadZulipUploadMock.mockClear();
@@ -671,7 +680,9 @@ describe("monitorZulipProvider", () => {
   });
 
   it("aborts active replies and clears reactions when the monitor stops", async () => {
+    enableDurableInboundJournal();
     state.autoAbort = false;
+    state.account.config.markHandledRead = true;
     state.account.config.reactions = {
       enabled: true,
       timing: { doneHoldMs: 500 },
@@ -717,6 +728,7 @@ describe("monitorZulipProvider", () => {
       state.client,
       expect.objectContaining({ messageId: "1094", emojiName: "cross_mark" }),
     );
+    expect(state.updateZulipMessageFlags).not.toHaveBeenCalled();
   });
 
   it("retries a transient placeholder deletion failure during ordinary abort", async () => {
@@ -2850,6 +2862,164 @@ describe("monitorZulipProvider", () => {
     expect(state.core.channel.inbound.buildContext).toHaveBeenCalledTimes(1);
   });
 
+  it("marks an opt-in handled stream message read only after durable completion", async () => {
+    enableDurableInboundJournal();
+    state.account.config.markHandledRead = true;
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions }) => {
+        await dispatcherOptions.deliver({ text: "handled reply" });
+        return { counts: { tool: 0, block: 0, final: 1 } };
+      },
+    );
+    state.pollResponses = [{
+      result: "success",
+      events: [{ id: 23, type: "message", message: makeChannelMessage(2120) }],
+    }];
+
+    await runMonitorOnce();
+
+    const queue = state.durableQueues.get(state.account.accountId);
+    expect(queue?.complete).toHaveBeenCalledTimes(1);
+    expect(state.updateZulipMessageFlags).toHaveBeenCalledExactlyOnceWith(state.client, {
+      messageIds: ["2120"],
+      flag: "read",
+      op: "add",
+    });
+    expect(queue?.complete.mock.invocationCallOrder[0]).toBeLessThan(
+      state.updateZulipMessageFlags.mock.invocationCallOrder[0] ?? 0,
+    );
+  });
+
+  it("marks an opt-in silent DM completion read", async () => {
+    enableDurableInboundJournal();
+    state.account.config.markHandledRead = true;
+    state.pollResponses = [{
+      result: "success",
+      events: [{ id: 24, type: "message", message: makePrivateMessage(2121) }],
+    }];
+
+    await runMonitorOnce();
+
+    expect(state.sendMessageZulip).not.toHaveBeenCalled();
+    expect(state.updateZulipMessageFlags).toHaveBeenCalledExactlyOnceWith(state.client, {
+      messageIds: ["2121"],
+      flag: "read",
+      op: "add",
+    });
+  });
+
+  it("does not mark a failed delivery read", async () => {
+    enableDurableInboundJournal();
+    state.account.config.markHandledRead = true;
+    state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementationOnce(
+      async () => ({
+        counts: { tool: 0, block: 0, final: 0 },
+        failedCounts: { tool: 0, block: 0, final: 1 },
+      }),
+    );
+    const failed = makeChannelMessage(2122);
+    state.pollResponses = [{
+      result: "success",
+      events: [{ id: 25, type: "message", message: failed }],
+    }];
+
+    await runMonitorOnce();
+
+    expect(state.updateZulipMessageFlags).not.toHaveBeenCalled();
+  });
+
+  it("does not mark unauthorized, duplicate, or already-read messages newly read", async () => {
+    enableDurableInboundJournal();
+    state.account.config.markHandledRead = true;
+    const alreadyRead = { ...makeChannelMessage(2123), flags: ["read"] };
+
+    state.pollResponses = [{
+      result: "success",
+      events: [{ id: 26, type: "message", message: alreadyRead }],
+    }];
+    await runMonitorOnce();
+    expect(state.updateZulipMessageFlags).not.toHaveBeenCalled();
+
+    state.account.config.dmPolicy = "disabled";
+    state.pollResponses = [{
+      result: "success",
+      events: [{ id: 27, type: "message", message: makePrivateMessage(2124) }],
+    }];
+    await runMonitorOnce();
+    expect(state.updateZulipMessageFlags).not.toHaveBeenCalled();
+
+    state.account.config.dmPolicy = "open";
+    const handled = makePrivateMessage(2127);
+    state.pollResponses = [{
+      result: "success",
+      events: [{ id: 28, type: "message", message: handled }],
+    }];
+    await runMonitorOnce();
+    expect(state.updateZulipMessageFlags).toHaveBeenCalledTimes(1);
+
+    state.pollResponses = [{
+      result: "success",
+      events: [{ id: 29, type: "message", message: handled }],
+    }];
+    await runMonitorOnce();
+    expect(state.updateZulipMessageFlags).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps mark-read failure observable without replaying a completed reply", async () => {
+    enableDurableInboundJournal();
+    state.account.config.markHandledRead = true;
+    state.updateZulipMessageFlags.mockRejectedValueOnce(new Error("synthetic mark-read failure"));
+    const runtimeError = vi.fn();
+    state.pollResponses = [{
+      result: "success",
+      events: [{ id: 31, type: "message", message: makePrivateMessage(2125) }],
+    }];
+
+    await runMonitorOnce(new AbortController(), {
+      log: vi.fn(),
+      error: runtimeError,
+      exit: vi.fn(),
+    });
+
+    expect(runtimeError).toHaveBeenCalledWith(
+      "zulip: failed to mark handled inbound message 2125 read: Error: synthetic mark-read failure",
+    );
+    const queue = state.durableQueues.get(state.account.accountId);
+    expect(queue?.listPending).toHaveBeenCalled();
+    await expect(queue?.listPending()).resolves.toEqual([]);
+
+    await runMonitorOnce();
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+    expect(state.updateZulipMessageFlags).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks read once after completion-only retry succeeds without redispatch", async () => {
+    enableDurableInboundJournal({ queueCompletionFailures: 1 });
+    state.account.config.markHandledRead = true;
+    state.autoAbort = false;
+    const controller = new AbortController();
+    state.pollResponses = [{
+      result: "success",
+      events: [{ id: 30, type: "message", message: makePrivateMessage(2126) }],
+    }];
+
+    const monitorPromise = runMonitorOnce(controller);
+    await vi.waitFor(() => {
+      const queue = state.durableQueues.get(state.account.accountId);
+      expect(queue?.complete).toHaveBeenCalledTimes(2);
+      expect(state.updateZulipMessageFlags).toHaveBeenCalledTimes(1);
+    });
+    controller.abort();
+    await monitorPromise;
+
+    expect(state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+    expect(state.updateZulipMessageFlags).toHaveBeenCalledExactlyOnceWith(state.client, {
+      messageIds: ["2126"],
+      flag: "read",
+      op: "add",
+    });
+  });
+
   it("commits edited placeholder error feedback and does not replay it", async () => {
     enableDurableInboundJournal();
     state.account.config.thinkingPlaceholder = { enabled: true, errorText: "Turn failed." };
@@ -3005,6 +3175,7 @@ describe("monitorZulipProvider", () => {
 
   it("completes durable inbound after a visible partial reply even when final delivery fails", async () => {
     enableDurableInboundJournal();
+    state.account.config.markHandledRead = true;
     state.account.config.reactions = { enabled: true, clearOnFinish: false };
     state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
       async ({ dispatcherOptions }) => {
@@ -3039,6 +3210,7 @@ describe("monitorZulipProvider", () => {
     expect(
       state.core.channel.reply.dispatchReplyWithBufferedBlockDispatcher,
     ).toHaveBeenCalledTimes(1);
+    expect(state.updateZulipMessageFlags).not.toHaveBeenCalled();
   });
 
   it("keeps durable journal store caps below the plugin state row limit", async () => {

--- a/src/zulip/monitor.test.ts
+++ b/src/zulip/monitor.test.ts
@@ -2931,11 +2931,11 @@ describe("monitorZulipProvider", () => {
   it("does not mark unauthorized, duplicate, or already-read messages newly read", async () => {
     enableDurableInboundJournal();
     state.account.config.markHandledRead = true;
-    const alreadyRead = { ...makeChannelMessage(2123), flags: ["read"] };
+    const alreadyRead = makeChannelMessage(2123);
 
     state.pollResponses = [{
       result: "success",
-      events: [{ id: 26, type: "message", message: alreadyRead }],
+      events: [{ id: 26, type: "message", message: alreadyRead, flags: ["read"] }],
     }];
     await runMonitorOnce();
     expect(state.updateZulipMessageFlags).not.toHaveBeenCalled();

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -2070,11 +2070,14 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
           }
 
           if (event.type === "message" && event.message) {
+            const inboundMessage = event.flags
+              ? { ...event.message, flags: [...event.flags] }
+              : event.message;
             let streamResolution: InboundStreamResolution;
             try {
               streamResolution = {
                 ok: true,
-                decision: await resolveInboundStreamDecision(event.message),
+                decision: await resolveInboundStreamDecision(inboundMessage),
               };
             } catch (error) {
               streamResolution = { ok: false, error };
@@ -2087,13 +2090,13 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
               if (streamDecision && !streamDecision.accepted) {
                 logRejectedStreamDecision(
                   streamDecision,
-                  event.message.sender_email?.trim() || String(event.message.sender_id ?? ""),
+                  inboundMessage.sender_email?.trim() || String(inboundMessage.sender_id ?? ""),
                 );
                 continue;
               }
             }
             // Start processing without awaiting (fire-and-forget with error handling)
-            const messageTask = processMessage(event.message, validEventId, streamResolution).catch(
+            const messageTask = processMessage(inboundMessage, validEventId, streamResolution).catch(
               (err) => {
                 runtime.error?.(`zulip: message processing failed: ${String(err)}`);
               },

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -389,6 +389,13 @@ const HANDLED_INBOUND_MESSAGE = Symbol("handled-inbound-message");
 const activeMonitorReactionCleanups = new Set<() => Promise<void>>();
 let monitorReactionShutdownStarted = false;
 
+function logHandledReadDiagnostic(event: string): void {
+  if (process.env.ZULIP_HANDLED_READ_DIAGNOSTICS !== "1") {
+    return;
+  }
+  process.stderr.write(`ZULIP_HANDLED_READ_DIAGNOSTIC event=${event}\n`);
+}
+
 export function startZulipMonitorReactionLifecycles(): void {
   monitorReactionShutdownStarted = false;
 }
@@ -1615,19 +1622,25 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
 
   const markHandledInboundMessageRead = async (message: ZulipMessage): Promise<void> => {
     if (account.config.markHandledRead !== true) {
+      logHandledReadDiagnostic("disabled");
       return;
     }
     const messageId = String(message.id ?? "");
     if (!messageId) {
+      logHandledReadDiagnostic("missing_id");
       return;
     }
     if (message.flags?.includes("read")) {
+      logHandledReadDiagnostic("already_read");
       return;
     }
     try {
+      logHandledReadDiagnostic("attempted");
       await handledReadBatcher.markRead(messageId);
+      logHandledReadDiagnostic("succeeded");
       logVerboseMessage(`zulip: marked handled inbound message ${messageId} read`);
     } catch (err) {
+      logHandledReadDiagnostic("failed");
       runtime.error?.(`zulip: failed to mark handled inbound message ${messageId} read: ${String(err)}`);
     }
   };
@@ -1678,6 +1691,9 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         return "pending-delivery";
       }
       if (manageDurableRecord) {
+        logHandledReadDiagnostic(
+          outcome === HANDLED_INBOUND_MESSAGE ? "delivery_handled" : "delivery_unhandled",
+        );
         try {
           await completeDurableInboundMessage(durableId, metadata);
         } catch (err) {

--- a/src/zulip/monitor.ts
+++ b/src/zulip/monitor.ts
@@ -35,6 +35,7 @@ import {
   removeZulipReaction,
   editZulipMessage,
   deleteZulipMessage,
+  createZulipReadBatcher,
   type ZulipMessage,
   type ZulipStream,
   type ZulipSubscription,
@@ -384,6 +385,7 @@ async function saveZulipMediaBuffer(params: {
 const ABORTED_INBOUND_MESSAGE = Symbol("aborted-inbound-message");
 const RETRYABLE_INBOUND_MESSAGE = Symbol("retryable-inbound-message");
 const RETRYABLE_STREAM_POLICY = Symbol("retryable-stream-policy");
+const HANDLED_INBOUND_MESSAGE = Symbol("handled-inbound-message");
 const activeMonitorReactionCleanups = new Set<() => Promise<void>>();
 let monitorReactionShutdownStarted = false;
 
@@ -1561,7 +1563,10 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     }
 
     opts.statusSink?.({ lastInboundAt: Date.now() });
-    return retryableNoDelivery ? RETRYABLE_INBOUND_MESSAGE : undefined;
+    if (retryableNoDelivery) {
+      return RETRYABLE_INBOUND_MESSAGE;
+    }
+    return terminalError ? undefined : HANDLED_INBOUND_MESSAGE;
   };
 
   // Register event queue
@@ -1606,6 +1611,26 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         : undefined,
     );
   };
+  const handledReadBatcher = createZulipReadBatcher(client);
+
+  const markHandledInboundMessageRead = async (message: ZulipMessage): Promise<void> => {
+    if (account.config.markHandledRead !== true) {
+      return;
+    }
+    const messageId = String(message.id ?? "");
+    if (!messageId) {
+      return;
+    }
+    if (message.flags?.includes("read")) {
+      return;
+    }
+    try {
+      await handledReadBatcher.markRead(messageId);
+      logVerboseMessage(`zulip: marked handled inbound message ${messageId} read`);
+    } catch (err) {
+      runtime.error?.(`zulip: failed to mark handled inbound message ${messageId} read: ${String(err)}`);
+    }
+  };
 
   const deliverDurableInboundMessage = async (
     durableId: string | undefined,
@@ -1617,7 +1642,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       acceptInbound?: () => Promise<boolean>;
       durableAccepted?: () => boolean;
     } = {},
-  ): Promise<"settled" | "pending-delivery" | "pending-completion"> => {
+  ): Promise<"settled" | "pending-delivery" | "pending-completion" | "pending-completion-handled"> => {
     try {
       const outcome = await handleMessage(message, {
         skipRecentDedupe: options.replay,
@@ -1657,7 +1682,12 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
           await completeDurableInboundMessage(durableId, metadata);
         } catch (err) {
           runtime.error?.(`zulip: durable inbound completion failed: ${String(err)}`);
-          return "pending-completion";
+          return outcome === HANDLED_INBOUND_MESSAGE
+            ? "pending-completion-handled"
+            : "pending-completion";
+        }
+        if (outcome === HANDLED_INBOUND_MESSAGE) {
+          await markHandledInboundMessageRead(message);
         }
       }
       return "settled";
@@ -1686,6 +1716,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
 
   const deferredDurableReplayIds = new Set<string>();
   const deferredDurableCompletionIds = new Set<string>();
+  const deferredDurableHandledIds = new Set<string>();
   const deferredDurableRetryState = new Map<
     string,
     { delayMs: number; nextAttemptAt: number }
@@ -1762,9 +1793,19 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
           const pending = await durableInboundJournal.pending();
           const record = pending.find((entry) => entry.id === durableId);
           if (record) {
-            let disposition: "settled" | "pending-delivery" | "pending-completion";
+            let disposition:
+              | "settled"
+              | "pending-delivery"
+              | "pending-completion"
+              | "pending-completion-handled";
             if (deferredDurableCompletionIds.has(durableId)) {
               await completeDurableInboundMessage(record.id, record.metadata);
+              if (deferredDurableHandledIds.has(durableId)) {
+                const payload = record.payload as ZulipDurableInboundPayload;
+                await markHandledInboundMessageRead(
+                  deserializeZulipDurableInboundMessage<ZulipMessage>(payload.message),
+                );
+              }
               disposition = "settled";
             } else {
               const payload = record.payload as ZulipDurableInboundPayload;
@@ -1776,8 +1817,14 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
               );
             }
             if (disposition !== "settled") {
-              if (disposition === "pending-completion") {
+              if (
+                disposition === "pending-completion" ||
+                disposition === "pending-completion-handled"
+              ) {
                 deferredDurableCompletionIds.add(durableId);
+                if (disposition === "pending-completion-handled") {
+                  deferredDurableHandledIds.add(durableId);
+                }
               }
               deferDurableReplayRetry(durableId);
               continue;
@@ -1785,6 +1832,7 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
           }
           deferredDurableReplayIds.delete(durableId);
           deferredDurableCompletionIds.delete(durableId);
+          deferredDurableHandledIds.delete(durableId);
           deferredDurableRetryState.delete(durableId);
         } catch (err) {
           runtime.error?.(`zulip: deferred durable replay failed: ${String(err)}`);
@@ -1810,8 +1858,11 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
     wakeDeferredDurableReplay?.();
     startDeferredDurableReplay();
   };
-  const schedulePendingDurableCompletion = (durableId: string) => {
+  const schedulePendingDurableCompletion = (durableId: string, handled: boolean) => {
     deferredDurableCompletionIds.add(durableId);
+    if (handled) {
+      deferredDurableHandledIds.add(durableId);
+    }
     schedulePendingDurableReplay(durableId);
   };
 
@@ -1896,8 +1947,14 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
       acceptInbound,
       durableAccepted: () => durableAccepted,
     });
-    if (disposition === "pending-completion" && durableId) {
-      schedulePendingDurableCompletion(durableId);
+    if (
+      (disposition === "pending-completion" || disposition === "pending-completion-handled") &&
+      durableId
+    ) {
+      schedulePendingDurableCompletion(
+        durableId,
+        disposition === "pending-completion-handled",
+      );
     }
   };
 
@@ -1922,8 +1979,14 @@ export async function monitorZulipProvider(opts: MonitorZulipOpts = {}): Promise
         record.metadata,
         { replay: true },
       );
-      if (disposition === "pending-completion") {
-        schedulePendingDurableCompletion(record.id);
+      if (
+        disposition === "pending-completion" ||
+        disposition === "pending-completion-handled"
+      ) {
+        schedulePendingDurableCompletion(
+          record.id,
+          disposition === "pending-completion-handled",
+        );
       }
     }
   };


### PR DESCRIPTION
Closes #27.

## Summary

- add the conservative, account-level `markHandledRead` opt-in
- mark DMs and stream/topic messages read only after successful dispatch settlement and durable receive completion
- retain handled eligibility across completion-only retries without redispatching replies
- safely batch account-local Zulip read-flag updates and keep API failures observable but non-fatal
- honor Zulip's top-level event flags so already-read messages remain no-ops
- prove the unread-to-read transition in the protected durable live smoke

## Validation

- OpenClaw 2026.7.1-2: build; 17 Vitest files / 304 tests; 64 offline smoke tests
- OpenClaw 2026.8.1: build; 17 Vitest files / 304 tests; 64 offline smoke tests
- Node 22.19.0 and Node 24 CI passed
- Cursor Bugbot passed; its event-flags finding was fixed in `4c18bc2`
- hosted Codex code and security reviews passed on exact head `4c18bc2e668dd17b33dff7e8a14e48552d94d3bb`
- independent read-only review of the exact head: no findings
- protected live smoke passed all eight scenarios on exact head: https://github.com/FtlC-ian/openclaw-channel-zulip/actions/runs/33461846648
- `git diff --check`

The protected run used plugin `2026.5.26` with OpenClaw `2026.7.1-2` and proved the durable command remained unread before interruption, then became read only after the replacement reply and durable completion.

The local Codex review loop could not authenticate to its API (401); hosted Codex code and security reviews supplied the final hosted review evidence.
