### PR TITLE
Fix Zulip action capability contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 ### Compatibility
 - **OpenClaw 2026.8.1 compatibility**: Use the shared ingress queue and typed media-runtime SDK surfaces while retaining OpenClaw 2026.7.1-2 as the minimum supported host, draining legacy durable records, and keeping command access-group checks enabled.
 
+### Security
+- **Action capability contract**: Make advertised, schema-described, and handled message actions share one allowlist; remove unreachable provider-specific admin handlers; reject hidden and unadvertised actions before credential or network access; and document the upstream SDK blocker in a checked-in capability matrix.
+
 ## 2026.5.26
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - **OpenClaw 2026.8.1 compatibility**: Use the shared ingress queue and typed media-runtime SDK surfaces while retaining OpenClaw 2026.7.1-2 as the minimum supported host, draining legacy durable records, and keeping command access-group checks enabled.
 
 ### Security
-- **Action capability contract**: Make advertised, schema-described, and handled message actions share one allowlist; remove unreachable provider-specific admin handlers; reject hidden and unadvertised actions before credential or network access; and document the upstream SDK blocker in a checked-in capability matrix.
+- **Action capability contract**: Make advertised, schema-described, and handled message actions share one allowlist; remove unreachable provider-specific admin handlers; reject hidden and unadvertised actions before credential or network access; and document the closed shared-action boundary plus plugin-owned agent-tool alternative in a checked-in capability matrix.
 
 ## 2026.5.26
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Add the plugin id to `plugins.allow` in `~/.openclaw/openclaw.json`:
       },
 
       // Legacy compatibility field. Accepted but intentionally has no runtime effect.
-      // Provider-specific admin actions require an upstream OpenClaw SDK extension.
+      // Provider-specific operations need a separately reviewed Zulip-owned agent tool.
       "enableAdminActions": false,
 
       // Multi-account: uncomment to run multiple bots

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # openclaw-channel-zulip
 
-> Zulip channel plugin for [OpenClaw](https://github.com/openclaw/openclaw) — concurrent message processing, native session conversation binding, file uploads, approval hooks, and full actions API.
+> Zulip channel plugin for [OpenClaw](https://github.com/openclaw/openclaw) — concurrent message processing, native session conversation binding, file uploads, approval hooks, and native message actions.
 
 [![npm version](https://img.shields.io/npm/v/openclaw-channel-zulip.svg)](https://www.npmjs.com/package/openclaw-channel-zulip)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -12,7 +12,7 @@
 - ✅ **Concurrent message processing** — events fire-and-forget with staggered start times (200 ms apart), so a burst of incoming messages is handled in parallel rather than queued sequentially
 - ✅ **Native session conversation binding** — stream topics resolve through the SDK session-conversation hook instead of hand-rolled session key grammar
 - ✅ **File uploads** — inbound Zulip file attachments are downloaded and forwarded to the AI pipeline; outbound media is uploaded via Zulip's file upload API
-- ✅ **Full actions API** — react, edit, delete, archive, move messages/topics; subscribe/unsubscribe streams; user management (requires `enableAdminActions: true`)
+- ✅ **Native message actions** — send, read, search, react, edit, delete/unsend, pin/unpin, polls, member lookup, and stream list/create/edit/delete with an [audited capability matrix](docs/ACTION_CAPABILITIES.md)
 - ✅ **Topic directives** — reply topics can be scoped per-message, enabling organized thread-based conversations
 - ✅ **Multi-account support** — run multiple Zulip bot accounts in one OpenClaw instance via the `accounts` map
 - ✅ **DM & channel policies** — open / pairing / allowlist / disabled per account
@@ -195,7 +195,8 @@ Add the plugin id to `plugins.allow` in `~/.openclaw/openclaw.json`:
         "idleMs": 1000
       },
 
-      // Enable admin-level actions (move/archive streams, manage users)
+      // Legacy compatibility field. Accepted but intentionally has no runtime effect.
+      // Provider-specific admin actions require an upstream OpenClaw SDK extension.
       "enableAdminActions": false,
 
       // Multi-account: uncomment to run multiple bots

--- a/docs/ACTION_CAPABILITIES.md
+++ b/docs/ACTION_CAPABILITIES.md
@@ -1,0 +1,43 @@
+# Zulip message action capabilities
+
+This matrix is the checked-in contract for the shared OpenClaw `message` tool.
+`src/actions.ts` owns the advertised list, action-scoped schema contributions,
+and plugin-handler allowlist so those surfaces cannot silently diverge.
+
+| Action | Owner | Target mode | Authorization | Confirmation | Dry run | Coverage |
+| --- | --- | --- | --- | --- | --- | --- |
+| `send` | plugin | `to` | configured account credential | no | yes | action and outbound tests |
+| `read` | plugin | `to` | configured account credential | no | host read-only | action tests |
+| `channel-list` | plugin | none | configured account credential | no | host read-only | action tests |
+| `channel-create` | plugin | none | Zulip credential permission | no | yes | action tests |
+| `channel-edit` | plugin | `channelId` | Zulip credential permission | no | yes | action tests |
+| `channel-delete` | plugin | `channelId` | Zulip credential permission | `confirm: true` | yes | action tests |
+| `react` | plugin | `to` | Zulip credential permission | no | yes | action tests |
+| `edit` | plugin | `to` | Zulip credential permission | no | yes | action tests |
+| `delete` | plugin | `to` | Zulip credential permission | `confirm: true` | yes | action tests |
+| `unsend` | plugin alias for `delete` | `to` | Zulip credential permission | `confirm: true` | yes | action tests |
+| `search` | plugin | none | configured account credential | no | host read-only | action tests |
+| `member-info` | plugin | none | configured account credential | no | host read-only | action tests |
+| `pin` | plugin | `to` | Zulip credential permission | no | yes | action tests |
+| `unpin` | plugin | `to` | Zulip credential permission | no | yes | action tests |
+| `poll` | OpenClaw core via `outbound.sendPoll` | `to` | configured account credential | no | host-owned | channel/outbound tests |
+
+The adapter does not add a separate owner/trusted-requester gate to mutable
+actions. Zulip applies the permissions of the selected bot credential. The
+three destructive actions additionally require the exact boolean
+`confirm: true` before any Zulip request.
+
+## Blocked provider-specific actions
+
+The former `channel-subscribe`, `invite`, `resolve-topic`, `user-presence`,
+`user-deactivate`, `user-reactivate`, `org-settings`, and `org-settings-edit`
+handlers were unreachable through OpenClaw's public message-action contract.
+They are no longer implemented or directly dispatchable. OpenClaw currently
+uses a closed action-name union and fixed target-mode map, so a plugin cannot
+advertise or route those provider-specific names. The upstream SDK request and
+minimal reproduction are tracked in
+[openclaw/openclaw#134666](https://github.com/openclaw/openclaw/issues/134666).
+
+`enableAdminActions` remains accepted as an inert legacy configuration field so
+existing strict configurations continue to load. It does not expose hidden
+actions and can be removed after a documented configuration migration.

--- a/docs/ACTION_CAPABILITIES.md
+++ b/docs/ACTION_CAPABILITIES.md
@@ -27,16 +27,19 @@ actions. Zulip applies the permissions of the selected bot credential. The
 three destructive actions additionally require the exact boolean
 `confirm: true` before any Zulip request.
 
-## Blocked provider-specific actions
+## Removed provider-specific actions
 
 The former `channel-subscribe`, `invite`, `resolve-topic`, `user-presence`,
 `user-deactivate`, `user-reactivate`, `org-settings`, and `org-settings-edit`
-handlers were unreachable through OpenClaw's public message-action contract.
-They are no longer implemented or directly dispatchable. OpenClaw currently
-uses a closed action-name union and fixed target-mode map, so a plugin cannot
-advertise or route those provider-specific names. The upstream SDK request and
-minimal reproduction are tracked in
-[openclaw/openclaw#134666](https://github.com/openclaw/openclaw/issues/134666).
+handlers were unreachable through OpenClaw's shared `message` action contract.
+They are no longer implemented or directly dispatchable. OpenClaw deliberately
+keeps that cross-channel action vocabulary closed and directs provider-specific
+operations to plugin-owned agent tools with their own schemas and target
+semantics. The extension request and minimal reproduction were
+[closed by design](https://github.com/openclaw/openclaw/issues/134666#issuecomment-5488003013).
+Future Zulip-specific operations must use a separately reviewed Zulip-owned
+agent tool or remain removed; they must not be hidden behind string casts in the
+shared adapter.
 
 `enableAdminActions` remains accepted as an inert legacy configuration field so
 existing strict configurations continue to load. It does not expose hidden

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -276,7 +276,7 @@
         },
         "enableAdminActions": {
           "label": "Legacy Admin Actions Flag",
-          "description": "Accepted for configuration compatibility but intentionally inert until OpenClaw supports plugin-defined action names and target modes."
+          "description": "Accepted for configuration compatibility but intentionally inert; provider-specific operations need a separately reviewed Zulip-owned agent tool."
         },
         "reactions.enabled": {
           "label": "Lifecycle Reaction Indicators"
@@ -332,7 +332,7 @@
     },
     "enableAdminActions": {
       "label": "Legacy Admin Actions Flag",
-      "description": "Accepted for configuration compatibility but intentionally inert until OpenClaw supports plugin-defined action names and target modes."
+      "description": "Accepted for configuration compatibility but intentionally inert; provider-specific operations need a separately reviewed Zulip-owned agent tool."
     },
     "reactions.enabled": {
       "label": "Lifecycle Reaction Indicators"

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -274,6 +274,10 @@
           "label": "Mark Successfully Handled Messages Read",
           "description": "Opt in to marking an inbound message read only after successful dispatch settlement and durable receive completion."
         },
+        "enableAdminActions": {
+          "label": "Legacy Admin Actions Flag",
+          "description": "Accepted for configuration compatibility but intentionally inert until OpenClaw supports plugin-defined action names and target modes."
+        },
         "reactions.enabled": {
           "label": "Lifecycle Reaction Indicators"
         },
@@ -325,6 +329,10 @@
     },
     "requireMention": {
       "label": "Require @mention in Streams"
+    },
+    "enableAdminActions": {
+      "label": "Legacy Admin Actions Flag",
+      "description": "Accepted for configuration compatibility but intentionally inert until OpenClaw supports plugin-defined action names and target modes."
     },
     "reactions.enabled": {
       "label": "Lifecycle Reaction Indicators"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openclaw-channel-zulip",
   "version": "2026.5.26",
-  "description": "Zulip channel plugin for OpenClaw \u2014 concurrent message processing, file uploads, approval hooks, and full actions API",
+  "description": "Zulip channel plugin for OpenClaw \u2014 concurrent message processing, file uploads, approval hooks, and native message actions",
   "type": "module",
   "author": "FtlC-ian",
   "license": "MIT",

--- a/src/actions.test.ts
+++ b/src/actions.test.ts
@@ -1,9 +1,22 @@
 import type { OpenClawConfig } from "./sdk.js";
 import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
-import { splitStreamTarget, zulipMessageActions } from "./actions.js";
+import {
+  splitStreamTarget,
+  ZULIP_ADVERTISED_ACTIONS,
+  zulipMessageActions,
+} from "./actions.js";
 
 type CoreAction = Parameters<NonNullable<typeof zulipMessageActions.handleAction>>[0]["action"];
-type AnyAction = CoreAction | "user-deactivate" | "org-settings-edit";
+type HiddenAction =
+  | "channel-subscribe"
+  | "invite"
+  | "resolve-topic"
+  | "user-presence"
+  | "user-deactivate"
+  | "user-reactivate"
+  | "org-settings"
+  | "org-settings-edit";
+type AnyAction = CoreAction | HiddenAction;
 type FetchMock = Mock<typeof fetch>;
 
 function jsonResponse(body: unknown): Response {
@@ -47,7 +60,12 @@ afterEach(() => {
 async function runAction(
   action: AnyAction,
   params: Record<string, unknown>,
-  options?: { dryRun?: boolean; fetchImpl?: FetchMock },
+  options?: {
+    accountId?: string;
+    cfg?: OpenClawConfig;
+    dryRun?: boolean;
+    fetchImpl?: FetchMock;
+  },
 ) {
   const fetchImpl =
     options?.fetchImpl ??
@@ -56,7 +74,8 @@ async function runAction(
   const result = await zulipMessageActions.handleAction?.({
     channel: "zulip",
     action: action as CoreAction,
-    cfg,
+    cfg: options?.cfg ?? cfg,
+    accountId: options?.accountId,
     params,
     dryRun: options?.dryRun,
   });
@@ -73,20 +92,12 @@ async function expectRejectedWithoutFetch(
 }
 
 describe("destructive action confirmation", () => {
-  it("rejects delete without confirm", async () => {
-    await expectRejectedWithoutFetch("delete", { messageId: "123" });
+  it.each(["delete", "unsend"] as const)("rejects %s without confirm", async (action) => {
+    await expectRejectedWithoutFetch(action, { messageId: "123" });
   });
 
   it("rejects channel-delete without confirm", async () => {
     await expectRejectedWithoutFetch("channel-delete", { streamId: "general" });
-  });
-
-  it("rejects user-deactivate without confirm", async () => {
-    await expectRejectedWithoutFetch("user-deactivate", { userId: "42" });
-  });
-
-  it("rejects org-settings-edit without confirm", async () => {
-    await expectRejectedWithoutFetch("org-settings-edit", { settings: { name: "X" } });
   });
 
   it("rejects delete when confirm is false", async () => {
@@ -98,16 +109,20 @@ describe("destructive action confirmation", () => {
   });
 
   it("scopes the confirmation schema to advertised destructive actions", () => {
-    expect(zulipMessageActions.describeMessageTool({ cfg })).toMatchObject({
-      schema: {
-        actions: ["channel-delete", "delete"],
-        properties: { confirm: { type: "boolean" } },
-      },
-    });
+    const discovery = zulipMessageActions.describeMessageTool({ cfg });
+    expect(discovery?.schema).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          actions: ["channel-delete", "delete", "unsend"],
+          properties: { confirm: expect.objectContaining({ type: "boolean" }) },
+        }),
+      ]),
+    );
   });
 
   it.each([
     ["delete", { messageId: "123", confirm: true }],
+    ["unsend", { messageId: "123", confirm: true }],
     ["channel-delete", { streamId: "general", confirm: true }],
   ] as const)("does not send Zulip requests for %s dry runs", async (action, params) => {
     const fetchImpl = vi.fn<typeof fetch>();
@@ -116,44 +131,20 @@ describe("destructive action confirmation", () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
-  it.each([
-    ["user-deactivate", { userId: "42", confirm: true }],
-    ["org-settings-edit", { settings: { name: "X" }, confirm: true }],
-  ] as const)("does not send Zulip requests for hidden %s dry runs", async (action, params) => {
-    const adminCfg: OpenClawConfig = {
-      channels: {
-        zulip: {
-          apiKey: "secret",
-          email: "bot@example.test",
-          url: "https://zulip.example.test",
-          enableAdminActions: true,
-        },
-      },
-    };
-    const fetchImpl = vi.fn<typeof fetch>();
-    vi.stubGlobal("fetch", fetchImpl);
-    const result = await zulipMessageActions.handleAction?.({
-      channel: "zulip",
-      action: action as CoreAction,
-      cfg: adminCfg,
-      params,
-      dryRun: true,
-    });
-    expect(result?.details).toMatchObject({ ok: true, dryRun: true, action });
-    expect(fetchImpl).not.toHaveBeenCalled();
-  });
-
-  it("succeeds delete when confirm is true and all other gates pass", async () => {
-    const { result, fetchImpl } = await runAction("delete", {
-      messageId: "123",
-      confirm: true,
-    });
-    expect(result?.details).toMatchObject({ ok: true, deleted: "123" });
-    expect(fetchImpl).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchImpl.mock.calls[0] ?? [];
-    expect(String(url)).toContain("/messages/123");
-    expect(init?.method).toBe("DELETE");
-  });
+  it.each(["delete", "unsend"] as const)(
+    "succeeds %s when confirm is true and all other gates pass",
+    async (action) => {
+      const { result, fetchImpl } = await runAction(action, {
+        messageId: "123",
+        confirm: true,
+      });
+      expect(result?.details).toMatchObject({ ok: true, deleted: "123" });
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchImpl.mock.calls[0] ?? [];
+      expect(String(url)).toContain("/messages/123");
+      expect(init?.method).toBe("DELETE");
+    },
+  );
 
   it("succeeds channel-delete when confirm is true and all other gates pass", async () => {
     const fetchImpl = vi
@@ -176,97 +167,171 @@ describe("destructive action confirmation", () => {
     expect(result?.details).toMatchObject({ ok: true, streamId: "7" });
   });
 
-  it("cannot bypass admin check via confirmation on user-deactivate", async () => {
-    const adminCfg: OpenClawConfig = {
-      channels: {
-        zulip: {
-          apiKey: "secret",
-          email: "bot@example.test",
-          url: "https://zulip.example.test",
-          enableAdminActions: true,
-        },
-      },
-    };
-    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
-      jsonResponse({
-        result: "success",
-        user: { user_id: 1, is_admin: false },
-      }),
-    );
-    vi.stubGlobal("fetch", fetchImpl);
-    await expect(
-      zulipMessageActions.handleAction?.({
-        channel: "zulip",
-        action: "user-deactivate" as CoreAction,
-        cfg: adminCfg,
-        params: { userId: "42", confirm: true },
-      }),
-    ).rejects.toThrow("admin privileges");
-  });
-
-  it("cannot bypass enableAdminActions via confirmation on org-settings-edit", async () => {
-    const lockedCfg: OpenClawConfig = {
-      channels: {
-        zulip: {
-          apiKey: "secret",
-          email: "bot@example.test",
-          url: "https://zulip.example.test",
-          enableAdminActions: false,
-        },
-      },
-    };
-    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
-      jsonResponse({ result: "success", user: { user_id: 1, is_admin: true } }),
-    );
-    vi.stubGlobal("fetch", fetchImpl);
-    await expect(
-      zulipMessageActions.handleAction?.({
-        channel: "zulip",
-        action: "org-settings-edit" as CoreAction,
-        cfg: lockedCfg,
-        params: { settings: { name: "X" }, confirm: true },
-      }),
-    ).rejects.toThrow("enableAdminActions");
-  });
-
-  it("cannot bypass enableAdminActions via confirmation on user-deactivate", async () => {
+  it.each<HiddenAction>([
+    "channel-subscribe",
+    "invite",
+    "resolve-topic",
+    "user-presence",
+    "user-deactivate",
+    "user-reactivate",
+    "org-settings",
+    "org-settings-edit",
+  ])("rejects hidden action %s before calling Zulip", async (action) => {
     const fetchImpl = vi.fn<typeof fetch>();
-    vi.stubGlobal("fetch", fetchImpl);
+    await expect(runAction(action, {}, { fetchImpl })).rejects.toThrow(
+      `Action ${action} is not supported`,
+    );
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe("action capability consistency", () => {
+  it("advertises the shared action list and supports exactly plugin-handled actions", () => {
+    expect(zulipMessageActions.describeMessageTool({ cfg }).actions).toEqual(
+      ZULIP_ADVERTISED_ACTIONS,
+    );
+    for (const action of ZULIP_ADVERTISED_ACTIONS) {
+      expect(zulipMessageActions.supportsAction?.({ action })).toBe(action !== "poll");
+    }
+  });
+
+  it.each(["ban", "rename-group", "set-group-icon"] as CoreAction[])(
+    "does not claim unadvertised canonical action %s",
+    (action) => {
+      expect(zulipMessageActions.supportsAction?.({ action })).toBe(false);
+    },
+  );
+
+  it("rejects the core-owned poll action before credential or network access", async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
     await expect(
-      zulipMessageActions.handleAction?.({
-        channel: "zulip",
-        action: "user-deactivate" as CoreAction,
-        cfg,
-        params: { userId: "42", confirm: true },
-      }),
-    ).rejects.toThrow("enableAdminActions");
+      runAction("poll", {}, { cfg: {}, fetchImpl }),
+    ).rejects.toThrow("Action poll is not supported");
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
-  it("cannot bypass Zulip admin check via confirmation on org-settings-edit", async () => {
-    const adminCfg: OpenClawConfig = {
+  it("discovers actions for the requested configured account", () => {
+    const namedAccountConfig: OpenClawConfig = {
       channels: {
         zulip: {
-          apiKey: "secret",
-          email: "bot@example.test",
-          url: "https://zulip.example.test",
-          enableAdminActions: true,
+          accounts: {
+            primary: {
+              apiKey: "named-secret",
+              email: "named@example.test",
+              url: "https://named.example.test",
+            },
+          },
         },
       },
     };
-    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
-      jsonResponse({ result: "success", user: { user_id: 1, is_admin: false } }),
+    expect(
+      zulipMessageActions.describeMessageTool({
+        cfg: namedAccountConfig,
+        accountId: "primary",
+      }).actions,
+    ).toEqual(ZULIP_ADVERTISED_ACTIONS);
+    expect(zulipMessageActions.describeMessageTool({ cfg: namedAccountConfig }).actions).toEqual(
+      [],
     );
-    vi.stubGlobal("fetch", fetchImpl);
-    await expect(
-      zulipMessageActions.handleAction?.({
-        channel: "zulip",
-        action: "org-settings-edit" as CoreAction,
-        cfg: adminCfg,
-        params: { settings: { name: "X" }, confirm: true },
+  });
+
+  it("contributes every Zulip-only handler parameter under its action scope", () => {
+    const discovery = zulipMessageActions.describeMessageTool({ cfg });
+    const contributions = Array.isArray(discovery?.schema) ? discovery.schema : [];
+    const propertiesFor = (action: CoreAction) =>
+      Object.assign(
+        {},
+        ...contributions
+          .filter((entry) => entry.actions?.includes(action))
+          .map((entry) => entry.properties),
+      ) as Record<string, unknown>;
+
+    expect(propertiesFor("channel-list")).toHaveProperty("includeAllPublic");
+    expect(propertiesFor("channel-create")).toMatchObject({
+      description: { type: "string" },
+      principals: { type: "array" },
+      announce: { type: "boolean" },
+      inviteOnly: { type: "boolean" },
+      isWebPublic: { type: "boolean" },
+      isDefaultStream: { type: "boolean" },
+      historyPublicToSubscribers: { type: "boolean" },
+    });
+    expect(propertiesFor("channel-edit")).toMatchObject({
+      description: { type: "string" },
+      newName: { type: "string" },
+      isPrivate: { type: "boolean" },
+      isWebPublic: { type: "boolean" },
+      isDefaultStream: { type: "boolean" },
+      historyPublicToSubscribers: { type: "boolean" },
+    });
+    expect(propertiesFor("react")).toMatchObject({
+      emojiCode: { type: "string" },
+      reactionType: { type: "string" },
+    });
+  });
+});
+
+describe("reachable action routes", () => {
+  it.each([
+    ["send", { to: "user:person@example.test", message: "hello" }],
+    ["channel-create", { name: "new-stream", description: "description" }],
+    ["channel-edit", { channelId: "7", newName: "renamed" }],
+    ["edit", { messageId: "123", message: "replacement" }],
+    ["pin", { messageId: "123" }],
+    ["unpin", { messageId: "123" }],
+  ] as const)("keeps %s dry runs network-free", async (action, params) => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    const { result } = await runAction(action, params, { dryRun: true, fetchImpl });
+    expect(result?.details).toMatchObject({ ok: true, dryRun: true, action });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["channel-list", { includeAllPublic: true }, "/users/me/subscriptions"],
+    ["read", { to: "stream:general:topic", limit: 3 }, "/messages?"],
+    ["member-info", { userId: "42" }, "/users/42"],
+    ["search", { query: "needle", stream: "general" }, "/messages?"],
+  ] as const)("routes %s to its Zulip read endpoint", async (action, params, path) => {
+    const fetchImpl = vi.fn<typeof fetch>().mockImplementation(async () =>
+      jsonResponse({
+        result: "success",
+        subscriptions: [],
+        streams: [],
+        messages: [],
+        user: { user_id: 42 },
       }),
-    ).rejects.toThrow("admin privileges");
-    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    );
+    const { result } = await runAction(action, params, { fetchImpl });
+    expect(result?.details).toMatchObject({ ok: true });
+    expect(String(fetchImpl.mock.calls[0]?.[0])).toContain(path);
+  });
+
+  it.each(["pin", "unpin"] as const)(
+    "rejects malformed %s message ids without truncating them",
+    async (action) => {
+      const fetchImpl = vi.fn<typeof fetch>();
+      await expect(runAction(action, { messageId: "123junk" }, { fetchImpl })).rejects.toThrow(
+        "Invalid messageId: 123junk",
+      );
+      expect(fetchImpl).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    ["send", { to: "user:person@example.test", message: "hello" }, "/messages", "POST"],
+    ["channel-create", { name: "new-stream", announce: true }, "/users/me/subscriptions", "POST"],
+    ["channel-edit", { channelId: "7", newName: "renamed" }, "/streams/7", "PATCH"],
+    ["edit", { messageId: "123", message: "replacement" }, "/messages/123", "PATCH"],
+    ["pin", { messageId: "123" }, "/messages/flags", "POST"],
+    ["unpin", { messageId: "123" }, "/messages/flags", "POST"],
+  ] as const)("routes %s mutations to the expected endpoint", async (action, params, path, method) => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockImplementation(async () => jsonResponse({ result: "success", id: 99 }));
+    await runAction(action, params, { fetchImpl });
+    const [url, init] = fetchImpl.mock.calls[0] ?? [];
+    expect(String(url)).toContain(path);
+    expect(init?.method).toBe(method);
   });
 });
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,6 +1,7 @@
 import type {
   ChannelMessageActionAdapter,
   ChannelMessageActionName,
+  ChannelMessageToolSchemaContribution,
   OpenClawConfig,
 } from "./sdk.js";
 import { jsonResult, normalizeMessagePresentation, readNumberParam, readStringParam } from "./sdk.js";
@@ -13,41 +14,136 @@ import {
   addZulipReaction,
   createZulipClient,
   createZulipStream,
-  deactivateZulipUser,
   deleteZulipMessage,
   deleteZulipStream,
   editZulipMessage,
   fetchZulipMemberInfo,
   fetchZulipMessages,
-  fetchZulipServerSettings,
   fetchZulipStreams,
   fetchZulipSubscriptions,
-  fetchZulipUserPresence,
-  inviteZulipUsersToStream,
   normalizeZulipBaseUrl,
-  reactivateZulipUser,
   removeZulipReaction,
   resolveZulipStreamId,
   searchZulipMessages,
   sendZulipPrivateMessage,
   sendZulipStreamMessage,
-  subscribeZulipStream,
   updateZulipMessageFlag,
-  updateZulipMessageTopic,
-  updateZulipRealm,
   updateZulipStream,
 } from "./zulip/client.js";
 import { presentationToZulipWidgetContent } from "./zulip/send.js";
 
 const providerId = "zulip";
 const MAX_STRING_LENGTH = 10000;
-const SAFE_REALM_SETTINGS = [
-  "name",
-  "description",
-  "default_language",
-  "notifications_stream_id",
-  "signup_notifications_stream_id",
-  "message_retention_days",
+export const ZULIP_ADVERTISED_ACTIONS = [
+  "send",
+  "read",
+  "channel-list",
+  "channel-create",
+  "channel-edit",
+  "channel-delete",
+  "react",
+  "edit",
+  "delete",
+  "unsend",
+  "search",
+  "member-info",
+  "pin",
+  "unpin",
+  "poll",
+] as const satisfies readonly ChannelMessageActionName[];
+
+const ZULIP_CORE_OWNED_ACTIONS = new Set<ChannelMessageActionName>(["poll"]);
+const ZULIP_HANDLED_ACTIONS = new Set<ChannelMessageActionName>(
+  ZULIP_ADVERTISED_ACTIONS.filter((action) => !ZULIP_CORE_OWNED_ACTIONS.has(action)),
+);
+const ZULIP_DESTRUCTIVE_ACTIONS = [
+  "channel-delete",
+  "delete",
+  "unsend",
+] as const satisfies readonly ChannelMessageActionName[];
+
+const ZULIP_ACTION_SCHEMA: ChannelMessageToolSchemaContribution[] = [
+  {
+    properties: {
+      confirm: { type: "boolean", description: "Set to true to confirm destructive actions." },
+    },
+    actions: ZULIP_DESTRUCTIVE_ACTIONS,
+    visibility: "current-channel" as const,
+  },
+  {
+    properties: {
+      includeAllPublic: {
+        type: "boolean",
+        description: "Include all public streams, not only subscriptions.",
+      },
+      includePublic: { type: "boolean" },
+      allPublic: { type: "boolean" },
+      all: { type: "boolean" },
+    },
+    actions: ["channel-list"] as const satisfies readonly ChannelMessageActionName[],
+    visibility: "current-channel" as const,
+  },
+  {
+    properties: {
+      description: { type: "string" },
+      principals: {
+        type: "array",
+        items: { anyOf: [{ type: "string" }, { type: "number" }] },
+      },
+      principal: {
+        anyOf: [
+          { type: "string" },
+          { type: "number" },
+          {
+            type: "array",
+            items: { anyOf: [{ type: "string" }, { type: "number" }] },
+          },
+        ],
+      },
+      announce: { type: "boolean" },
+      inviteOnly: { type: "boolean" },
+      invite_only: { type: "boolean" },
+      isPrivate: { type: "boolean" },
+      is_private: { type: "boolean" },
+      isWebPublic: { type: "boolean" },
+      is_web_public: { type: "boolean" },
+      isDefaultStream: { type: "boolean" },
+      is_default_stream: { type: "boolean" },
+      defaultStream: { type: "boolean" },
+      historyPublicToSubscribers: { type: "boolean" },
+      history_public_to_subscribers: { type: "boolean" },
+    },
+    actions: ["channel-create"] as const satisfies readonly ChannelMessageActionName[],
+    visibility: "current-channel" as const,
+  },
+  {
+    properties: {
+      description: { type: "string" },
+      newName: { type: "string" },
+      isPrivate: { type: "boolean" },
+      inviteOnly: { type: "boolean" },
+      invite_only: { type: "boolean" },
+      is_private: { type: "boolean" },
+      isWebPublic: { type: "boolean" },
+      is_web_public: { type: "boolean" },
+      isDefaultStream: { type: "boolean" },
+      is_default_stream: { type: "boolean" },
+      historyPublicToSubscribers: { type: "boolean" },
+      history_public_to_subscribers: { type: "boolean" },
+    },
+    actions: ["channel-edit"] as const satisfies readonly ChannelMessageActionName[],
+    visibility: "current-channel" as const,
+  },
+  {
+    properties: {
+      emojiCode: { type: "string" },
+      emoji_code: { type: "string" },
+      reactionType: { type: "string" },
+      reaction_type: { type: "string" },
+    },
+    actions: ["react"] as const satisfies readonly ChannelMessageActionName[],
+    visibility: "current-channel" as const,
+  },
 ];
 
 type StreamTarget = {
@@ -184,22 +280,9 @@ async function resolveZulipClient(cfg: OpenClawConfig, accountId?: string | null
   };
 }
 
-function requireAdminActionsEnabled(account: ReturnType<typeof resolveZulipAccount>): void {
-  if (!account.enableAdminActions) {
-    throw new Error("Admin actions require enableAdminActions: true in Zulip config");
-  }
-}
-
 function requireDestructiveConfirmation(params: Record<string, unknown>): void {
   if (params.confirm !== true) {
     throw new Error("This destructive action requires confirm: true.");
-  }
-}
-
-async function requireZulipAdmin(client: ReturnType<typeof createZulipClient>): Promise<void> {
-  const me = await fetchZulipMemberInfo(client, "me");
-  if (!me.is_admin) {
-    throw new Error("Zulip admin privileges are required for this action.");
   }
 }
 
@@ -353,20 +436,6 @@ function readSendMessageContent(params: Record<string, unknown>): string {
   return trimmed;
 }
 
-const resolvedTopicPrefixes = ["✔", "✅"];
-
-function resolveTopicName(topic: string): { topic: string; alreadyResolved: boolean } {
-  const trimmed = topic.trim();
-  if (!trimmed) {
-    return { topic: trimmed, alreadyResolved: false };
-  }
-  const alreadyResolved = resolvedTopicPrefixes.some((prefix) => trimmed.startsWith(prefix));
-  if (alreadyResolved) {
-    return { topic: trimmed, alreadyResolved: true };
-  }
-  return { topic: `✔ ${trimmed}`, alreadyResolved: false };
-}
-
 function parseBooleanValue(value: unknown): boolean | undefined {
   if (typeof value === "boolean") {
     return value;
@@ -445,136 +514,21 @@ function readStreamId(params: Record<string, unknown>): string {
   throw new Error("streamId is required for Zulip channel actions.");
 }
 
-function readUserIdParam(params: Record<string, unknown>): string {
-  const userId =
-    readStringParam(params, "userId") ??
-    readStringParam(params, "memberId") ??
-    readStringParam(params, "id") ??
-    readStringParam(params, "user");
-  if (userId) {
-    return userId;
-  }
-  const numericId =
-    readNumberParam(params, "userId", { integer: true }) ??
-    readNumberParam(params, "memberId", { integer: true }) ??
-    readNumberParam(params, "id", { integer: true });
-  if (typeof numericId === "number") {
-    return String(numericId);
-  }
-  throw new Error("userId is required for Zulip user actions.");
-}
-
-function readUserIdOrEmailParam(params: Record<string, unknown>): string {
-  const userIdOrEmail =
-    readStringParam(params, "userId") ??
-    readStringParam(params, "memberId") ??
-    readStringParam(params, "id") ??
-    readStringParam(params, "user") ??
-    readStringParam(params, "email");
-  if (userIdOrEmail) {
-    return userIdOrEmail;
-  }
-  const numericId =
-    readNumberParam(params, "userId", { integer: true }) ??
-    readNumberParam(params, "memberId", { integer: true }) ??
-    readNumberParam(params, "id", { integer: true });
-  if (typeof numericId === "number") {
-    return String(numericId);
-  }
-  throw new Error("userId or email is required for Zulip presence.");
-}
-
-function readRealmUpdateParams(
-  params: Record<string, unknown>,
-): Record<string, string | number | boolean> {
-  const raw = params.settings ?? params.realm ?? params.updates ?? params.update;
-  if (raw === undefined) {
-    throw new Error("settings are required to update Zulip organization settings.");
-  }
-  let parsed: unknown = raw;
-  if (typeof raw === "string") {
-    try {
-      parsed = JSON.parse(raw);
-    } catch {
-      throw new Error("settings must be a JSON object or key/value map.");
-    }
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error("settings must be a key/value object to update Zulip organization settings.");
-  }
-  const entries = Object.entries(parsed as Record<string, unknown>);
-  if (entries.length === 0) {
-    throw new Error("settings must include at least one field to update.");
-  }
-  const updates: Record<string, string | number | boolean> = {};
-  for (const [key, value] of entries) {
-    if (!SAFE_REALM_SETTINGS.includes(key)) {
-      throw new Error(`Unsupported organization setting: ${key}.`);
-    }
-    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
-      if (typeof value === "string") {
-        assertStringLength(value, key, MAX_STRING_LENGTH);
-      }
-      updates[key] = value;
-      continue;
-    }
-    throw new Error(`Unsupported setting value for ${key}; expected string, number, or boolean.`);
-  }
-  return updates;
-}
-
 export const zulipMessageActions: ChannelMessageActionAdapter = {
-  describeMessageTool: ({ cfg }) => {
-    const accounts = [resolveZulipAccount({ cfg })].filter((account) =>
+  describeMessageTool: ({ cfg, accountId }) => {
+    const accounts = [resolveZulipAccount({ cfg, accountId })].filter((account) =>
       isZulipAccountConfigured(account),
     );
     if (accounts.length === 0) {
       return { actions: [] };
     }
-    const actions = new Set<ChannelMessageActionName>([
-      "send",
-      "read",
-      "channel-list",
-      "channel-create",
-      "channel-edit",
-      "channel-delete",
-      "react",
-      "edit",
-      "delete",
-      "search",
-      "member-info",
-      "pin",
-      "unpin",
-      "poll",
-    ]);
-    // TODO: These actions require core SDK changes to MESSAGE_ACTION_TARGET_MODE.
-    // Re-enable once the SDK supports plugin-registered action target modes.
-    // See: https://github.com/openclaw/openclaw/issues/TBD
-    // actions.add("channel-subscribe" as ChannelMessageActionName);
-    // actions.add("invite" as ChannelMessageActionName);
-    // actions.add("resolve-topic" as ChannelMessageActionName);
-    // actions.add("user-presence" as ChannelMessageActionName);
-    // actions.add("user-deactivate" as ChannelMessageActionName);
-    // actions.add("user-reactivate" as ChannelMessageActionName);
-    // actions.add("org-settings" as ChannelMessageActionName);
-    // actions.add("org-settings-edit" as ChannelMessageActionName);
-    const destructiveActions: ChannelMessageActionName[] = [
-      "channel-delete",
-      "delete",
-    ];
     return {
-      actions: Array.from(actions),
+      actions: ZULIP_ADVERTISED_ACTIONS,
       capabilities: ["presentation"],
-      schema: {
-        properties: {
-          confirm: { type: "boolean", description: "Set to true to confirm destructive actions." },
-        },
-        actions: destructiveActions,
-        visibility: "current-channel",
-      },
+      schema: ZULIP_ACTION_SCHEMA,
     };
   },
-  supportsAction: ({ action }) => action !== "poll",
+  supportsAction: ({ action }) => ZULIP_HANDLED_ACTIONS.has(action),
   extractToolSend: ({ args }) => {
     const action = typeof args.action === "string" ? args.action.trim() : "";
     if (action !== "send") {
@@ -589,7 +543,10 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
   },
   prepareSendPayload: ({ payload }) => payload,
   handleAction: async ({ action, params, cfg, accountId, toolContext, dryRun }) => {
-    const { client, account } = await resolveZulipClient(cfg, accountId ?? undefined);
+    if (!ZULIP_HANDLED_ACTIONS.has(action)) {
+      throw new Error(`Action ${action} is not supported for provider ${providerId}.`);
+    }
+    const { client } = await resolveZulipClient(cfg, accountId ?? undefined);
 
     if (action === "send") {
       const to = readStringParam(params, "to", { required: true });
@@ -598,6 +555,16 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
       const widgetContent = presentationToZulipWidgetContent(
         normalizeMessagePresentation(params.presentation),
       );
+
+      if (dryRun) {
+        return jsonResult({
+          ok: true,
+          dryRun: true,
+          action,
+          target,
+          hasPresentation: Boolean(widgetContent),
+        });
+      }
 
       if (target.kind === "stream") {
         const result = await sendZulipStreamMessage(client, {
@@ -634,16 +601,6 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
       });
     }
 
-    if ((action as string) === "channel-subscribe") {
-      const raw =
-        readStringParam(params, "stream") ??
-        readStringParam(params, "channelId") ??
-        readStringParam(params, "to", { required: true });
-      const target = splitStreamTarget(raw);
-      const result = await subscribeZulipStream(client, target.stream);
-      return jsonResult({ ok: true, stream: target.stream, result });
-    }
-
     if (action === "channel-create") {
       const raw =
         readStringParam(params, "stream") ??
@@ -677,6 +634,16 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
         "historyPublicToSubscribers",
         "history_public_to_subscribers",
       );
+      if (dryRun) {
+        return jsonResult({
+          ok: true,
+          dryRun: true,
+          action,
+          stream: target.stream,
+          ...(description !== undefined ? { description } : {}),
+          ...(principals ? { principals } : {}),
+        });
+      }
       await createZulipStream(client, {
         name: target.stream,
         description: description ?? undefined,
@@ -726,6 +693,16 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
         throw new Error("At least one field is required to update a Zulip channel.");
       }
 
+      if (dryRun) {
+        return jsonResult({
+          ok: true,
+          dryRun: true,
+          action,
+          streamId: streamIdOrName,
+          ...(newName !== undefined ? { name: newName } : {}),
+        });
+      }
+
       // Resolve stream name to ID if necessary
       const streamId = await resolveZulipStreamId(client, streamIdOrName);
 
@@ -761,87 +738,6 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
         readStringParam(params, "user");
       const user = await fetchZulipMemberInfo(client, userId ?? undefined);
       return jsonResult({ ok: true, user });
-    }
-
-    if ((action as string) === "user-presence") {
-      const userIdOrEmail = readUserIdOrEmailParam(params);
-      const presence = await fetchZulipUserPresence(client, userIdOrEmail);
-      return jsonResult({ ok: true, user: userIdOrEmail, presence });
-    }
-
-    if ((action as string) === "user-deactivate") {
-      requireDestructiveConfirmation(params);
-      requireAdminActionsEnabled(account);
-      const userId = readUserIdParam(params);
-      if (dryRun) {
-        return jsonResult({ ok: true, dryRun: true, action: "user-deactivate", userId });
-      }
-      await requireZulipAdmin(client);
-      await deactivateZulipUser(client, userId);
-      return jsonResult({ ok: true, userId, deactivated: true });
-    }
-
-    if ((action as string) === "user-reactivate") {
-      requireAdminActionsEnabled(account);
-      await requireZulipAdmin(client);
-      const userId = readUserIdParam(params);
-      await reactivateZulipUser(client, userId);
-      return jsonResult({ ok: true, userId, reactivated: true });
-    }
-
-    if ((action as string) === "org-settings") {
-      const settings = await fetchZulipServerSettings(client);
-      return jsonResult({ ok: true, settings });
-    }
-
-    if ((action as string) === "org-settings-edit") {
-      requireDestructiveConfirmation(params);
-      requireAdminActionsEnabled(account);
-      const updates = readRealmUpdateParams(params);
-      if (dryRun) {
-        return jsonResult({
-          ok: true,
-          dryRun: true,
-          action: "org-settings-edit",
-          updated: Object.keys(updates),
-        });
-      }
-      await requireZulipAdmin(client);
-      await updateZulipRealm(client, updates);
-      return jsonResult({ ok: true, updated: Object.keys(updates) });
-    }
-
-    if ((action as string) === "invite") {
-      const raw =
-        readStringParam(params, "stream") ??
-        readStringParam(params, "channelId") ??
-        readStringParam(params, "to", { required: true });
-      const target = splitStreamTarget(raw);
-      let principals =
-        parseStringArrayParam(params, "principals") ??
-        parseStringArrayParam(params, "principal") ??
-        parseStringArrayParam(params, "userIds") ??
-        parseStringArrayParam(params, "users");
-      // Support comma-separated string for userId param (message tool compat)
-      if ((!principals || principals.length === 0) && typeof params.userId === "string") {
-        principals = params.userId
-          .split(",")
-          .map((s: string) => s.trim())
-          .filter(Boolean);
-      }
-      if (!principals || principals.length === 0) {
-        throw new Error("principals are required to invite Zulip users to a stream.");
-      }
-      for (const principal of principals) {
-        if (typeof principal === "string") {
-          assertStringLength(principal, "principal", MAX_STRING_LENGTH);
-        }
-      }
-      await inviteZulipUsersToStream(client, {
-        stream: target.stream,
-        principals,
-      });
-      return jsonResult({ ok: true, stream: target.stream, principals });
     }
 
     if (action === "read") {
@@ -934,11 +830,14 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
     if (action === "edit") {
       const messageId = readMessageId(params);
       const content = readMessageContent(params);
+      if (dryRun) {
+        return jsonResult({ ok: true, dryRun: true, action, messageId });
+      }
       await editZulipMessage(client, { messageId, content });
       return jsonResult({ ok: true, edited: messageId });
     }
 
-    if (action === "delete") {
+    if (action === "delete" || action === "unsend") {
       requireDestructiveConfirmation(params);
       const messageId = readMessageId(params);
       if (dryRun) {
@@ -951,9 +850,15 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
     if (action === "pin" || action === "unpin") {
       const messageId = readMessageId(params);
       // Convert messageId to integer for API call
-      const messageIdInt = parseInt(messageId, 10);
-      if (isNaN(messageIdInt)) {
+      if (!/^\d+$/.test(messageId)) {
         throw new Error(`Invalid messageId: ${messageId}`);
+      }
+      const messageIdInt = Number(messageId);
+      if (!Number.isSafeInteger(messageIdInt)) {
+        throw new Error(`Invalid messageId: ${messageId}`);
+      }
+      if (dryRun) {
+        return jsonResult({ ok: true, dryRun: true, action, messageId });
       }
       await updateZulipMessageFlag(client, {
         messageId: messageIdInt,
@@ -964,67 +869,6 @@ export const zulipMessageActions: ChannelMessageActionAdapter = {
         ok: true,
         messageId,
         starred: action === "pin",
-      });
-    }
-
-    if ((action as string) === "resolve-topic") {
-      const explicitTopic = readStringParam(params, "topic") ?? readStringParam(params, "subject");
-      const rawStream =
-        readStringParam(params, "stream") ??
-        readStringParam(params, "channelId") ??
-        readStringParam(params, "to");
-      const target = rawStream ? splitStreamTarget(rawStream) : undefined;
-      const topic = explicitTopic ?? target?.topic;
-
-      if (!topic) {
-        throw new Error("topic is required to resolve a Zulip topic.");
-      }
-
-      assertStringLength(topic, "topic", MAX_STRING_LENGTH);
-      const { topic: resolvedTopic, alreadyResolved } = resolveTopicName(topic);
-      if (alreadyResolved) {
-        return jsonResult({ ok: true, topic, resolvedTopic, alreadyResolved: true });
-      }
-
-      const messageId = (() => {
-        try {
-          return readMessageId(params);
-        } catch {
-          return undefined;
-        }
-      })();
-
-      let targetMessageId = messageId;
-      if (!targetMessageId) {
-        if (!target?.stream) {
-          throw new Error(
-            "stream is required to resolve a Zulip topic when messageId is not provided.",
-          );
-        }
-        const messages = await fetchZulipMessages(client, {
-          stream: target.stream,
-          topic,
-          limit: 1,
-        });
-        const latest = messages[0];
-        if (!latest?.id) {
-          throw new Error("No messages found for the specified stream/topic.");
-        }
-        targetMessageId = String(latest.id);
-      }
-
-      await updateZulipMessageTopic(client, {
-        messageId: targetMessageId,
-        topic: resolvedTopic,
-        propagateMode: "change_all",
-      });
-
-      return jsonResult({
-        ok: true,
-        stream: target?.stream,
-        topic,
-        resolvedTopic,
-        messageId: targetMessageId,
       });
     }
 

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,6 +1,11 @@
 export type { ChannelPlugin, OpenClawConfig, OpenClawPluginApi, PluginRuntime } from "openclaw/plugin-sdk/core";
 export { emptyPluginConfigSchema } from "openclaw/plugin-sdk/core";
-export type { ChannelAccountSnapshot, ChannelMessageActionAdapter, ChannelMessageActionName } from "openclaw/plugin-sdk/channel-contract";
+export type {
+  ChannelAccountSnapshot,
+  ChannelMessageActionAdapter,
+  ChannelMessageActionName,
+  ChannelMessageToolSchemaContribution,
+} from "openclaw/plugin-sdk/channel-contract";
 export type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 export type { MessagePresentation } from "openclaw/plugin-sdk/interactive-runtime";
 export { normalizeMessagePresentation, resolveMessagePresentationActionValue } from "openclaw/plugin-sdk/interactive-runtime";

--- a/src/zulip/client.ts
+++ b/src/zulip/client.ts
@@ -38,19 +38,6 @@ export type ZulipUser = {
   is_admin?: boolean | null;
 };
 
-export type ZulipPresenceEntry = {
-  status?: "active" | "idle" | string;
-  timestamp?: number;
-  client?: string | null;
-  [key: string]: unknown;
-};
-
-export type ZulipPresenceMap = Record<string, ZulipPresenceEntry>;
-
-export type ZulipServerSettings = ZulipApiResponse & Record<string, unknown>;
-
-export type ZulipRealmUpdate = Record<string, string | number | boolean>;
-
 export type ZulipStream = {
   id: string;
   name?: string | null;
@@ -701,35 +688,6 @@ export async function resolveZulipStreamId(
   throw new Error(`Zulip stream not found: ${streamIdOrName}`);
 }
 
-export async function subscribeZulipStream(client: ZulipClient, stream: string): Promise<void> {
-  const body = new URLSearchParams({
-    subscriptions: JSON.stringify([{ name: stream }]),
-  });
-  const payload = await client.request<ZulipApiResponse>("/users/me/subscriptions", {
-    method: "POST",
-    body: body.toString(),
-  });
-  assertSuccess(payload, "Zulip stream subscribe failed");
-}
-
-export async function inviteZulipUsersToStream(
-  client: ZulipClient,
-  params: {
-    stream: string;
-    principals: Array<string | number>;
-  },
-): Promise<void> {
-  const body = new URLSearchParams({
-    subscriptions: JSON.stringify([{ name: params.stream }]),
-    principals: JSON.stringify(params.principals),
-  });
-  const payload = await client.request<ZulipApiResponse>("/users/me/subscriptions", {
-    method: "POST",
-    body: body.toString(),
-  });
-  assertSuccess(payload, "Zulip stream invite failed");
-}
-
 export async function createZulipStream(
   client: ZulipClient,
   params: {
@@ -1009,25 +967,6 @@ export function createZulipReadBatcher(client: ZulipClient): {
   };
 }
 
-export async function updateZulipMessageTopic(
-  client: ZulipClient,
-  params: {
-    messageId: string;
-    topic: string;
-    propagateMode?: "change_one" | "change_all";
-  },
-): Promise<void> {
-  const body = new URLSearchParams({
-    topic: params.topic,
-    propagate_mode: params.propagateMode ?? "change_all",
-  });
-  const payload = await client.request<ZulipApiResponse>(`/messages/${params.messageId}`, {
-    method: "PATCH",
-    body: body.toString(),
-  });
-  assertSuccess(payload, "Zulip update message topic failed");
-}
-
 export async function fetchZulipMessages(
   client: ZulipClient,
   params: {
@@ -1082,66 +1021,4 @@ export async function searchZulipMessages(
   );
   assertSuccess(payload, "Zulip search failed");
   return payload.messages ?? [];
-}
-
-export async function fetchZulipUserPresence(
-  client: ZulipClient,
-  userIdOrEmail: string,
-): Promise<ZulipPresenceMap> {
-  const trimmed = userIdOrEmail?.trim();
-  if (!trimmed) {
-    throw new Error("userId or email is required to fetch Zulip presence.");
-  }
-  const encoded = encodeURIComponent(trimmed);
-  const payload = await client.request<ZulipApiResponse & { presence?: ZulipPresenceMap }>(
-    `/users/${encoded}/presence`,
-  );
-  assertSuccess(payload, "Zulip user presence failed");
-  return payload.presence ?? {};
-}
-
-export async function deactivateZulipUser(client: ZulipClient, userId: string): Promise<void> {
-  const trimmed = userId?.trim();
-  if (!trimmed) {
-    throw new Error("userId is required to deactivate a Zulip user.");
-  }
-  const payload = await client.request<ZulipApiResponse>(`/users/${trimmed}` as const, {
-    method: "DELETE",
-  });
-  assertSuccess(payload, "Zulip deactivate user failed");
-}
-
-export async function reactivateZulipUser(client: ZulipClient, userId: string): Promise<void> {
-  const trimmed = userId?.trim();
-  if (!trimmed) {
-    throw new Error("userId is required to reactivate a Zulip user.");
-  }
-  const payload = await client.request<ZulipApiResponse>(`/users/${trimmed}/reactivate` as const, {
-    method: "POST",
-  });
-  assertSuccess(payload, "Zulip reactivate user failed");
-}
-
-export async function fetchZulipServerSettings(client: ZulipClient): Promise<ZulipServerSettings> {
-  const payload = await client.request<ZulipServerSettings>("/server_settings");
-  assertSuccess(payload, "Zulip server settings failed");
-  return payload;
-}
-
-export async function updateZulipRealm(
-  client: ZulipClient,
-  params: ZulipRealmUpdate,
-): Promise<void> {
-  const body = new URLSearchParams();
-  for (const [key, value] of Object.entries(params)) {
-    body.set(key, String(value));
-  }
-  if (Array.from(body.keys()).length === 0) {
-    throw new Error("No realm settings provided to update.");
-  }
-  const payload = await client.request<ZulipApiResponse>("/realm", {
-    method: "PATCH",
-    body: body.toString(),
-  });
-  assertSuccess(payload, "Zulip realm update failed");
 }


### PR DESCRIPTION
Closes #29.

## Summary

- centralize the advertised, handled, core-owned, and destructive Zulip action sets
- remove unreachable provider-specific admin handlers and their dead client helpers
- reject hidden, core-owned, and unadvertised actions before credential or network access
- contribute action-scoped schemas for every Zulip-only handler parameter
- add `unsend` as the canonical delete alias and strict pin/unpin message-id validation
- add a checked-in capability matrix documenting the closed shared-action boundary and plugin-owned agent-tool alternative

## Compatibility

`enableAdminActions` remains accepted as an explicitly inert legacy field so strict existing configurations continue to load. OpenClaw deliberately keeps shared message actions closed; openclaw/openclaw#134666 directs future provider-specific operations to a separately reviewed plugin-owned agent tool.

## Verification

- OpenClaw 2026.7.1-2: build, 332 Vitest tests, 64 offline smoke tests
- OpenClaw 2026.8.1: build, 332 Vitest tests, 64 offline smoke tests
- 80 focused action/channel tests
- `git diff --check`

Local Node 26.5.0 emits the expected unsupported-engine warning; CI validates supported Node 22.19.0 and Node 24.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-relevant narrowing of dispatchable message actions and removal of admin paths that could be reached via casts; remaining mutable actions still run under the bot credential’s Zulip permissions.
> 
> **Overview**
> **Tightens the Zulip plugin’s shared `message` tool surface** so advertised actions, action-scoped schemas, and `handleAction`/`supportsAction` all derive from one allowlist in `src/actions.ts`, with a checked-in matrix in `docs/ACTION_CAPABILITIES.md`.
> 
> **Removes previously hidden provider-specific handlers** (`channel-subscribe`, `invite`, `resolve-topic`, user/org admin actions, etc.) and their Zulip client helpers. Unsupported or core-owned actions (e.g. `poll`) now fail **before** resolving credentials or calling Zulip. **`enableAdminActions` stays in config for load compatibility but does nothing**; docs and plugin UI hints call that out.
> 
> **Behavior tweaks:** `unsend` is a confirmed alias for `delete`; destructive confirmation schema includes it; pin/unpin validate numeric-only message IDs; more mutations honor **dry run** without network I/O; tool discovery is **account-scoped** via `accountId`. Tests shift from admin-bypass cases to allowlist consistency and routing coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c171d47bfad0bc24acabe408beadf43d7fa7530c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->